### PR TITLE
[three] - workaround path trailing slash assumption in three/LoaderUtil

### DIFF
--- a/src/three/B3DMLoader.js
+++ b/src/three/B3DMLoader.js
@@ -41,7 +41,7 @@ export class B3DMLoader extends B3DMLoaderBase {
 
 			// GLTFLoader assumes the working path ends in a slash
 			let workingPath = this.workingPath;
-			if ( ! /[\\/]$/.test( workingPath ) ) {
+			if ( ! /[\\/]$/.test( workingPath ) && workingPath.length ) {
 
 				workingPath += '/';
 

--- a/src/three/GLTFExtensionLoader.js
+++ b/src/three/GLTFExtensionLoader.js
@@ -40,13 +40,12 @@ export class GLTFExtensionLoader extends LoaderBase {
 
 				}
 
-
 			}
 
 			// assume any pre-registered loader has paths configured as the user desires, but if we're making
 			// a new loader, use the working path during parse to support relative uris on other hosts
 			let resourcePath = loader.resourcePath || loader.path || this.workingPath;
-			if ( ! /[\\/]$/.test( resourcePath ) ) {
+			if ( ! /[\\/]$/.test( resourcePath ) && resourcePath.length ) {
 
 				resourcePath += '/';
 

--- a/src/three/GLTFExtensionLoader.js
+++ b/src/three/GLTFExtensionLoader.js
@@ -45,7 +45,12 @@ export class GLTFExtensionLoader extends LoaderBase {
 
 			// assume any pre-registered loader has paths configured as the user desires, but if we're making
 			// a new loader, use the working path during parse to support relative uris on other hosts
-			const resourcePath = loader.resourcePath || loader.path || this.workingPath;
+			let resourcePath = loader.resourcePath || loader.path || this.workingPath;
+			if ( ! /[\\/]$/.test( resourcePath ) ) {
+
+				resourcePath += '/';
+
+			}
 
 			loader.parse( buffer, resourcePath, model => {
 


### PR DESCRIPTION
You were definitely right, the trailing slash **was** required to support subdirectories in the GLTFExtensionLoader, the same as it was in the B3DMLoader (!). It was not required when using the .load in the tests, as the LoaderBase sets it as expected by three. However the TilesRenderer.parseTile does not append the slash.

Notable once loading a tileset where .glb/.gltf files are in subdirectories.
