### PR TITLE
TilesRendererBase: Improve default priority behavior

### DIFF
--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -46,7 +46,7 @@ export interface Tile {
 	 * How far is this tiles bounds from the nearest active Camera.
 	 * Expected to be filled in during calculateError implementations.
 	 */
-	 __distanceFromCamera : Number;
+	__distanceFromCamera : Number;
 	/**
 	 * This tile is currently active if:
 	 *  1: Tile content is loaded and ready to be made visible if needed
@@ -58,14 +58,20 @@ export interface Tile {
 	 *  2: Tile is within a camera frustum
 	 *  3: Tile meets the SSE requirements
 	 */
-	 __visible : Boolean;
+	__visible : Boolean;
 	/**
-	 * Frame number that this tile was last used: active+visible
+	 * Whether or not the tile was visited during the last update run.
 	 */
-	 __lastFrameVisited : Number;
+	__used : Boolean;
+
+	/**
+	 * Whether or not the tile was within the frustum on the last update run.
+	 */
+	__inFrustum : Boolean;
+
 	/**
 	 * TODO: Document this if it is useful enough to be the default property in the LRU sorting.
 	 */
-	 __depthFromRenderedParent : Number;
+	__depthFromRenderedParent : Number;
 
 }

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -19,6 +19,11 @@ const priorityCallback = ( a, b ) => {
 		// the lastFrameVisited tracks the last frame where a tile was used
 		return a.__lastFrameVisited - b.__lastFrameVisited;
 
+	} else if ( a.__inFrustum !== b.__inFrustum ) {
+
+		// prioritize loading whatever is in the frame
+		return a.__inFrustum ? 1 : - 1;
+
 	} else if ( a.__error !== b.__error ) {
 
 		// tiles which have greater error next

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -14,17 +14,17 @@ import { UNLOADED, LOADING, PARSING, LOADED, FAILED } from './constants.js';
  */
 const priorityCallback = ( a, b ) => {
 
-	if ( a.__lastFrameVisited !== b.__lastFrameVisited ) {
-
-		// the lastFrameVisited tracks the last frame where a tile was used
-		return a.__lastFrameVisited - b.__lastFrameVisited;
-
-	} else if ( a.__inFrustum !== b.__inFrustum ) {
+	if ( a.__inFrustum !== b.__inFrustum ) {
 
 		// prioritize loading whatever is in the frame
 		return a.__inFrustum ? 1 : - 1;
 
-	} else if ( a.__error !== b.__error ) {
+	} else if ( a.__used !== b.__used ) {
+
+		// prioritize tiles that were used most recently
+		return a.__used ? 1 : - 1;
+
+	} if ( a.__error !== b.__error ) {
 
 		// tiles which have greater error next
 		return a.__error - b.__error;

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -452,6 +452,25 @@ export class TilesRenderer extends TilesRendererBase {
 			vecY.normalize();
 			vecZ.normalize();
 
+			// handle the case where the box has a dimension of 0 in one axis
+			if ( scaleX === 0 ) {
+
+				vecX.crossVectors( vecY, vecZ );
+
+			}
+
+			if ( scaleY === 0 ) {
+
+				vecY.crossVectors( vecX, vecZ );
+
+			}
+
+			if ( scaleZ === 0 ) {
+
+				vecZ.crossVectors( vecX, vecY );
+
+			}
+
 			// create the oriented frame that the box exists in
 			boxTransform.set(
 				vecX.x, vecY.x, vecZ.x, data[ 0 ],


### PR DESCRIPTION
Related to #143

- Change the priority queue sort function to prioritize loading tile geometry that is within the frustum. Previously tiles outside the frustum were being loaded first because the error for those tiles is set to infinity because it's never calculated.
- Change the priority function to use `__used` instead of `__lastFrameVisited`. `__lastFrameVisited` could cause issues when multiple tile sets were loaded and shared priority queues in case the number of updates calls (the max possible value of `_lastFrameVisited`) became out of sync between the renderer causing one tileset to always finish loading first.
- Handle case where bounding boxes have a dimension of 0 in one axis (mars data sky tiles)

cc @dbuck