### PR TITLE
Calculate SSE directly from projection matrix rather than specific Camera subclass properties

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -10,14 +10,12 @@ import {
 	Sphere,
 	Vector3,
 	Vector2,
-	Math as MathUtils,
 	Frustum,
 	LoadingManager
 } from 'three';
 import { raycastTraverse, raycastTraverseFirstHit } from './raycastTraverse.js';
 
 const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
-const DEG2RAD = MathUtils.DEG2RAD;
 const tempMat = new Matrix4();
 const tempMat2 = new Matrix4();
 const tempVector = new Vector3();

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -391,17 +391,24 @@ export class TilesRenderer extends TilesRendererBase {
 
 			}
 
+			// Read the calculated projection matrix directly to support custom Camera implementations
 			const projection = camera.projectionMatrix.elements;
+
+			// The last element of the projection matrix is 1 for orthographic, 0 for perspective
 			info.isOrthographic = projection[ 15 ] === 1;
 
 			if ( info.isOrthographic ) {
 
+				// See OrthographicCamera.updateProjectionMatrix and Matrix4.makeOrthographic:
+				// the view width and height are used to populate matrix elements 0 and 5.
 				const w = 2 / projection[ 0 ];
 				const h = 2 / projection[ 5 ];
 				info.pixelSize = Math.max( h / resolution.height, w / resolution.width );
 
 			} else {
 
+				// See PerspectiveCamera.updateProjectionMatrix and Matrix4.makePerspective:
+				// the vertical FOV is used to populate matrix element 5.
 				info.sseDenominator = ( 2 / projection[ 5 ] ) / resolution.height;
 
 			}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -355,10 +355,11 @@ export class TilesRenderer extends TilesRendererBase {
 			cameraInfo.push( {
 
 				frustum: new Frustum(),
-				sseDenominator: - 1,
+				isOrthographic: false,
+				sseDenominator: - 1, // used if isOrthographic:false
 				position: new Vector3(),
 				invScale: - 1,
-				pixelSize: 0,
+				pixelSize: 0, // used if isOrthographic:true
 
 			} );
 
@@ -392,17 +393,18 @@ export class TilesRenderer extends TilesRendererBase {
 
 			}
 
-			if ( camera.isPerspectiveCamera ) {
+			const projection = camera.projectionMatrix.elements;
+			info.isOrthographic = projection[ 15 ] === 1;
 
-				info.sseDenominator = 2 * Math.tan( 0.5 * camera.fov * DEG2RAD ) / resolution.height;
+			if ( info.isOrthographic ) {
 
-			}
-
-			if ( camera.isOrthographicCamera ) {
-
-				const w = camera.right - camera.left;
-				const h = camera.top - camera.bottom;
+				const w = 2 / projection[ 0 ];
+				const h = 2 / projection[ 5 ];
 				info.pixelSize = Math.max( h / resolution.height, w / resolution.width );
+
+			} else {
+
+				info.sseDenominator = ( 2 / projection[ 5 ] ) / resolution.height;
 
 			}
 
@@ -842,12 +844,11 @@ export class TilesRenderer extends TilesRendererBase {
 				}
 
 				// transform camera position into local frame of the tile bounding box
-				const camera = cameras[ i ];
 				const info = cameraInfo[ i ];
 				const invScale = info.invScale;
 
 				let error;
-				if ( camera.isOrthographicCamera ) {
+				if ( info.isOrthographic ) {
 
 					const pixelSize = info.pixelSize;
 					error = tile.geometricError / ( pixelSize * invScale );


### PR DESCRIPTION
Our app uses a custom Camera implementation where we control its projection matrix directly, changing its FOV and even transitioning between perspective and orthographic projections on the fly. But the existing SSE calculation uses the logical config properties of `PerspectiveCamera` and `OrthographicCamera` subclasses, which are incorrect for our camera.

This PR tweaks the SSE logic to look directly at each camera's `projectionMatrix` instead of assuming particular Camera subclasses, based on the following characteristics from how Three's cameras construct their projections:

- Orthographic projections have `mat[ 15 ] === 1`
- Perspective FOV and ortho width/height are encoded into `mat[0]` and `mat[5]`

I've been running this for a while with a `oldResult === newResult` assertion in there to validate that the end behavior is equivalent. Let me know if there's a better way to prove correctness for this PR.

Some lesser-used properties like [PerspectiveCamera.zoom](https://threejs.org/docs/?q=perspe#api/en/cameras/PerspectiveCamera.zoom) should now be taken into account too.