### PR TITLE
Preprocess URL for tileset root

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -337,7 +337,7 @@ export class TilesRendererBase {
 		if ( ! ( url in tileSets ) ) {
 
 			const pr = this
-				.fetchTileSet( url, this.fetchOptions )
+				.fetchTileSet( this.preprocessURL ? this.preprocessURL( url ) : url, this.fetchOptions )
 				.then( json => {
 
 					tileSets[ url ] = json;


### PR DESCRIPTION
This library already supports a `preprocessURL` callback which is called just before tile URLs are fetched. However, the callback is not currently applied to the root tileset URL. Preprocessing is less of an issue with the root tileset URL, since some forms of preprocessing can easily be applied in application code before the tileset URL is passed to the `TilesRenderer` constructor.

However, some forms of preprocessing are time-sensitive -- for example, appending a query-param signature with an expiry datetime, as is common practice when serving tilesets from a CDN. In this case, preprocessing the tileset URL when the constructor is initialized may not be sufficient, since the URL might have expired by the time the tileset root is actually fetched (for example, if the entire tileset is hidden when the renderer is initialized).

Applying the preprocessing callback to the tileset root just before fetching ensures that the preprocessed URL is valid when the fetch actually happens.