### PR TITLE
update GLTFExtensionLoader to import cesium extension correctly

### DIFF
--- a/src/three/GLTFExtensionLoader.js
+++ b/src/three/GLTFExtensionLoader.js
@@ -1,7 +1,7 @@
 import { DefaultLoadingManager } from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { LoaderBase } from '../base/LoaderBase.js';
-import GLTFCesiumRTCExtension from './GLTFCesiumRTCExtension.js';
+import { GLTFCesiumRTCExtension } from './GLTFCesiumRTCExtension.js';
 
 export class GLTFExtensionLoader extends LoaderBase {
 


### PR DESCRIPTION
Just noticed that one of the imports needed to be updated. I have included this change, sorry for missing this. A new version should be released to fix this as it can cause issues otherwise.