### PR TITLE
Update the priority function (again)

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -14,26 +14,31 @@ import { UNLOADED, LOADING, PARSING, LOADED, FAILED } from './constants.js';
  */
 const priorityCallback = ( a, b ) => {
 
-	if ( a.__inFrustum !== b.__inFrustum ) {
+	if ( a.__depth !== b.__depth ) {
 
-		// prioritize loading whatever is in the frame
+		// load shallower tiles first
+		return a.__depth > b.__depth ? - 1 : 1;
+
+	} else if ( a.__inFrustum !== b.__inFrustum ) {
+
+		// load tiles that are in the frustum at the current depth
 		return a.__inFrustum ? 1 : - 1;
 
 	} else if ( a.__used !== b.__used ) {
 
-		// prioritize tiles that were used most recently
+		// load tiles that have been used
 		return a.__used ? 1 : - 1;
 
-	} if ( a.__error !== b.__error ) {
+	} else if ( a.__error !== b.__error ) {
 
-		// tiles which have greater error next
-		return a.__error - b.__error;
+		// load the tile with the higher error
+		return a.__error > b.__error ? 1 : - 1;
 
 	} else if ( a.__distanceFromCamera !== b.__distanceFromCamera ) {
 
 		// and finally visible tiles which have equal error (ex: if geometricError === 0)
 		// should prioritize based on distance.
-		return a.__distanceFromCamera - b.__distanceFromCamera;
+		return a.__distanceFromCamera > b.__distanceFromCamera ? - 1 : 1;
 
 	}
 


### PR DESCRIPTION
cc @dbuck

After playing around with this a bit more in our internal projects I found that the priority sort function on master would cause the queue to prioritize tiles that the camera was inside the bounds of before anything else because in that case the distance is "0" and the error is "Infinity" for those tiles. This would lead to the closest parent tile displaying at lowest level of detail for a long time until all children loaded before it would "pop" to the target level of detail. This was particularly noticeable because we'd start the camera in the middle of the tileset close to the ground.

This PR adjusts the sort function so tiles at the shallowest depth are loaded first and within that depth the most visible / highest error tiles are loaded first within that set.

Getting a good priority function has turned out to be trickier than I expected 😁 I was trying to figure out how to keep the visual error consistent as data loaded so depth wouldn't have to be considered but I don't have anything concrete that comes to mind, yet.