### PR TITLE
Update type definitions to correctly type properties and expose available APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,14 @@ getOrientedBounds( box : Box3, boxTransform : Matrix4 ) : boolean;
 
 Sets `box` and `boxTransform` to the bounds and matrix that describe the oriented bounding box that encapsulates the root of the tile set. Returns `false` if the tile root was not loaded.
 
+### .getBoundingSphere
+
+```js
+getBoundingSphere( sphere : Sphere ) : boolean;
+```
+
+Sets `sphere` to the bounding sphere that encapsulates the root of the tile set. Returns `false` if the tile root was not loaded.
+
 ### .hasCamera
 
 ```js

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -13,7 +13,7 @@ export class TilesRendererBase {
 	maxDepth : Number;
 	stopAtEmptyTiles : Boolean;
 
-	fetchOptions : Object;
+	fetchOptions : RequestInit;
 	/** function to preprocess the url for each individual tile */
 	preprocessURL : ((uri: string | URL) => string) | null;
 

--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -13,9 +13,11 @@ export class TilesRenderer extends TilesRendererBase {
 
 	group : TilesGroup;
 
-	getBoundsTransform( target: Matrix4 ) : Boolean;
-
 	getBounds( box : Box3 ) : Boolean;
+	getOrientedBounds( box, matrix ) : Boolean;
+	getBoundingSphere( sphere ) : Boolean;
+
+	raycast( raycaster, intersects ) : Boolean;
 
 	hasCamera( camera : Camera ) : Boolean;
 	setCamera( camera : Camera ) : Boolean;

--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -1,4 +1,4 @@
-import { Box3, Camera, Vector2, Matrix4, WebGLRenderer, Object3D, LoadingManager } from 'three';
+import { Box3, Camera, Vector2, Matrix4, WebGLRenderer, Object3D, LoadingManager, Sphere } from 'three';
 import { Tile } from '../base/Tile';
 import { Tileset } from '../base/Tileset';
 import { TilesRendererBase } from '../base/TilesRendererBase';
@@ -14,10 +14,8 @@ export class TilesRenderer extends TilesRendererBase {
 	group : TilesGroup;
 
 	getBounds( box : Box3 ) : Boolean;
-	getOrientedBounds( box, matrix ) : Boolean;
-	getBoundingSphere( sphere ) : Boolean;
-
-	raycast( raycaster, intersects ) : Boolean;
+	getOrientedBounds( box : Box3, matrix : Matrix4 ) : Boolean;
+	getBoundingSphere( sphere: Sphere ) : Boolean;
 
 	hasCamera( camera : Camera ) : Boolean;
 	setCamera( camera : Camera ) : Boolean;


### PR DESCRIPTION
TilesRendererBase.d.ts
- Added the _RequestInit_ type instead of _Object_ so that the expected type is used and typescript will not complain about accessing non-existing properties

TilesRenderer.d.ts
- Added getOrientedBounds
- Added getBoundingSphere
- Added raycast