### PR TITLE
Readd trailing slash

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -191,7 +191,7 @@ export class TilesRendererBase {
 			if ( tile.content.uri ) {
 
 				// tile content uri has to be interpreted relative to the tileset.json
-				tile.content.uri = new URL( tile.content.uri, tileSetDir ).toString();
+				tile.content.uri = new URL( tile.content.uri, tileSetDir + '/' ).toString();
 
 			}
 


### PR DESCRIPTION
cc @usefulthink 

It looks like #256 actually broke all the demos. Is there a reason the trailing slash is being removed entirely from the tileset basepath string? Readding it and ensuring it's there fixes the issue. Here's the difference in behavior with `URL`:

```js
new URL( 'page.html', 'http://www.test.com/end/path' ).toString()
// http://www.test.com/end/page.html

new URL( 'page.html', 'http://www.test.com/end/path/' ).toString()
// http://www.test.com/end/path/page.html
```