### PR TITLE
Fix RTC_CENTER for pnts model

### DIFF
--- a/src/three/PNTSLoader.js
+++ b/src/three/PNTSLoader.js
@@ -58,6 +58,16 @@ export class PNTSLoader extends PNTSLoaderBase {
 		result.scene = object;
 		result.scene.featureTable = featureTable;
 
+		const rtcCenter = featureTable.getData( 'RTC_CENTER' );
+
+		if ( rtcCenter ) {
+
+			result.scene.position.x += rtcCenter[ 0 ];
+			result.scene.position.y += rtcCenter[ 1 ];
+			result.scene.position.z += rtcCenter[ 2 ];
+
+		}
+
 		return result;
 
 	}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -617,10 +617,12 @@ export class TilesRenderer extends TilesRendererBase {
 			// rotation fix which is why "multiply" happens here.
 			if ( extension !== 'pnts' ) {
 
-				scene.matrix.multiply( tempMat ).premultiply( cachedTransform );
-				scene.matrix.decompose( scene.position, scene.quaternion, scene.scale );
+				scene.matrix.multiply( tempMat );
 
 			}
+
+			scene.matrix.premultiply( cachedTransform );
+			scene.matrix.decompose( scene.position, scene.quaternion, scene.scale );
 			scene.traverse( c => {
 
 				c[ INITIAL_FRUSTUM_CULLED ] = c.frustumCulled;

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -615,8 +615,12 @@ export class TilesRenderer extends TilesRendererBase {
 			// any transformations applied to it can be assumed to be applied after load
 			// (such as applying RTC_CENTER) meaning they should happen _after_ the z-up
 			// rotation fix which is why "multiply" happens here.
-			scene.matrix.multiply( tempMat ).premultiply( cachedTransform );
-			scene.matrix.decompose( scene.position, scene.quaternion, scene.scale );
+			if ( extension !== 'pnts' ) {
+
+				scene.matrix.multiply( tempMat ).premultiply( cachedTransform );
+				scene.matrix.decompose( scene.position, scene.quaternion, scene.scale );
+
+			}
 			scene.traverse( c => {
 
 				c[ INITIAL_FRUSTUM_CULLED ] = c.frustumCulled;


### PR DESCRIPTION
Fix for [Issue 182](https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/182);
- add RTC_CENTER correction in PNTSLoader
- wrap local up-axis correction rotation into condition to avoid its apply to pnts model