### PR TITLE
Address x rotation for GLTF

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -37,7 +37,7 @@ let params = {
 	'maxDepth': 15,
 	'loadSiblings': true,
 
-	'up': '+Y',
+	'up': '+Z',
 	'displayBounds': false,
 	'showThirdPerson': true,
 	'reload': reinstantiateTiles,
@@ -158,7 +158,7 @@ function init() {
 	tiles.add( params, 'errorTarget' ).min( 0 ).max( 50 );
 	tiles.add( params, 'errorThreshold' ).min( 0 ).max( 1000 );
 	tiles.add( params, 'maxDepth' ).min( 1 ).max( 100 );
-	tiles.add( params, 'up', [ '+Y', '-Z' ] );
+	tiles.add( params, 'up', [ '+Y', '+Z', '-Z' ] );
 	tiles.open();
 
 	gui.add( params, 'displayBounds' );
@@ -240,6 +240,10 @@ function animate() {
 	if ( params.up === '-Z' ) {
 
 		offsetParent.rotation.x = Math.PI / 2;
+
+	} else if ( params.up === '+Z' ) {
+
+		offsetParent.rotation.x = - Math.PI / 2;
 
 	}
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -24,6 +24,7 @@ const vecX = new Vector3();
 const vecY = new Vector3();
 const vecZ = new Vector3();
 const _sphere = new Sphere();
+const _xAxis = new Vector3( 1.0, 0.0, 0.0 );
 
 function emptyRaycast() {}
 
@@ -291,12 +292,15 @@ export class TilesRenderer extends TilesRendererBase {
 			boxHelperGroup.add( boxHelper );
 			boxHelperGroup.updateMatrixWorld( true );
 
+			// rotate the scene by 90 degrees on X to convert +Y to +Z "up"
 			const scene = res.scene;
-			cached.transform.decompose( scene.position, scene.quaternion, scene.scale );
+			scene.matrix.makeRotationAxis( _xAxis, Math.PI / 2 );
+			scene.matrix.multiply( cached.transform );
+			scene.matrix.decompose( scene.position, scene.quaternion, scene.scale );
 			scene.traverse( c => c.frustumCulled = false );
 
 			cached.boxHelperGroup = boxHelperGroup;
-			cached.scene = res.scene;
+			cached.scene = scene;
 
 			if ( this.displayBounds ) {
 


### PR DESCRIPTION
Fix #12 

Apply a 90 degree rotation about X to accommodate +Y -> +Z conversion.

Frustum checks seem to be incorrect which this exposed more apparently, which should be fixed.