### PR TITLE
Account for children visibility

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -167,6 +167,7 @@ export class TilesRendererBase {
 
 		tile.__wasSetVisible = false;
 		tile.__visible = false;
+		tile.__childrenWereVisible = false;
 
 		tile.__wasSetActive = false;
 		tile.__active = false;

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -153,16 +153,13 @@ export function markUsedSetLeaves( tile, renderer ) {
 
 	const children = tile.children;
 	let anyChildrenUsed = false;
-	let childrenWereVisible = false;
 	for ( let i = 0, l = children.length; i < l; i ++ ) {
 
 		const c = children[ i ];
 		anyChildrenUsed = anyChildrenUsed || isUsedThisFrame( c, frameCount );
-		childrenWereVisible = childrenWereVisible || c.__wasSetVisible || c.__childrenWereVisible;
 
 	}
 
-	tile.__childrenWereVisible = childrenWereVisible;
 
 	if ( ! anyChildrenUsed ) {
 
@@ -175,12 +172,15 @@ export function markUsedSetLeaves( tile, renderer ) {
 
 	} else {
 
+		let childrenWereVisible = false;
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
 			const c = children[ i ];
 			markUsedSetLeaves( c, renderer );
+			childrenWereVisible = childrenWereVisible || c.__wasSetVisible || c.__childrenWereVisible;
 
 		}
+		tile.__childrenWereVisible = childrenWereVisible;
 
 	}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -252,23 +252,27 @@ export function skipTraversal( tile, renderer ) {
 
 	// TODO: this condition is skipped over if data hasn't loaded yet meaning that between when this tile is first
 	// used trigger and when it loads the children are iterated over and triggered to load, which is unnecessary
-	if ( meetsSSE && loadedContent && ! allChildrenHaveContent && ! childrenWereVisible ) {
+	if ( meetsSSE && ! allChildrenHaveContent && ! childrenWereVisible ) {
 
-		if ( tile.__inFrustum ) {
+		if ( loadedContent ) {
 
-			tile.__visible = true;
-			stats.visible ++;
+			if ( tile.__inFrustum ) {
 
-		}
-		tile.__active = true;
-		stats.active ++;
+				tile.__visible = true;
+				stats.visible ++;
 
-		for ( let i = 0, l = children.length; i < l; i ++ ) {
+			}
+			tile.__active = true;
+			stats.active ++;
 
-			const c = children[ i ];
-			if ( isUsedThisFrame( c, frameCount ) && ! lruCache.isFull() ) {
+			for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-				renderer.requestTileContents( c );
+				const c = children[ i ];
+				if ( isUsedThisFrame( c, frameCount ) && ! lruCache.isFull() ) {
+
+					renderer.requestTileContents( c );
+
+				}
 
 			}
 


### PR DESCRIPTION
Fix #29 

Checks if any children _were_ visible first before deciding to render a parent tile. This helps the case where the camera is zooming out and triggers a parent tile to render, causing it to jump to that LOD to briefly while it downloads.