### PR TITLE
Supporting boundingSpheres for GeometricError calculations

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -786,6 +786,7 @@ export class TilesRenderer extends TilesRendererBase {
 			const boundingBox = cached.box;
 			const boxTransformInverse = cached.boxTransformInverse;
 			const transformInverse = cached.transformInverse;
+			const useBox = boundingBox && boxTransformInverse;
 
 			let maxError = - Infinity;
 			let minDistance = Infinity;
@@ -812,9 +813,20 @@ export class TilesRenderer extends TilesRendererBase {
 				} else {
 
 					tempVector.copy( info.position );
-					tempVector.applyMatrix4( boxTransformInverse || transformInverse );
 
-					const distance = boundingBox ? boundingBox.distanceToPoint( tempVector ) : boundingSphere.distanceToPoint( tempVector );
+					let distance;
+					if ( useBox ) {
+
+						tempVector.applyMatrix4( boxTransformInverse );
+						distance = boundingBox.distanceToPoint( tempVector );
+
+					} else {
+
+						tempVector.applyMatrix4( transformInverse );
+						distance = boundingSphere.distanceToPoint( tempVector );
+
+					}
+
 					const scaledDistance = distance * invScale;
 					const sseDenominator = info.sseDenominator;
 					error = tile.geometricError / ( scaledDistance * sseDenominator );

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -501,6 +501,7 @@ export class TilesRenderer extends TilesRendererBase {
 			loadIndex: 0,
 			transform,
 			transformInverse,
+
 			active: false,
 			inFrustum: [],
 


### PR DESCRIPTION
my first pass on supporting boundingSpheres for geometricError calculations, unsure if this fits with the current style of the code.

changes:
- cache inverse transform to be used later on (we currently only cache inverse box transform)
- fall back to sphere data if box data is unavailable (i.e use TransformInverse & boundingSphere)

I am yet to manually test with a tileset