### PR TITLE
Add tile visibility callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,14 @@ onDisposeModel = null : ( scene : Object3D, tile : Tile ) => void
 
 Callback that is called every time a model is disposed of. This should be used in conjunction with [.onLoadModel](#onLoadModel) to dispose of any custom materials created for a tile. Note that the textures, materials, and geometries that a tile loaded in with are all automatically disposed of even if they have been removed from the tile meshes.
 
+### .onTileVisibilityChange
+
+```js
+onTileVisibilityChange = null : ( scene : Object3D, tile : Tile, visible : boolean ) => void
+```
+
+Callback that is called when a tile's visibility changed. The parameter `visible` is `true` when the tile is visible
+
 ### .dispose
 
 ```js

--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -30,6 +30,7 @@ export class TilesRenderer extends TilesRendererBase {
 	onLoadTileSet : ( ( tileSet : Tileset ) => void ) | null;
 	onLoadModel : ( ( scene : Object3D, tile : Tile ) => void ) | null;
 	onDisposeModel : ( ( scene : Object3D, tile : Tile ) => void ) | null;
+	onTileVisibilityChange : ( ( scene : Object3D, tile : Tile, visible : boolean ) => void ) | null;
 
 
 }

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -802,6 +802,7 @@ export class TilesRenderer extends TilesRendererBase {
 			this.onTileVisibilityChange( scene, tile, visible );
 
 		}
+
 	}
 
 	setTileActive( tile, active ) {

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -74,6 +74,7 @@ export class TilesRenderer extends TilesRendererBase {
 		this.onLoadTileSet = null;
 		this.onLoadModel = null;
 		this.onDisposeModel = null;
+		this.onTileVisibilityChange = null;
 
 		const manager = new LoadingManager();
 		manager.setURLModifier( url => {
@@ -796,6 +797,11 @@ export class TilesRenderer extends TilesRendererBase {
 
 		}
 
+		if ( this.onTileVisibilityChange ) {
+
+			this.onTileVisibilityChange( scene, tile, visible );
+
+		}
 	}
 
 	setTileActive( tile, active ) {


### PR DESCRIPTION
Related #232 
Add a property named `onTileVisibilityChange ` to `TilesRenderer `, so we can track the visibility of each tile. If it's ok and if necessary, I can add the api intro into readme file.