### PR TITLE
fix: detect content type from mime-type and magic bytes

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -550,12 +550,16 @@ export class TilesRendererBase {
 
 					if ( res.ok ) {
 
-						return {
+						return res.arrayBuffer().then( buffer => {
 
-							mediaType: res.headers.get( 'Content-Type' ),
-							buffer: res.arrayBuffer()
+							return {
 
-						};
+								mediaType: res.headers.get( 'Content-Type' ),
+								buffer
+
+							};
+
+						} );
 
 					} else {
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -550,16 +550,7 @@ export class TilesRendererBase {
 
 					if ( res.ok ) {
 
-						return res.arrayBuffer().then( buffer => {
-
-							return {
-
-								mediaType: res.headers.get( 'Content-Type' ),
-								buffer
-
-							};
-
-						} );
+						return res.arrayBuffer();
 
 					} else {
 
@@ -568,7 +559,7 @@ export class TilesRendererBase {
 					}
 
 				} )
-				.then( result => {
+				.then( buffer => {
 
 					// if it has been unloaded then the tile has been disposed
 					if ( tile.__loadIndex !== loadIndex ) {
@@ -576,8 +567,6 @@ export class TilesRendererBase {
 						return;
 
 					}
-
-					const { buffer, mediaType = '' } = result;
 
 					stats.downloading --;
 					stats.parsing ++;
@@ -593,7 +582,7 @@ export class TilesRendererBase {
 
 						}
 
-						const contentType = getTileContentType( buffer, mediaType );
+						const contentType = getTileContentType( buffer );
 
 						return this.parseTile( buffer, parseTile, contentType );
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -167,7 +167,7 @@ export class TilesRendererBase {
 	}
 
 	// Overrideable
-	parseTile( buffer, tile, tileContentType ) {
+	parseTile( buffer, tile, extension, tileContentType ) {
 
 		return null;
 
@@ -528,6 +528,8 @@ export class TilesRendererBase {
 
 		} else {
 
+			const uri = this.preprocessURL ? this.preprocessURL( tile.content.uri ) : tile.content.uri;
+
 			downloadQueue.add( tile, downloadTile => {
 
 				if ( downloadTile.__loadIndex !== loadIndex ) {
@@ -536,7 +538,6 @@ export class TilesRendererBase {
 
 				}
 
-				const uri = this.preprocessURL ? this.preprocessURL( downloadTile.content.uri ) : downloadTile.content.uri;
 				return fetch( uri, Object.assign( { signal }, this.fetchOptions ) );
 
 			} )
@@ -583,8 +584,9 @@ export class TilesRendererBase {
 						}
 
 						const contentType = getTileContentType( buffer );
+						const extension = getUrlExtension( uri );
 
-						return this.parseTile( buffer, parseTile, contentType );
+						return this.parseTile( buffer, parseTile, extension, contentType );
 
 					} );
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -151,10 +151,10 @@ export class TilesRendererBase {
 
 		const root = rootTileSet.root;
 
-		stats.inFrustum = 0,
-		stats.used = 0,
-		stats.active = 0,
-		stats.visible = 0,
+		stats.inFrustum = 0;
+		stats.used = 0;
+		stats.active = 0;
+		stats.visible = 0;
 		this.frameCount ++;
 
 		determineFrustumSet( root, this );

--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -422,10 +422,10 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 	}
 
-	parseTile( buffer, tile, extension ) {
+	parseTile( buffer, tile, contentType ) {
 
 		return super
-			.parseTile( buffer, tile, extension )
+			.parseTile( buffer, tile, contentType )
 			.then( () => {
 
 				const cached = tile.cached;

--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -422,10 +422,10 @@ export class DebugTilesRenderer extends TilesRenderer {
 
 	}
 
-	parseTile( buffer, tile, contentType ) {
+	parseTile( buffer, tile, extension, tileContentType ) {
 
 		return super
-			.parseTile( buffer, tile, contentType )
+			.parseTile( buffer, tile, extension, tileContentType )
 			.then( () => {
 
 				const cached = tile.cached;

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -566,7 +566,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 	}
 
-	parseTile( buffer, tile, contentType ) {
+	parseTile( buffer, tile, extension, contentType ) {
 
 		tile._loadIndex = tile._loadIndex || 0;
 		tile._loadIndex ++;

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -15,6 +15,7 @@ import {
 	LoadingManager
 } from 'three';
 import { raycastTraverse, raycastTraverseFirstHit } from './raycastTraverse.js';
+import { TileContentType } from '../utilities/tileContentType';
 
 const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
@@ -565,7 +566,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 	}
 
-	parseTile( buffer, tile, extension ) {
+	parseTile( buffer, tile, contentType ) {
 
 		tile._loadIndex = tile._loadIndex || 0;
 		tile._loadIndex ++;
@@ -600,9 +601,9 @@ export class TilesRenderer extends TilesRendererBase {
 
 		}
 
-		switch ( extension ) {
+		switch ( contentType ) {
 
-			case 'b3dm': {
+			case TileContentType.B3DM: {
 
 				const loader = new B3DMLoader( manager );
 				loader.workingPath = workingPath;
@@ -617,7 +618,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 			}
 
-			case 'pnts': {
+			case TileContentType.PNTS: {
 
 				const loader = new PNTSLoader( manager );
 				loader.workingPath = workingPath;
@@ -629,7 +630,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 			}
 
-			case 'i3dm': {
+			case TileContentType.I3DM: {
 
 				const loader = new I3DMLoader( manager );
 				loader.workingPath = workingPath;
@@ -644,7 +645,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 			}
 
-			case 'cmpt': {
+			case TileContentType.CMPT: {
 
 				const loader = new CMPTLoader( manager );
 				loader.workingPath = workingPath;
@@ -660,8 +661,8 @@ export class TilesRenderer extends TilesRendererBase {
 			}
 
 			// 3DTILES_content_gltf
-			case 'gltf':
-			case 'glb':
+			case TileContentType.GLTF:
+			case TileContentType.GLB:
 				const loader = new GLTFExtensionLoader( manager );
 				loader.workingPath = workingPath;
 				loader.fetchOptions = fetchOptions;
@@ -671,7 +672,7 @@ export class TilesRenderer extends TilesRendererBase {
 				break;
 
 			default:
-				console.warn( `TilesRenderer: Content type "${ extension }" not supported.` );
+				console.warn( `TilesRenderer: Content type "${ contentType }" not supported.` );
 				promise = Promise.resolve( null );
 				break;
 
@@ -692,7 +693,7 @@ export class TilesRenderer extends TilesRendererBase {
 			// any transformations applied to it can be assumed to be applied after load
 			// (such as applying RTC_CENTER) meaning they should happen _after_ the z-up
 			// rotation fix which is why "multiply" happens here.
-			if ( extension === 'glb' || extension === 'gltf' ) {
+			if ( contentType === TileContentType.GLB || contentType === TileContentType.GLTF ) {
 
 				scene.matrix.multiply( tempMat );
 

--- a/src/utilities/tileContentType.js
+++ b/src/utilities/tileContentType.js
@@ -1,0 +1,58 @@
+
+export const TileContentType = {
+	B3DM: 'b3dm',
+	I3DM: 'i3dm',
+	PNTS: 'pnts',
+	CMPT: 'cmpt',
+
+	// 3DTILES_content_gltf
+	GLB: 'glb',
+	GLTF: 'gltf'
+};
+
+// first four bytes ('magic bytes') in big-endian uint32-format
+const MAGIC_BYTES = {
+	0x6233646d: TileContentType.B3DM, // 'b3dm'
+	0x6933646d: TileContentType.I3DM, // 'i3dm'
+	0x706e7473: TileContentType.PNTS, // 'pnts'
+	0x636d7074: TileContentType.CMPT, // 'cmpt'
+	0x676c5446: TileContentType.GLB // 'glTF'
+};
+
+/**
+ * Returns the content-type for the tile-contents, determined from
+ * the media-type and the magic bytes in the data-buffer. Returns
+ * one of the Strings defined in `TileContentType`, or null if
+ * the content-type couldn't be recognized.
+ * @param {ArrayBuffer} buffer
+ * @param {string} mediaType
+ * @return {string|null}
+ */
+export function getTileContentType( buffer, mediaType = '' ) {
+
+	// glTF formats have registered media-types
+	if ( mediaType === 'model/gltf+json' ) {
+
+		return TileContentType.GLTF;
+
+	} else if ( mediaType === 'model/gltf-binary' ) {
+
+		return TileContentType.GLB;
+
+	}
+
+	const view = new DataView( buffer );
+
+	// the glTF json format is the only json-based format supported, so
+	// we'll just assume something that looks like json has to be glTF.
+	if ( String.fromCharCode( view.getUint8( 0 ) ) === '{' ) {
+
+		return TileContentType.GLTF;
+
+	}
+
+	const magic = view.getUint32( 0, false );
+
+	return MAGIC_BYTES[ magic ] || null;
+
+}

--- a/src/utilities/tileContentType.js
+++ b/src/utilities/tileContentType.js
@@ -21,25 +21,13 @@ const MAGIC_BYTES = {
 
 /**
  * Returns the content-type for the tile-contents, determined from
- * the media-type and the magic bytes in the data-buffer. Returns
- * one of the Strings defined in `TileContentType`, or null if
- * the content-type couldn't be recognized.
+ * the magic bytes in the data-buffer. Returns one of the Strings
+ * defined in `TileContentType`, or null if  the content-type couldn't
+ * be recognized.
  * @param {ArrayBuffer} buffer
- * @param {string} mediaType
  * @return {string|null}
  */
-export function getTileContentType( buffer, mediaType = '' ) {
-
-	// glTF formats have registered media-types
-	if ( mediaType === 'model/gltf+json' ) {
-
-		return TileContentType.GLTF;
-
-	} else if ( mediaType === 'model/gltf-binary' ) {
-
-		return TileContentType.GLB;
-
-	}
+export function getTileContentType( buffer ) {
 
 	const view = new DataView( buffer );
 


### PR DESCRIPTION
Removes the reliance on file-extensions to determine the content type and instead use the mime-type or magic bytes from the buffer to detect the format.

fixes #254 