### PR TITLE
Fix RTC_CENTER being overwritten by the adjustmentTransform

### DIFF
--- a/src/three/B3DMLoader.js
+++ b/src/three/B3DMLoader.js
@@ -64,6 +64,7 @@ export class B3DMLoader extends B3DMLoaderBase {
 
 				}
 
+				model.scene.updateMatrix();
 				model.scene.matrix.multiply( adjustmentTransform );
 				model.scene.matrix.decompose( model.scene.position, model.scene.quaternion, model.scene.scale );
 


### PR DESCRIPTION
The changes introduced in  d2de4c5bc3ccd3273a3c9f1b53bdf3f8b27a7e93 overwrite the offset introduced by `RTC_CENTER`. This PR fixes this by updating the scene's model matrix before applying the adjustment transform.