### PR TITLE
Add Draco, DDS, and KTX2 Loader support

### DIFF
--- a/src/three/B3DMLoader.d.ts
+++ b/src/three/B3DMLoader.d.ts
@@ -1,6 +1,9 @@
 import { B3DMBaseResult } from '../base/B3DMLoaderBase';
 import { LoadingManager } from 'three';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
+import { DracoLoader } from 'three/examples/jsm/loaders/DracoLoader';
+import { DDSLoader } from 'three/examples/jsm/loaders/DDSLoader';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader';
 
 export interface B3DMResult extends GLTF, B3DMBaseResult {}
 
@@ -9,5 +12,9 @@ export class B3DMLoader {
 	constructor( manager : LoadingManager );
 	load( url : String ) : Promise< B3DMResult >;
 	parse( buffer : ArrayBuffer ) : B3DMResult;
+	
+	setDracoLoader( loader : DracoLoader | null ) : void;
+	setDDSLoader( loader : DDSLoader | null ) : void;
+	setKTX2Loader( loader : KTX2Loader | null ) : void;
 
 }

--- a/src/three/B3DMLoader.js
+++ b/src/three/B3DMLoader.js
@@ -7,6 +7,27 @@ export class B3DMLoader extends B3DMLoaderBase {
 
 		super();
 		this.manager = manager;
+		this.ktx2Loader = null;
+		this.dracoLoader = null;
+		this.ddsLoader = null;
+
+	}
+	
+	setKTX2Loader( loader ) {
+
+		this.ktx2Loader = loader;
+
+	}
+	
+	setDracoLoader( loader ) {
+
+		this.dracoLoader = loader;
+
+	}
+	
+	setDDSLoader( loader ) {
+
+		this.ddsLoader = loader;
 
 	}
 
@@ -17,7 +38,11 @@ export class B3DMLoader extends B3DMLoaderBase {
 		return new Promise( ( resolve, reject ) => {
 
 			const manager = this.manager;
-			new GLTFLoader( manager ).parse( gltfBuffer, null, model => {
+			const loader = new GLTFLoader( manager );
+			loader.setKTX2Loader( this.ktx2Loader );
+			loader.setDracoLoader( this.dracoLoader );
+			loader.setDDSLoader( this.ddsLoader );
+			loader.parse( gltfBuffer, null, model => {
 
 				model.batchTable = b3dm.batchTable;
 				model.featureTable = b3dm.featureTable;

--- a/src/three/CMPTLoader.d.ts
+++ b/src/three/CMPTLoader.d.ts
@@ -2,6 +2,9 @@ import { B3DMBaseResult } from '../base/B3DMLoaderBase';
 import { I3DMBaseResult } from '../base/I3DMLoaderBase';
 import { PNTSBaseResult } from '../base/B3DMLoaderBase';
 import { Group } from 'three';
+import { DracoLoader } from 'three/examples/jsm/loaders/DracoLoader';
+import { DDSLoader } from 'three/examples/jsm/loaders/DDSLoader';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader';
 
 export interface CMPTResult {
 
@@ -12,8 +15,16 @@ export interface CMPTResult {
 
 export class CMPTLoader {
 
+	dracoLoader : DracoLoader | null;
+	ddsLoader : DDSLoader | null;
+	ktx2Loader : KTX2Loader | null;
+	
 	constructor( manager : LoadingManager );
 	load( url : String ) : Promise< CMPTResult >;
 	parse( buffer : ArrayBuffer ) : CMPTResult;
+
+	setDracoLoader( loader : DracoLoader | null ) : void;
+	setDDSLoader( loader : DDSLoader | null ) : void;
+	setKTX2Loader( loader : KTX2Loader | null ) : void;
 
 }

--- a/src/three/CMPTLoader.d.ts
+++ b/src/three/CMPTLoader.d.ts
@@ -15,10 +15,6 @@ export interface CMPTResult {
 
 export class CMPTLoader {
 
-	dracoLoader : DracoLoader | null;
-	ddsLoader : DDSLoader | null;
-	ktx2Loader : KTX2Loader | null;
-	
 	constructor( manager : LoadingManager );
 	load( url : String ) : Promise< CMPTResult >;
 	parse( buffer : ArrayBuffer ) : CMPTResult;

--- a/src/three/CMPTLoader.js
+++ b/src/three/CMPTLoader.js
@@ -9,6 +9,27 @@ export class CMPTLoader extends CMPTLoaderBase {
 
 		super();
 		this.manager = manager;
+		this.ktx2Loader = null;
+		this.dracoLoader = null;
+		this.ddsLoader = null;
+
+	}
+	
+	setKTX2Loader( loader ) {
+
+		this.ktx2Loader = loader;
+
+	}
+	
+	setDracoLoader( loader ) {
+
+		this.dracoLoader = loader;
+
+	}
+	
+	setDDSLoader( loader ) {
+
+		this.ddsLoader = loader;
 
 	}
 
@@ -28,7 +49,12 @@ export class CMPTLoader extends CMPTLoaderBase {
 				case 'b3dm': {
 
 					const slicedBuffer = buffer.slice();
-					const promise = new B3DMLoader( manager )
+					const loader = new B3DMLoader( manager );
+					loader.setKTX2Loader( this.ktx2Loader );
+					loader.setDracoLoader( this.dracoLoader );
+					loader.setDDSLoader( this.ddsLoader );
+
+					const promise = loader
 						.parse( slicedBuffer.buffer )
 						.then( res => {
 
@@ -55,7 +81,12 @@ export class CMPTLoader extends CMPTLoaderBase {
 				case 'i3dm': {
 
 					const slicedBuffer = buffer.slice();
-					const promise = new I3DMLoader( manager )
+					const loader = new I3DMLoader( manager );
+					loader.setKTX2Loader( this.ktx2Loader );
+					loader.setDracoLoader( this.dracoLoader );
+					loader.setDDSLoader( this.ddsLoader );
+					
+					const promise = loader
 						.parse( slicedBuffer.buffer )
 						.then( res => {
 

--- a/src/three/I3DMLoader.d.ts
+++ b/src/three/I3DMLoader.d.ts
@@ -12,10 +12,6 @@ export interface I3DMResult extends GLTF, I3DMBaseResult {
 }
 
 export class I3DMLoader {
-
-	dracoLoader : DracoLoader | null;
-	ddsLoader : DDSLoader | null;
-	ktx2Loader : KTX2Loader | null;
 	
 	constructor( manager : LoadingManager );
 	load( url : String ) : Promise< I3DMResult >;

--- a/src/three/I3DMLoader.d.ts
+++ b/src/three/I3DMLoader.d.ts
@@ -1,5 +1,8 @@
 import { I3DMBaseResult } from '../base/I3DMLoaderBase';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
+import { DracoLoader } from 'three/examples/jsm/loaders/DracoLoader';
+import { DDSLoader } from 'three/examples/jsm/loaders/DDSLoader';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader';
 
 export interface I3DMResult extends GLTF, I3DMBaseResult {
 
@@ -10,8 +13,16 @@ export interface I3DMResult extends GLTF, I3DMBaseResult {
 
 export class I3DMLoader {
 
+	dracoLoader : DracoLoader | null;
+	ddsLoader : DDSLoader | null;
+	ktx2Loader : KTX2Loader | null;
+	
 	constructor( manager : LoadingManager );
 	load( url : String ) : Promise< I3DMResult >;
 	parse( buffer : ArrayBuffer ) : I3DMResult;
 
+	setDracoLoader( loader : DracoLoader | null ) : void;
+	setDDSLoader( loader : DDSLoader | null ) : void;
+	setKTX2Loader( loader : KTX2Loader | null ) : void;
+	
 }

--- a/src/three/I3DMLoader.js
+++ b/src/three/I3DMLoader.js
@@ -12,6 +12,27 @@ export class I3DMLoader extends I3DMLoaderBase {
 
 		super();
 		this.manager = manager;
+		this.ktx2Loader = null;
+		this.dracoLoader = null;
+		this.ddsLoader = null;
+
+	}
+
+	setKTX2Loader( loader ) {
+
+		this.ktx2Loader = loader;
+
+	}
+	
+	setDracoLoader( loader ) {
+
+		this.dracoLoader = loader;
+
+	}
+	
+	setDDSLoader( loader ) {
+
+		this.ddsLoader = loader;
 
 	}
 
@@ -26,7 +47,11 @@ export class I3DMLoader extends I3DMLoaderBase {
 				return new Promise( ( resolve, reject ) => {
 
 					const manager = this.manager;
-					new GLTFLoader( manager ).parse( gltfBuffer, null, model => {
+					const loader = new GLTFLoader( manager );
+					loader.setKTX2Loader( this.ktx2Loader );
+					loader.setDracoLoader( this.dracoLoader );
+					loader.setDDSLoader( this.ddsLoader );
+					loader.parse( gltfBuffer, null, model => {
 
 						const INSTANCES_LENGTH = featureTable.getData( 'INSTANCES_LENGTH' );
 

--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -1,6 +1,9 @@
 import { Box3, Camera, Vector2, WebGLRenderer, Object3D } from 'three';
 import { TilesRendererBase } from '../base/TilesRendererBase';
 import { TilesGroup } from './TilesGroup';
+import { DracoLoader } from 'three/examples/jsm/loaders/DracoLoader';
+import { DDSLoader } from 'three/examples/jsm/loaders/DDSLoader';
+import { KTX2Loader } from 'three/examples/jsm/loaders/KTX2Loader';
 
 export class TilesRenderer extends TilesRendererBase {
 
@@ -21,5 +24,9 @@ export class TilesRenderer extends TilesRendererBase {
 	onLoadModel : ( ( scene : Object3D, tile : object ) => void ) | null;
 	onDisposeModel : ( ( scene : Object3D, tile : object ) => void ) | null;
 	forEachLoadedModel( callback : ( scene : Object3D, tile : object ) => void );
+
+	setDracoLoader( loader : DracoLoader | null ) : void;
+	setDDSLoader( loader : DDSLoader | null ) : void;
+	setKTX2Loader( loader : KTX2Loader | null ) : void;
 
 }

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -84,6 +84,28 @@ export class TilesRenderer extends TilesRendererBase {
 
 		this.onLoadModel = null;
 		this.onDisposeModel = null;
+		
+		this.ktx2Loader = null;
+		this.dracoLoader = null;
+		this.ddsLoader = null;
+	
+	}
+
+	setKTX2Loader( loader ) {
+
+		this.ktx2Loader = loader;
+
+	}
+
+	setDracoLoader( loader ) {
+
+		this.dracoLoader = loader;
+
+	}
+
+	setDDSLoader( loader ) {
+
+		this.ddsLoader = loader;
 
 	}
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -496,26 +496,56 @@ export class TilesRenderer extends TilesRendererBase {
 
 		switch ( extension ) {
 
-			case 'b3dm':
-				promise = new B3DMLoader( manager ).parse( buffer );
+			case 'b3dm': {
+				
+				const loader = new B3DMLoader( manager );
+				loader.setDracoLoader( this.dracoLoader );
+				loader.setDDSLoader( this.ddsLoader );
+				loader.setKTX2Loader( this.ktx2Loader );
+				
+				promise = loader.parse( buffer );
 				break;
+				
+			}
 
-			case 'pnts':
+			case 'pnts': {
+				
 				promise = Promise.resolve( new PNTSLoader( manager ).parse( buffer ) );
 				break;
+				
+			}
 
-			case 'i3dm':
-				promise = new I3DMLoader( manager ).parse( buffer );
+			case 'i3dm': {
+
+				const loader = new I3DMLoader( manager );
+				loader.setDracoLoader( this.dracoLoader );
+				loader.setDDSLoader( this.ddsLoader );
+				loader.setKTX2Loader( this.ktx2Loader );
+				
+				promise = new loader.parse( buffer );
 				break;
+				
+			}
 
-			case 'cmpt':
-				promise = new CMPTLoader( manager ).parse( buffer );
+			case 'cmpt': {
+				
+				const loader = new CMPTLoader( manager );
+				loader.setDracoLoader( this.dracoLoader );
+				loader.setDDSLoader( this.ddsLoader );
+				loader.setKTX2Loader( this.ktx2Loader );
+				
+				promise = new loader.parse( buffer );
 				break;
+				
+			}
 
-			default:
+			default: {
+				
 				console.warn( `TilesRenderer: Content type "${ extension }" not supported.` );
 				promise = Promise.resolve( null );
 				break;
+				
+			}
 
 		}
 


### PR DESCRIPTION
Fix #28 

**TODO**

- [x] Add loaders to CMPTLoader
- [x] Add loaders to I3DMLoader
- [x] Add loaders to TilesRenderer
- [ ] Linting
- [x] d.ts updates
- [ ] Test using data from #78 

NOTE: It may be simpler to just have the i3dm and b3dm loaders resolve a gltf loader from a manager using something like a ".gltf" path which would allow for creation and use of a custom GLTF loader which could include draco etc loaders. Otherwise there's lots of redundant information here.