### PR TITLE
explicitly use path-browserify for better webpack 5+ support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10439,6 +10439,12 @@
         "vm-browserify": "^1.0.1"
       },
       "dependencies": {
+        "path-browserify": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+          "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+          "dev": true
+        },
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -10973,9 +10979,9 @@
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
-      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true
     },
     "path-dirname": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10981,8 +10981,7 @@
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-dirname": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jest": "^25.5.4",
     "jest-cli": "^25.5.4",
     "parcel-bundler": "^1.12.4",
+    "path-browserify": "^1.0.1",
     "static-server": "^2.2.1",
     "three": ">=0.126.0",
     "typescript": "^3.9.9"

--- a/package.json
+++ b/package.json
@@ -48,12 +48,14 @@
     "jest": "^25.5.4",
     "jest-cli": "^25.5.4",
     "parcel-bundler": "^1.12.4",
-    "path-browserify": "^1.0.1",
     "static-server": "^2.2.1",
     "three": ">=0.126.0",
     "typescript": "^3.9.9"
   },
   "peerDependencies": {
     "three": ">=0.123.0"
+  },
+  "dependencies": {
+    "path-browserify": "^1.0.1"
   }
 }

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'path-browserify';
 import { urlJoin } from '../utilities/urlJoin.js';
 import { LRUCache } from '../utilities/LRUCache.js';
 import { PriorityQueue } from '../utilities/PriorityQueue.js';

--- a/src/utilities/urlJoin.js
+++ b/src/utilities/urlJoin.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'path-browserify';
 
 // Function that properly handles path resolution for parts that have
 // a protocol component like "http://".


### PR DESCRIPTION
Fixes #197 

explicitly use `path-browserify` as a dependency to better support new versions of webpack (5+).

Under the hood older webpack builds would automatically polyfill node libraries with browser suitable alternatives like `path-browserify`
