### PR TITLE
Fix mising typescript types

### DIFF
--- a/src/base/LoaderBase.d.ts
+++ b/src/base/LoaderBase.d.ts
@@ -1,0 +1,10 @@
+export class LoaderBase {
+
+	fetchOptions: any;
+	workingPath: string;
+	load( url: string ): Promise< any >;
+	resolveExternalURL( url: string ): string;
+	workingPathForURL( url: string ): string
+	parse( buffer: ArrayBuffer ): Promise< any >;
+
+}

--- a/src/utilities/LRUCache.d.ts
+++ b/src/utilities/LRUCache.d.ts
@@ -13,6 +13,6 @@ export class LRUCache {
 	markAllUnused() : void;
 
 	unloadUnusedContent() : void;
-	scheduleUnload( markAllUnused : Boolean );
+	scheduleUnload( markAllUnused? : Boolean ): void;
 
 }


### PR DESCRIPTION
This PR fixes a couple missing types that were preventing our project from compiling.

Also, I have some more I'd like to do in the future if you're up for it @gkjohnson. We'll probably be using the base classes for most of the work we're doing on https://github.com/matrix-org/thirdroom. We're using Three.js but the actually loading of glTF files happens on another thread in our engine so for my next step in integrating 3D tiles, I need to rewrite the `/three` folder to work in our engine. That means I really need all the other files to have accurate typescript definitions. I'm up for submitting PRs for those typescript updates if you are! That way we don't have to maintain our fork of this library.