### PR TITLE
Add option to use a custom color mode in DebugTilesRenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,16 +533,16 @@ RANDOM_COLOR
 // Render every individual mesh in the scene with a random color.
 RANDOM_NODE_COLOR
 
-// Sets a custom color using the customDebugColor call back. 
+// Sets a custom color using the customColorCallback call back. 
 CUSTOM_COLOR_MODE
 ```
-### .customDebugColor
+### .customColorCallback
 
-```
-customDebugColor: (tile: Tile, child: Object) => void
+```js
+customColorCallback: (tile: Tile, child: Object3D) => void
 ```
 
-The callback used if `debugColor` is set to `CUSTOM_COLOR_MODE`. Value default to `null` and must be explicitly set
+The callback used if `debugColor` is set to `CUSTOM_COLOR_MODE`. Value defaults to `null` and must be set explicitly.
 
 ### .displayBoxBounds
 

--- a/README.md
+++ b/README.md
@@ -532,7 +532,17 @@ RANDOM_COLOR
 
 // Render every individual mesh in the scene with a random color.
 RANDOM_NODE_COLOR
+
+// Sets a custom color using the customDebugColor call back. 
+CUSTOM_COLOR_MODE
 ```
+### .customDebugColor
+
+```
+customDebugColor: (tile: Tile, child: Object) => void
+```
+
+The callback used if `debugColor` is set to `CUSTOM_COLOR_MODE`. Value default to `null` and must be explicitly set
 
 ### .displayBoxBounds
 

--- a/example/index.js
+++ b/example/index.js
@@ -9,6 +9,7 @@ import {
 	IS_LEAF,
 	RANDOM_COLOR,
 	RANDOM_NODE_COLOR,
+	CUSTOM_COLOR_MODE
 } from '../src/index.js';
 import {
 	Scene,
@@ -101,6 +102,17 @@ function reinstantiateTiles() {
 	tiles.fetchOptions.mode = 'cors';
 	tiles.manager.addHandler( /\.gltf$/, loader );
 	offsetParent.add( tiles.group );
+
+
+	// Used with CUSTOM_COLOR_MODE
+	tiles.customColorCallback = ( tile, child ) => {
+
+		const depthIsEven = tile.__depth % 2 === 0;
+		const color = depthIsEven ? [ 255, 0, 0 ] : [ 255, 255, 255 ];
+
+		child.material.color.setRGB( ...color );
+
+	};
 
 }
 
@@ -253,6 +265,7 @@ function init() {
 		IS_LEAF,
 		RANDOM_COLOR,
 		RANDOM_NODE_COLOR,
+		CUSTOM_COLOR_MODE
 
 	} );
 	debug.open();

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
 	RELATIVE_DEPTH,
 	IS_LEAF,
 	RANDOM_COLOR,
+	CUSTOM_COLOR_MODE
 } from './three/DebugTilesRenderer.js';
 import { TilesRenderer } from './three/TilesRenderer.js';
 import { B3DMLoader } from './three/B3DMLoader.js';
@@ -49,4 +50,5 @@ export {
 	RELATIVE_DEPTH,
 	IS_LEAF,
 	RANDOM_COLOR,
+	CUSTOM_COLOR_MODE
 };

--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -17,6 +17,7 @@ export const RELATIVE_DEPTH = 5;
 export const IS_LEAF = 6;
 export const RANDOM_COLOR = 7;
 export const RANDOM_NODE_COLOR = 8;
+export const CUSTOM_COLOR_MODE = 9;
 
 export class DebugTilesRenderer extends TilesRenderer {
 
@@ -36,6 +37,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 		this.displayBoxBounds = false;
 		this.displaySphereBounds = false;
 		this.colorMode = NONE;
+		this.customDebugColor = null;
 		this.boxGroup = boxGroup;
 		this.sphereGroup = sphereGroup;
 		this.maxDebugDepth = - 1;
@@ -258,7 +260,6 @@ export class DebugTilesRenderer extends TilesRenderer {
 						delete c.material[ HAS_RANDOM_COLOR ];
 
 					}
-
 					// Set the color on the basic material
 					switch ( colorMode ) {
 
@@ -339,6 +340,20 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 								c.material.color.setHSL( h, s, l );
 								c.material[ HAS_RANDOM_COLOR ] = true;
+
+							}
+							break;
+
+						}
+						case CUSTOM_COLOR_MODE: {
+
+							if ( this.customDebugColor ) {
+
+								this.customDebugColor( tile, c );
+
+							} else {
+
+								console.error( 'customDebugColor callback not defined' );
 
 							}
 							break;

--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -37,7 +37,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 		this.displayBoxBounds = false;
 		this.displaySphereBounds = false;
 		this.colorMode = NONE;
-		this.customDebugColor = null;
+		this.customColorCallback = null;
 		this.boxGroup = boxGroup;
 		this.sphereGroup = sphereGroup;
 		this.maxDebugDepth = - 1;
@@ -347,13 +347,13 @@ export class DebugTilesRenderer extends TilesRenderer {
 						}
 						case CUSTOM_COLOR_MODE: {
 
-							if ( this.customDebugColor ) {
+							if ( this.customColorCallback ) {
 
-								this.customDebugColor( tile, c );
+								this.customColorCallback( tile, c );
 
 							} else {
 
-								console.error( 'customDebugColor callback not defined' );
+								console.warn( 'DebugTilesRenderer: customColorCallback not defined' );
 
 							}
 							break;


### PR DESCRIPTION
The PR adds a `CUSTOM_COLOR_MODE` option for `DebugTilesRenderer`. It gives developers flexibility over and above the existing colour modes. 

It was born from a need to debug LODs, by colouring a LOD tile explicitly. The `DEPTH` and `RELATIVE_DEPTH` options are alright but lacking explicitness in colour (grey scale) and accuracy i.e a child tile may not be a LOD. To colour LODs I needed to add a property into the tilesetJSON (i.e `extras.lodLevel`). This introduces an unnecessary coupling between `3d-tiles-renderer` and design of the tiler. Using the more generic custom colour approach with a callback feels more useful. 