### PR TITLE
DebugTilesRenderer tweaks

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -8,6 +8,7 @@ import {
 	RELATIVE_DEPTH,
 	IS_LEAF,
 	RANDOM_COLOR,
+	RANDOM_NODE_COLOR,
 } from '../src/index.js';
 import {
 	Scene,
@@ -251,6 +252,7 @@ function init() {
 		RELATIVE_DEPTH,
 		IS_LEAF,
 		RANDOM_COLOR,
+		RANDOM_NODE_COLOR,
 
 	} );
 	debug.open();

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -1,9 +1,10 @@
 import { LRUCache } from '../utilities/LRUCache';
 import { PriorityQueue } from '../utilities/PriorityQueue';
+import { Tileset } from './Tileset';
 
 export class TilesRendererBase {
 
-	readonly rootTileset : Object | null;
+	readonly rootTileset : Tileset | null;
 	readonly root : Object | null;
 
 	errorTarget : Number;

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -1,10 +1,9 @@
 import { LRUCache } from '../utilities/LRUCache';
 import { PriorityQueue } from '../utilities/PriorityQueue';
-import { Tileset } from './Tileset';
 
 export class TilesRendererBase {
 
-	readonly rootTileset : Tileset | null;
+	readonly rootTileset : Object | null;
 	readonly root : Object | null;
 
 	errorTarget : Number;

--- a/src/three/DebugTilesRenderer.d.ts
+++ b/src/three/DebugTilesRenderer.d.ts
@@ -9,7 +9,7 @@ export const DEPTH : ColorMode;
 export const RELATIVE_DEPTH : ColorMode;
 export const IS_LEAF : ColorMode;
 export const RANDOM_COLOR : ColorMode;
-
+export const RANDOM_NODE_COLOR: ColorMode;
 export class DebugTilesRenderer extends TilesRenderer {
 
 	displayBoxBounds : Boolean;

--- a/src/three/DebugTilesRenderer.d.ts
+++ b/src/three/DebugTilesRenderer.d.ts
@@ -1,4 +1,5 @@
 import { TilesRenderer } from './TilesRenderer';
+import { Color } from 'three';
 
 export enum ColorMode {}
 export const NONE : ColorMode;
@@ -15,6 +16,11 @@ export class DebugTilesRenderer extends TilesRenderer {
 	displayBoxBounds : Boolean;
 	displaySphereBounds : Boolean;
 	colorMode : ColorMode;
+	
+	/** Debug color min value, default 'black' */
+	minDebugColor : Color;
+	/** Debug color max value, default 'white' */
+	maxDebugColor : Color;
 
 	maxDebugDepth : Number;
 	maxDebugDistance : Number;

--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -1,4 +1,4 @@
-import { Box3Helper, Group, MathUtils, MeshStandardMaterial, PointsMaterial } from 'three';
+import { Box3Helper, Group, MeshStandardMaterial, PointsMaterial, Color } from 'three';
 import { getIndexedRandomColor } from './utilities.js';
 import { TilesRenderer } from './TilesRenderer.js';
 import { SphereHelper } from './SphereHelper.js';
@@ -41,6 +41,8 @@ export class DebugTilesRenderer extends TilesRenderer {
 		this.maxDebugDepth = - 1;
 		this.maxDebugDistance = - 1;
 		this.maxDebugError = - 1;
+		this.minDebugColor = new Color( 'black' );
+		this.maxDebugColor = new Color( 'white' );
 
 		this.extremeDebugDepth = - 1;
 		this.extremeDebugError = - 1;
@@ -183,6 +185,8 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 		}
 
+		const minDebugColor = this.minDebugColor;
+		const maxDebugColor = this.maxDebugColor;
 		const errorTarget = this.errorTarget;
 		const colorMode = this.colorMode;
 		const visibleTiles = this.visibleTiles;
@@ -250,14 +254,14 @@ export class DebugTilesRenderer extends TilesRenderer {
 						case DEPTH: {
 
 							const val = tile.__depth / maxDepth;
-							c.material.color.setRGB( val, val, val );
+							c.material.color.copy( minDebugColor ).lerpHSL( maxDebugColor, val );
 							break;
 
 						}
 						case RELATIVE_DEPTH: {
 
 							const val = tile.__depthFromRenderedParent / maxDepth;
-							c.material.color.setRGB( val, val, val );
+							c.material.color.copy( minDebugColor ).lerpHSL( maxDebugColor, val );
 							break;
 
 						}
@@ -270,8 +274,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 							} else {
 
-								// map higher depth values to red, lower to green, lerping by hue
-								c.material.color.setHSL( MathUtils.mapLinear( val, 0, 1, 0.43, 0 ), 1, 0.5 );
+								c.material.color.copy( minDebugColor ).lerpHSL( maxDebugColor, val );
 
 							}
 							break;
@@ -279,8 +282,8 @@ export class DebugTilesRenderer extends TilesRenderer {
 						}
 						case GEOMETRIC_ERROR: {
 
-							const val = MathUtils.mapLinear( Math.min( tile.geometricError / maxError, 1 ), 1, 0, 0.1, 1 );
-							c.material.color.setRGB( val, val, val );
+							const val = Math.min( tile.geometricError / maxError, 1 );
+							c.material.color.copy( minDebugColor ).lerpHSL( maxDebugColor, val );
 							break;
 
 						}
@@ -289,7 +292,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 							// We don't update the distance if the geometric error is 0.0 so
 							// it will always be black.
 							const val = Math.min( tile.__distanceFromCamera / maxDistance, 1 );
-							c.material.color.setRGB( val, val, val );
+							c.material.color.copy( minDebugColor ).lerpHSL( maxDebugColor, val );
 							break;
 
 						}
@@ -297,11 +300,11 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 							if ( ! tile.children || tile.children.length === 0 ) {
 
-								c.material.color.set( 0xffffff );
+								c.material.color.copy( maxDebugColor );
 
 							} else {
 
-								c.material.color.set( 0 );
+								c.material.color.set( minDebugColor );
 
 							}
 							break;

--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -1,8 +1,9 @@
-import { Box3Helper, Group, MeshBasicMaterial, PointsMaterial } from 'three';
+import { Box3Helper, Group, MathUtils, MeshStandardMaterial, PointsMaterial } from 'three';
+import { getIndexedRandomColor } from './utilities.js';
 import { TilesRenderer } from './TilesRenderer.js';
 import { SphereHelper } from './SphereHelper.js';
 
-const ORIGINAL_MATERIAL = Symbol( 'ORIGINAL_MATERIAL' );
+export const ORIGINAL_MATERIAL = Symbol( 'ORIGINAL_MATERIAL' );
 const HAS_RANDOM_COLOR = Symbol( 'HAS_RANDOM_COLOR' );
 
 function emptyRaycast() {}
@@ -24,9 +25,11 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 		const tilesGroup = this.group;
 		const boxGroup = new Group();
+		boxGroup.name = 'DebugTilesRenderer.boxGroup';
 		tilesGroup.add( boxGroup );
 
 		const sphereGroup = new Group();
+		sphereGroup.name = 'DebugTilesRenderer.sphereGroup';
 		tilesGroup.add( sphereGroup );
 
 		this.displayBoxBounds = false;
@@ -219,7 +222,8 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 						} else {
 
-							c.material = new MeshBasicMaterial();
+							c.material = new MeshStandardMaterial();
+							c.material.flatShading = true;
 
 						}
 
@@ -257,7 +261,8 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 							} else {
 
-								c.material.color.setRGB( val, val, val );
+								const v = MathUtils.mapLinear( val, 1, 0, 0.1, 1 );
+								c.material.color.setRGB( v, v, v );
 
 							}
 							break;
@@ -265,7 +270,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 						}
 						case GEOMETRIC_ERROR: {
 
-							const val = Math.min( tile.geometricError / maxError, 1 );
+							const val = MathUtils.mapLinear( Math.min( tile.geometricError / maxError, 1 ), 1, 0, 0.1, 1 );
 							c.material.color.setRGB( val, val, val );
 							break;
 
@@ -359,10 +364,11 @@ export class DebugTilesRenderer extends TilesRenderer {
 					// In some cases the bounding box may have a scale of 0 in one dimension resulting
 					// in the NaNs in an extracted rotation so we disable matrix updates instead.
 					const boxHelperGroup = new Group();
+					boxHelperGroup.name = 'DebugTilesRenderer.boxHelperGroup';
 					boxHelperGroup.matrix.copy( cachedBoxMat );
 					boxHelperGroup.matrixAutoUpdate = false;
 
-					const boxHelper = new Box3Helper( cachedBox );
+					const boxHelper = new Box3Helper( cachedBox, getIndexedRandomColor( tile.__depth ) );
 					boxHelper.raycast = emptyRaycast;
 					boxHelperGroup.add( boxHelper );
 

--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -3,7 +3,7 @@ import { getIndexedRandomColor } from './utilities.js';
 import { TilesRenderer } from './TilesRenderer.js';
 import { SphereHelper } from './SphereHelper.js';
 
-export const ORIGINAL_MATERIAL = Symbol( 'ORIGINAL_MATERIAL' );
+const ORIGINAL_MATERIAL = Symbol( 'ORIGINAL_MATERIAL' );
 const HAS_RANDOM_COLOR = Symbol( 'HAS_RANDOM_COLOR' );
 
 function emptyRaycast() {}
@@ -250,8 +250,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 						case DEPTH: {
 
 							const val = tile.__depth / maxDepth;
-							/** map higher depth values to red, lower to green, lerping by hue */
-							c.material.color.setHSL( MathUtils.mapLinear( val, 0, 1, 0.9, 0.1 ), 1, 0.5 );
+							c.material.color.setRGB( val, val, val );
 							break;
 
 						}
@@ -271,7 +270,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 							} else {
 
-								/** map higher error values to red, lower to green, lerping by hue */
+								// map higher depth values to red, lower to green, lerping by hue
 								c.material.color.setHSL( MathUtils.mapLinear( val, 0, 1, 0.43, 0 ), 1, 0.5 );
 
 							}

--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -16,6 +16,7 @@ export const DEPTH = 4;
 export const RELATIVE_DEPTH = 5;
 export const IS_LEAF = 6;
 export const RANDOM_COLOR = 7;
+export const RANDOM_NODE_COLOR = 8;
 
 export class DebugTilesRenderer extends TilesRenderer {
 
@@ -201,6 +202,14 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 			scene.traverse( c => {
 
+				if ( colorMode === RANDOM_NODE_COLOR ) {
+
+					h = Math.random();
+					s = 0.5 + Math.random() * 0.5;
+					l = 0.375 + Math.random() * 0.25;
+
+				}
+
 				const currMaterial = c.material;
 				if ( currMaterial ) {
 
@@ -229,7 +238,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 					}
 
-					if ( colorMode !== RANDOM_COLOR ) {
+					if ( colorMode !== RANDOM_COLOR && colorMode !== RANDOM_NODE_COLOR ) {
 
 						delete c.material[ HAS_RANDOM_COLOR ];
 
@@ -241,7 +250,8 @@ export class DebugTilesRenderer extends TilesRenderer {
 						case DEPTH: {
 
 							const val = tile.__depth / maxDepth;
-							c.material.color.setRGB( val, val, val );
+							/** map higher depth values to red, lower to green, lerping by hue */
+							c.material.color.setHSL( MathUtils.mapLinear( val, 0, 1, 0.9, 0.1 ), 1, 0.5 );
 							break;
 
 						}
@@ -261,8 +271,8 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 							} else {
 
-								const v = MathUtils.mapLinear( val, 1, 0, 0.1, 1 );
-								c.material.color.setRGB( v, v, v );
+								/** map higher error values to red, lower to green, lerping by hue */
+								c.material.color.setHSL( MathUtils.mapLinear( val, 0, 1, 0.43, 0 ), 1, 0.5 );
 
 							}
 							break;
@@ -293,6 +303,17 @@ export class DebugTilesRenderer extends TilesRenderer {
 							} else {
 
 								c.material.color.set( 0 );
+
+							}
+							break;
+
+						}
+						case RANDOM_NODE_COLOR: {
+
+							if ( ! c.material[ HAS_RANDOM_COLOR ] ) {
+
+								c.material.color.setHSL( h, s, l );
+								c.material[ HAS_RANDOM_COLOR ] = true;
 
 							}
 							break;

--- a/src/three/TilesGroup.js
+++ b/src/three/TilesGroup.js
@@ -9,6 +9,7 @@ export class TilesGroup extends Group {
 	constructor( tilesRenderer ) {
 
 		super();
+		this.name = 'TilesRenderer.TilesGroup';
 		this.tilesRenderer = tilesRenderer;
 
 	}

--- a/src/three/utilities.js
+++ b/src/three/utilities.js
@@ -1,23 +1,19 @@
 import { Color } from 'three';
 
-/** Return a consistant random color for an index */
-export const getIndexedRandomColor = ( () => {
+const colors = {};
 
-	const colors = {};
+// Return a consistant random color for an index
+export function getIndexedRandomColor( index ) {
 
-	return ( index ) => {
+	if ( ! colors[ index ] ) {
 
-		if ( ! colors[ index ] ) {
+		const h = Math.random();
+		const s = 0.5 + Math.random() * 0.5;
+		const l = 0.375 + Math.random() * 0.25;
 
-			const h = Math.random();
-			const s = 0.5 + Math.random() * 0.5;
-			const l = 0.375 + Math.random() * 0.25;
+		colors[ index ] = new Color().setHSL( h, s, l );
 
-			colors[ index ] = new Color().setHSL( h, s, l );
+	}
+	return colors[ index ];
 
-		}
-		return colors[ index ];
-
-	};
-
-} )();
+}

--- a/src/three/utilities.js
+++ b/src/three/utilities.js
@@ -1,0 +1,23 @@
+import { Color } from 'three';
+
+/** Return a consistant random color for an index */
+export const getIndexedRandomColor = ( () => {
+
+	const colors = {};
+
+	return ( index ) => {
+
+		if ( ! colors[ index ] ) {
+
+			const h = Math.random();
+			const s = 0.5 + Math.random() * 0.5;
+			const l = 0.375 + Math.random() * 0.25;
+
+			colors[ index ] = new Color().setHSL( h, s, l );
+
+		}
+		return colors[ index ];
+
+	};
+
+} )();


### PR DESCRIPTION
* [debug] - adjust colors of the SCREEN_ERROR colorMode in DebugTilesRenderer to lerp from green -> red as it gets closer to the transition point.
![image](https://user-images.githubusercontent.com/983807/124847213-693b0300-df68-11eb-8c3c-5b4188ed3e1b.png)

* [debug] - Add RANDOM_NODE_COLOR which sets a random color per individual object in the loaded gltf scene.
![image](https://user-images.githubusercontent.com/983807/124847278-853ea480-df68-11eb-9bc5-e0fc198c294d.png)

* [naming] - Adding .name's to objects in the hierarchy can help slightly with debugging using the [three chrome extension](https://chrome.google.com/webstore/detail/threejs-developer-tools/ebpnegggocnnhleeicgljbedjkganaek)
![image](https://user-images.githubusercontent.com/983807/124847075-2842ee80-df68-11eb-8e50-50d767fa1336.png)

* [util] - getIndexedRandomColor util which can generate a unique random color for each index, but always return the same color for the same index.

* [debug] - Colorize the bounds differently for each depth when `displayBoxBounds: true`
![image](https://user-images.githubusercontent.com/983807/124847714-71e00900-df69-11eb-9f32-0106364bb933.png)

Things which probably need to be re-thought, but this was my first attempt at doing it:
* [debug] - expose ORIGINAL_MATERIAL symbol from DebugTilesRenderer so that I can 'init' an original material if my implementation manually modifiers or replaces a material.
 - I think we might need a better way to do this, it 'works', but it's confusing and not very discoverable if anyone else ever needs to cover this use case?