### PR TITLE
Fix for parsing Cesium Ion paths

### DIFF
--- a/example/ionExample.js
+++ b/example/ionExample.js
@@ -157,7 +157,7 @@ function reinstantiateTiles() {
 				url = new URL( json.url );
 				const version = url.searchParams.get( 'v' );
 
-				tiles = new TilesRenderer( url );
+				tiles = new TilesRenderer( url.toString() );
 				tiles.fetchOptions.headers = {};
 				tiles.fetchOptions.headers.Authorization = `Bearer ${json.accessToken}`;
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -308,7 +308,6 @@ export class TilesRendererBase {
 					'asset.version is expected to be a string of "1.0" or "0.0"'
 				);
 
-				url = (typeof url === 'string') ? url : url.toString();
 				const basePath = path.dirname( url );
 
 				traverseSet(

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -308,6 +308,7 @@ export class TilesRendererBase {
 					'asset.version is expected to be a string of "1.0" or "0.0"'
 				);
 
+				url = (typeof url === 'string') ? url : url.toString();
 				const basePath = path.dirname( url );
 
 				traverseSet(


### PR DESCRIPTION
I wasn't able to run the Cesium default Photogrammetry tileset since it appears a url object is returned from the server instead of a string.

This token can be used temporarily for testing: **_eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkN2UwMzFmOC1mY2E3LTQ1ZDQtYjg4NC1mZDhlMzZmZjk4NTkiLCJpZCI6MjU5LCJpYXQiOjE2Mjc5MzM4NTJ9.Rv6Icz_hBcEDbR160A3jPJQfhdZKWo_MJ6KovN7HRpw_**

AssetId: _**40866**_