### PR TITLE
Improve the performance of attribute parsing for .b3dm

### DIFF
--- a/src/utilities/arrayToString.js
+++ b/src/utilities/arrayToString.js
@@ -1,12 +1,6 @@
 export function arrayToString( array ) {
 
-	let str = '';
-	for ( let i = 0, l = array.length; i < l; i ++ ) {
-
-		str += String.fromCharCode( array[ i ] );
-
-	}
-
-	return str;
+	const utf8decoder = new TextDecoder();
+	return utf8decoder.decode( array );
 
 }


### PR DESCRIPTION
The previous implementation would use a lot of string allocations which would cause the garbage collector to kick in often and that was a major fit for performance.

This patch fixes the issue by using the built-in TextDecoder class, but it might break compatibility with old browsers (e.g. Internet Explorer).

We noticed that this was causing major hick ups before. I don't think it's worth to keep compatibility with old browsers in this scenario. Or we can just use the old function as a fallback in case TextDecoder is not present.