### PR TITLE
Fix incorrect i3dm transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Add warnings if unsupported feature semantics are detected for I3DM and PNTS files
+- Support for I3DM rotation, scale features.
+
+### Fixed
+- A case where I3DM instances could have an incorrect transformations by respecting existing Mesh transformations when converting them to InstancedMeshes.
+
+### Changed
+- Make CMPTLoader group child order consistent between loads.
+
 ## [0.2.6] - 2021-02-03
 ### Fixed
 - I3DM files not correctly loading external gltf files.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jest-cli": "^25.4.0",
     "parcel-bundler": "^1.12.4",
     "static-server": "^2.2.1",
-    "three": ">=0.123.0",
+    "three": ">=0.125.0",
     "typescript": "^3.7.4"
   },
   "peerDependencies": {

--- a/src/three/CMPTLoader.js
+++ b/src/three/CMPTLoader.js
@@ -17,8 +17,6 @@ export class CMPTLoader extends CMPTLoaderBase {
 
 		const result = super.parse( buffer );
 		const manager = this.manager;
-		const group = new Group();
-		const results = [];
 		const promises = [];
 
 		for ( const i in result.tiles ) {
@@ -29,15 +27,7 @@ export class CMPTLoader extends CMPTLoaderBase {
 				case 'b3dm': {
 
 					const slicedBuffer = buffer.slice();
-					const promise = new B3DMLoader( manager )
-						.parse( slicedBuffer.buffer )
-						.then( res => {
-
-							results.push( res );
-							group.add( res.scene );
-
-						} );
-
+					const promise = new B3DMLoader( manager ).parse( slicedBuffer.buffer );
 					promises.push( promise );
 					break;
 
@@ -47,8 +37,8 @@ export class CMPTLoader extends CMPTLoaderBase {
 
 					const slicedBuffer = buffer.slice();
 					const pointsResult = new PNTSLoader( manager ).parse( slicedBuffer.buffer );
-					results.push( pointsResult );
-					group.add( pointsResult.scene );
+					const promise = Promise.resolve( pointsResult );
+					promises.push( promise );
 					break;
 
 				}
@@ -60,14 +50,7 @@ export class CMPTLoader extends CMPTLoaderBase {
 					loader.workingPath = this.workingPath;
 					loader.fetchOptions = this.fetchOptions;
 
-					const promise = loader
-						.parse( slicedBuffer.buffer )
-						.then( res => {
-
-							results.push( res );
-							group.add( res.scene );
-
-						} );
+					const promise = loader.parse( slicedBuffer.buffer );
 					promises.push( promise );
 					break;
 
@@ -77,7 +60,14 @@ export class CMPTLoader extends CMPTLoaderBase {
 
 		}
 
-		return Promise.all( promises ).then( () => {
+		return Promise.all( promises ).then( results => {
+
+			const group = new Group();
+			results.forEach( result => {
+
+				group.add( result.scene );
+
+			} );
 
 			return {
 

--- a/src/three/I3DMLoader.js
+++ b/src/three/I3DMLoader.js
@@ -39,22 +39,29 @@ export class I3DMLoader extends I3DMLoaderBase {
 					loader.parse( gltfBuffer, null, model => {
 
 						const INSTANCES_LENGTH = featureTable.getData( 'INSTANCES_LENGTH' );
-
-						// RTC_CENTER
-						// QUANTIZED_VOLUME_OFFSET
-						// QUANTIZED_VOLUME_SCALE
-						// EAST_NORTH_UP
-
 						const POSITION = featureTable.getData( 'POSITION', INSTANCES_LENGTH, 'FLOAT', 'VEC3' );
 						const NORMAL_UP = featureTable.getData( 'NORMAL_UP', INSTANCES_LENGTH, 'FLOAT', 'VEC3' );
 						const NORMAL_RIGHT = featureTable.getData( 'NORMAL_RIGHT', INSTANCES_LENGTH, 'FLOAT', 'VEC3' );
 						const SCALE_NON_UNIFORM = featureTable.getData( 'SCALE_NON_UNIFORM', INSTANCES_LENGTH, 'FLOAT', 'VEC3' );
 						const SCALE = featureTable.getData( 'SCALE', INSTANCES_LENGTH, 'FLOAT', 'SCALAR' );
 
-						// POSITION_QUANTIZED
-						// NORMAL_UP_OCT32P
-						// NORMAL_RIGHT_OCT32P
-						// BATCH_ID
+						[
+							'RTC_CENTER',
+							'QUANTIZED_VOLUME_OFFSET',
+							'QUANTIZED_VOLUME_SCALE',
+							'EAST_NORTH_UP',
+							'POSITION_QUANTIZED',
+							'NORMAL_UP_OCT32P',
+							'NORMAL_RIGHT_OCT32P',
+						].forEach( feature => {
+
+							if ( feature in featureTable.header ) {
+
+								console.warn( `I3DMLoader: Unsupported FeatureTable feature "${ feature }" detected.` );
+
+							}
+
+						} );
 
 						const instanceMap = new Map();
 						const instances = [];

--- a/src/three/I3DMLoader.js
+++ b/src/three/I3DMLoader.js
@@ -71,6 +71,9 @@ export class I3DMLoader extends I3DMLoaderBase {
 
 								const { geometry, material } = child;
 								const instancedMesh = new InstancedMesh( geometry, material, INSTANCES_LENGTH );
+								instancedMesh.position.copy( child.position );
+								instancedMesh.rotation.copy( child.rotation );
+								instancedMesh.scale.copy( child.scale );
 								instances.push( instancedMesh );
 								instanceMap.set( child, instancedMesh );
 
@@ -81,7 +84,6 @@ export class I3DMLoader extends I3DMLoaderBase {
 						const averageVector = new Vector3();
 						for ( let i = 0; i < INSTANCES_LENGTH; i ++ ) {
 
-							// TODO: handle quantized position
 							averageVector.x += POSITION[ i * 3 + 0 ] / INSTANCES_LENGTH;
 							averageVector.y += POSITION[ i * 3 + 1 ] / INSTANCES_LENGTH;
 							averageVector.z += POSITION[ i * 3 + 2 ] / INSTANCES_LENGTH;
@@ -99,9 +101,13 @@ export class I3DMLoader extends I3DMLoaderBase {
 								parent.add( instancedMesh );
 
 								// Center the instance around an average point to avoid jitter at large scales.
+								// Transform the average vector by matrix world so we can account for any existing
+								// transforms of the instanced mesh.
+								instancedMesh.updateMatrixWorld();
 								instancedMesh
 									.position
-									.copy( averageVector );
+									.copy( averageVector )
+									.applyMatrix4( instancedMesh.matrixWorld );
 
 							}
 

--- a/src/three/I3DMLoader.js
+++ b/src/three/I3DMLoader.js
@@ -49,11 +49,11 @@ export class I3DMLoader extends I3DMLoaderBase {
 						const NORMAL_UP = featureTable.getData( 'NORMAL_UP', INSTANCES_LENGTH, 'FLOAT', 'VEC3' );
 						const NORMAL_RIGHT = featureTable.getData( 'NORMAL_RIGHT', INSTANCES_LENGTH, 'FLOAT', 'VEC3' );
 						const SCALE_NON_UNIFORM = featureTable.getData( 'SCALE_NON_UNIFORM', INSTANCES_LENGTH, 'FLOAT', 'VEC3' );
+						const SCALE = featureTable.getData( 'SCALE', INSTANCES_LENGTH, 'FLOAT', 'SCALAR' );
 
 						// POSITION_QUANTIZED
 						// NORMAL_UP_OCT32P
 						// NORMAL_RIGHT_OCT32P
-						// SCALE
 						// BATCH_ID
 
 						const instanceMap = new Map();
@@ -141,7 +141,11 @@ export class I3DMLoader extends I3DMLoaderBase {
 							}
 
 							// scale
-							if ( SCALE_NON_UNIFORM ) {
+							if ( SCALE ) {
+
+								tempSca.setScalar( SCALE[ i ] );
+
+							} else if ( SCALE_NON_UNIFORM ) {
 
 								tempSca.set(
 									SCALE_NON_UNIFORM[ i * 3 + 0 ],

--- a/src/three/I3DMLoader.js
+++ b/src/three/I3DMLoader.js
@@ -124,7 +124,8 @@ export class I3DMLoader extends I3DMLoaderBase {
 									NORMAL_RIGHT[ i * 3 + 2 ],
 								);
 
-								tempFwd.crossVectors( tempRight, tempUp );
+								tempFwd.crossVectors( tempRight, tempUp )
+									.normalize();
 
 								tempMat.makeBasis(
 									tempRight,

--- a/src/three/PNTSLoader.js
+++ b/src/three/PNTSLoader.js
@@ -15,30 +15,30 @@ export class PNTSLoader extends PNTSLoaderBase {
 		const result = super.parse( buffer );
 		const { featureTable } = result;
 
-		// global semantics
 		const POINTS_LENGTH = featureTable.getData( 'POINTS_LENGTH' );
-
-		// RTC_CENTER
-		// QUANTIZED_VOLUME_OFFSET
-		// QUANTIZED_VOLUME_SCALE
-		// CONSTANT_RGBA
-		// BATCH_LENGTH
-
 		const POSITION = featureTable.getData( 'POSITION', POINTS_LENGTH, 'FLOAT', 'VEC3' );
 		const RGB = featureTable.getData( 'RGB', POINTS_LENGTH, 'UNSIGNED_BYTE', 'VEC3' );
 
-		// POSITION_QUANTIZED
-		// RGBA
-		// RGB565
-		// NORMAL
-		// NORMAL_OCT16P
-		// BATCH_ID
+		[
+			'RTC_CENTER',
+			'QUANTIZED_VOLUME_OFFSET',
+			'QUANTIZED_VOLUME_SCALE',
+			'CONSTANT_RGBA',
+			'BATCH_LENGTH',
+			'POSITION_QUANTIZED',
+			'RGBA',
+			'RGB565',
+			'NORMAL',
+			'NORMAL_OCT16P',
+		].forEach( feature => {
 
-		if ( POSITION === null ) {
+			if ( feature in featureTable.header ) {
 
-			throw new Error( 'PNTSLoader : POSITION_QUANTIZED feature type is not supported.' );
+				console.warn( `PNTSLoader: Unsupported FeatureTable feature "${ feature }" detected.` );
 
-		}
+			}
+
+		} );
 
 		const geometry = new BufferGeometry();
 		geometry.setAttribute( 'position', new BufferAttribute( POSITION, 3, false ) );


### PR DESCRIPTION
Fix #158
Related to #83 

- Make CMPTLoader groups consistent
- Bump dev three.js version to 125
- Handle i3dm rotation, scale features
- Add warnings if unsupported feature semantics are detected for I3DM and PNTS files
- Respect existing Mesh transformations when converting them to InstancedMeshes

![image](https://user-images.githubusercontent.com/734200/107327918-c33fa700-6a62-11eb-911d-2e6c63c8cf08.png)
