### PR TITLE
Exporting GLTFCesiumRTCExtension

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,7 @@ export { B3DMLoader } from './three/B3DMLoader';
 export { I3DMLoader } from './three/I3DMLoader';
 export { PNTSLoader } from './three/PNTSLoader';
 export { CMPTLoader } from './three/CMPTLoader';
+export { GLTFCesiumRTCExtension } from './three/GLTFCesiumRTCExtension';
 export { GLTFExtensionLoader } from './three/GLTFExtensionLoader';
 export { Ellipsoid } from './three/math/Ellipsoid';
 export { EllipsoidRegion } from './three/math/EllipsoidRegion';

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ export { B3DMLoader } from './three/B3DMLoader.js';
 export { PNTSLoader } from './three/PNTSLoader.js';
 export { I3DMLoader } from './three/I3DMLoader.js';
 export { CMPTLoader } from './three/CMPTLoader.js';
+export { GLTFCesiumRTCExtension } from './three/GLTFCesiumRTCExtension.js';
 export { GLTFExtensionLoader } from './three/GLTFExtensionLoader.js';
 export { EllipsoidRegionHelper, EllipsoidRegionLineHelper } from './three/objects/EllipsoidRegionHelper.js';
 export { SphereHelper } from './three/objects/SphereHelper.js';

--- a/src/three/GLTFCesiumRTCExtension.d.ts
+++ b/src/three/GLTFCesiumRTCExtension.d.ts
@@ -1,6 +1,6 @@
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 
-export default class GLTFCesiumRTCExtension{
+export class GLTFCesiumRTCExtension{
 	name: 'CESIUM_RTC';
 
 	afterRoot(result: GLTF): null

--- a/src/three/GLTFCesiumRTCExtension.js
+++ b/src/three/GLTFCesiumRTCExtension.js
@@ -1,5 +1,4 @@
-
-export default class GLTFCesiumRTCExtension {
+export class GLTFCesiumRTCExtension {
 
 	constructor() {
 
@@ -9,10 +8,14 @@ export default class GLTFCesiumRTCExtension {
 
 	afterRoot( res ) {
 
-		const { center } = res.parser.json.extensions.CESIUM_RTC;
-		res.scene.position.x += center[ 0 ];
-		res.scene.position.y += center[ 1 ];
-		res.scene.position.z += center[ 2 ];
+		if ( res.parser.json.extensions ) {
+
+			const { center } = res.parser.json.extensions.CESIUM_RTC;
+			res.scene.position.x += center[ 0 ];
+			res.scene.position.y += center[ 1 ];
+			res.scene.position.z += center[ 2 ];
+
+		}
 
 	}
 


### PR DESCRIPTION
Exporting GLTFCesiumRTCExtension so it can be used and registered with the GLTFLoader to support use with B3DMLoaders. 
Also added a check for the extensions property before running the extension to ensure no errors are thrown when non-CesiumRTC tiles are run against it.