### PR TITLE
Feature: PNTs Draco support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ const tilesRenderer = new TilesRenderer( './path/to/tileset.json' );
 tilesRenderer.manager.addHandler( /\.gltf$/, loader );
 ```
 
+Adding support for DRACO decompression within the PNTS files.
+
+```js
+
+// Note the DRACO compression files need to be supplied via an explicit source.
+// We use unpkg here but in practice should be provided by the application.
+const dracoLoader = new DRACOLoader();
+dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.123.0/examples/js/libs/draco/gltf/' );
+
+
+const tilesRenderer = new TilesRenderer( './path/to/tileset.json' );
+tilesRenderer.manager.addHandler( /\.drc$/, loader );
+```
+
+
 ## Loading from Cesium Ion
 
 Loading from Cesium Ion requires some extra fetching of the ion url endpoint, as well as a temporary bearer access token. A full example is found in the ionExample.js file in the examples folder.

--- a/src/three/PNTSLoader.js
+++ b/src/three/PNTSLoader.js
@@ -1,122 +1,134 @@
-import { PNTSLoaderBase } from "../base/PNTSLoaderBase.js";
+import { PNTSLoaderBase } from '../base/PNTSLoaderBase.js';
 import {
 	Points,
 	PointsMaterial,
 	BufferGeometry,
 	BufferAttribute,
 	DefaultLoadingManager,
-} from "three";
+} from 'three';
 
 const DRACO_ATTRIBUTE_MAP = {
-	RGB: "color",
-	POSITION: "position",
+	RGB: 'color',
+	POSITION: 'position',
 };
 export class PNTSLoader extends PNTSLoaderBase {
-	constructor(manager = DefaultLoadingManager) {
+
+	constructor( manager = DefaultLoadingManager ) {
+
 		super();
 		this.manager = manager;
 
 		// very hacky way of getting the draco loader
-		this.dracoLoader = this.manager.getHandler("test.drc");
+		this.dracoLoader = this.manager.getHandler( 'test.drc' );
+
 	}
 
-	parse(buffer) {
-		return super.parse(buffer).then(async (result) => {
+	parse( buffer ) {
+
+		return super.parse( buffer ).then( async ( result ) => {
+
 			const { featureTable } = result;
 
 			const geometry = new BufferGeometry();
 			const material = new PointsMaterial();
 
-			if (featureTable.isDraco()) {
+			if ( featureTable.isDraco() ) {
+
 				const dracoIDs = featureTable.getDracoProperties();
 				const attributeIDs = {};
 
-				for (let [key, value] of Object.entries(dracoIDs)) {
-					attributeIDs[DRACO_ATTRIBUTE_MAP[key]] = value;
+				for ( const [ key, value ] of Object.entries( dracoIDs ) ) {
+
+					attributeIDs[ DRACO_ATTRIBUTE_MAP[ key ] ] = value;
+
 				}
 
 				const taskConfig = {
 					attributeIDs,
 					attributeTypes: {
-						position: "Float32Array",
-						color: "Uint8Array",
+						position: 'Float32Array',
+						color: 'Uint8Array',
 					},
 					useUniqueIDs: true,
 				};
 
 				const buffer = featureTable.getDracoBuffer();
 
-				if (this.dracoLoader == null) {
-					throw new Error("PNTSLoader: dracoLoader not available.");
+				if ( this.dracoLoader == null ) {
+
+					throw new Error( 'PNTSLoader: dracoLoader not available.' );
+
 				}
 
 				const dracoGeometry = await this.dracoLoader
-					.decodeGeometry(buffer, taskConfig)
-					.catch(() => new BufferGeometry());
+					.decodeGeometry( buffer, taskConfig );
 
-				geometry.copy(dracoGeometry);
+				geometry.copy( dracoGeometry );
 
-				if (geometry.attributes.color) {
+				if ( geometry.attributes.color ) {
+
 					geometry.attributes.color.normalized = true;
 					material.vertexColors = true;
+
 				}
+
 			} else {
-				const POINTS_LENGTH = featureTable.getData("POINTS_LENGTH");
-				POSITION = featureTable.getData(
-					"POSITION",
-					POINTS_LENGTH,
-					"FLOAT",
-					"VEC3"
-				);
-				geometry.setAttribute(
-					"position",
-					new BufferAttribute(POSITION, 3, false)
-				);
 
-				RGB = featureTable.getData(
-					"RGB",
-					POINTS_LENGTH,
-					"UNSIGNED_BYTE",
-					"VEC3"
-				);
+				const POINTS_LENGTH = featureTable.getData( 'POINTS_LENGTH' );
+				const POSITION = featureTable.getData( 'POSITION', POINTS_LENGTH, 'FLOAT', 'VEC3' );
+				const RGB = featureTable.getData( 'RGB', POINTS_LENGTH, 'UNSIGNED_BYTE', 'VEC3' );
 
-				if (RGB !== null) {
-					geometry.setAttribute("color", new BufferAttribute(RGB, 3, true));
+				geometry.setAttribute( 'position', new BufferAttribute( POSITION, 3, false ) );
+
+				if ( RGB !== null ) {
+
+					geometry.setAttribute( 'color', new BufferAttribute( RGB, 3, true ) );
 					material.vertexColors = true;
+
 				}
+
 			}
 
 			[
-				"QUANTIZED_VOLUME_OFFSET",
-				"QUANTIZED_VOLUME_SCALE",
-				"CONSTANT_RGBA",
-				"BATCH_LENGTH",
-				"POSITION_QUANTIZED",
-				"RGBA",
-				"RGB565",
-				"NORMAL",
-				"NORMAL_OCT16P",
-			].forEach((feature) => {
-				if (feature in featureTable.header) {
+				'QUANTIZED_VOLUME_OFFSET',
+				'QUANTIZED_VOLUME_SCALE',
+				'CONSTANT_RGBA',
+				'BATCH_LENGTH',
+				'POSITION_QUANTIZED',
+				'RGBA',
+				'RGB565',
+				'NORMAL',
+				'NORMAL_OCT16P',
+			].forEach( ( feature ) => {
+
+				if ( feature in featureTable.header ) {
+
 					console.warn(
 						`PNTSLoader: Unsupported FeatureTable feature "${feature}" detected.`
 					);
-				}
-			});
 
-			const object = new Points(geometry, material);
+				}
+
+			} );
+
+			const object = new Points( geometry, material );
 			result.scene = object;
 			result.scene.featureTable = featureTable;
 
-			const rtcCenter = featureTable.getData("RTC_CENTER");
+			const rtcCenter = featureTable.getData( 'RTC_CENTER' );
 
-			if (rtcCenter) {
-				result.scene.position.x += rtcCenter[0];
-				result.scene.position.y += rtcCenter[1];
-				result.scene.position.z += rtcCenter[2];
+			if ( rtcCenter ) {
+
+				result.scene.position.x += rtcCenter[ 0 ];
+				result.scene.position.y += rtcCenter[ 1 ];
+				result.scene.position.z += rtcCenter[ 2 ];
+
 			}
 
 			return result;
-		});
+
+		} );
+
 	}
+
 }

--- a/src/three/PNTSLoader.js
+++ b/src/three/PNTSLoader.js
@@ -18,8 +18,8 @@ export class PNTSLoader extends PNTSLoaderBase {
 		super();
 		this.manager = manager;
 
-		// very hacky way of getting the draco loader
-		this.dracoLoader = this.manager.getHandler( 'test.drc' );
+		// hacky way of getting the draco loader from the manager
+		this.dracoLoader = this.manager.getHandler( 'draco.drc' );
 
 	}
 

--- a/src/three/PNTSLoader.js
+++ b/src/three/PNTSLoader.js
@@ -1,79 +1,122 @@
-import { PNTSLoaderBase } from '../base/PNTSLoaderBase.js';
-import { Points, PointsMaterial, BufferGeometry, BufferAttribute, DefaultLoadingManager } from 'three';
+import { PNTSLoaderBase } from "../base/PNTSLoaderBase.js";
+import {
+	Points,
+	PointsMaterial,
+	BufferGeometry,
+	BufferAttribute,
+	DefaultLoadingManager,
+} from "three";
 
+const DRACO_ATTRIBUTE_MAP = {
+	RGB: "color",
+	POSITION: "position",
+};
 export class PNTSLoader extends PNTSLoaderBase {
-
-	constructor( manager = DefaultLoadingManager ) {
-
+	constructor(manager = DefaultLoadingManager) {
 		super();
 		this.manager = manager;
 
+		// very hacky way of getting the draco loader
+		this.dracoLoader = this.manager.getHandler("test.drc");
 	}
 
-	parse( buffer ) {
+	parse(buffer) {
+		return super.parse(buffer).then(async (result) => {
+			const { featureTable } = result;
 
-		return super
-			.parse( buffer )
-			.then( result => {
+			const geometry = new BufferGeometry();
+			const material = new PointsMaterial();
 
-				const { featureTable } = result;
+			if (featureTable.isDraco()) {
+				const dracoIDs = featureTable.getDracoProperties();
+				const attributeIDs = {};
 
-				const POINTS_LENGTH = featureTable.getData( 'POINTS_LENGTH' );
-				const POSITION = featureTable.getData( 'POSITION', POINTS_LENGTH, 'FLOAT', 'VEC3' );
-				const RGB = featureTable.getData( 'RGB', POINTS_LENGTH, 'UNSIGNED_BYTE', 'VEC3' );
+				for (let [key, value] of Object.entries(dracoIDs)) {
+					attributeIDs[DRACO_ATTRIBUTE_MAP[key]] = value;
+				}
 
-				[
-					'QUANTIZED_VOLUME_OFFSET',
-					'QUANTIZED_VOLUME_SCALE',
-					'CONSTANT_RGBA',
-					'BATCH_LENGTH',
-					'POSITION_QUANTIZED',
-					'RGBA',
-					'RGB565',
-					'NORMAL',
-					'NORMAL_OCT16P',
-				].forEach( feature => {
+				const taskConfig = {
+					attributeIDs,
+					attributeTypes: {
+						position: "Float32Array",
+						color: "Uint8Array",
+					},
+					useUniqueIDs: true,
+				};
 
-					if ( feature in featureTable.header ) {
+				const buffer = featureTable.getDracoBuffer();
 
-						console.warn( `PNTSLoader: Unsupported FeatureTable feature "${ feature }" detected.` );
+				if (this.dracoLoader == null) {
+					throw new Error("PNTSLoader: dracoLoader not available.");
+				}
 
-					}
+				const dracoGeometry = await this.dracoLoader
+					.decodeGeometry(buffer, taskConfig)
+					.catch(() => new BufferGeometry());
 
-				} );
+				geometry.copy(dracoGeometry);
 
-				const geometry = new BufferGeometry();
-				geometry.setAttribute( 'position', new BufferAttribute( POSITION, 3, false ) );
-
-				const material = new PointsMaterial();
-				material.size = 2;
-				material.sizeAttenuation = false;
-
-				if ( RGB !== null ) {
-
-					geometry.setAttribute( 'color', new BufferAttribute( RGB, 3, true ) );
+				if (geometry.attributes.color) {
+					geometry.attributes.color.normalized = true;
 					material.vertexColors = true;
-
 				}
+			} else {
+				const POINTS_LENGTH = featureTable.getData("POINTS_LENGTH");
+				POSITION = featureTable.getData(
+					"POSITION",
+					POINTS_LENGTH,
+					"FLOAT",
+					"VEC3"
+				);
+				geometry.setAttribute(
+					"position",
+					new BufferAttribute(POSITION, 3, false)
+				);
 
-				const object = new Points( geometry, material );
-				result.scene = object;
-				result.scene.featureTable = featureTable;
+				RGB = featureTable.getData(
+					"RGB",
+					POINTS_LENGTH,
+					"UNSIGNED_BYTE",
+					"VEC3"
+				);
 
-				const rtcCenter = featureTable.getData( 'RTC_CENTER' );
-
-				if ( rtcCenter ) {
-
-					result.scene.position.x += rtcCenter[ 0 ];
-					result.scene.position.y += rtcCenter[ 1 ];
-					result.scene.position.z += rtcCenter[ 2 ];
-
+				if (RGB !== null) {
+					geometry.setAttribute("color", new BufferAttribute(RGB, 3, true));
+					material.vertexColors = true;
 				}
+			}
 
-				return result;
+			[
+				"QUANTIZED_VOLUME_OFFSET",
+				"QUANTIZED_VOLUME_SCALE",
+				"CONSTANT_RGBA",
+				"BATCH_LENGTH",
+				"POSITION_QUANTIZED",
+				"RGBA",
+				"RGB565",
+				"NORMAL",
+				"NORMAL_OCT16P",
+			].forEach((feature) => {
+				if (feature in featureTable.header) {
+					console.warn(
+						`PNTSLoader: Unsupported FeatureTable feature "${feature}" detected.`
+					);
+				}
+			});
 
-			} );
+			const object = new Points(geometry, material);
+			result.scene = object;
+			result.scene.featureTable = featureTable;
 
+			const rtcCenter = featureTable.getData("RTC_CENTER");
+
+			if (rtcCenter) {
+				result.scene.position.x += rtcCenter[0];
+				result.scene.position.y += rtcCenter[1];
+				result.scene.position.z += rtcCenter[2];
+			}
+
+			return result;
+		});
 	}
-
 }

--- a/src/utilities/FeatureTable.d.ts
+++ b/src/utilities/FeatureTable.d.ts
@@ -16,6 +16,12 @@ export class FeatureTable {
 		defaultType? : String | null
 	) : Number | String | ArrayBufferView;
 
+	isDraco() : boolean;
+
+	getDracoBuffer() : ArrayBuffer;
+
+	getDracoProperties() : Record<string, number>;
+
 }
 
 export class BatchTable {

--- a/src/utilities/FeatureTable.js
+++ b/src/utilities/FeatureTable.js
@@ -141,6 +141,39 @@ export class FeatureTable {
 
 	}
 
+	isDraco() {
+
+		return !!this.header?.extensions[ "3DTILES_draco_point_compression" ];
+
+	}
+
+	getDracoBuffer() {
+
+		if ( !this.isDraco() ) {
+
+			throw new Error( 'FeatureTable: Feature data is not draco encoded' );
+
+		}
+
+		const { buffer, binOffset } = this;
+
+		const { byteOffset, byteLength } = this.header?.extensions["3DTILES_draco_point_compression"];
+
+		return buffer.slice( binOffset + byteOffset, binOffset + byteOffset + byteLength );
+
+	}
+
+	getDracoProperties() {
+
+		if ( !this.isDraco() ) {
+
+			throw new Error( 'FeatureTable: Feature data is not draco encoded' );
+
+		}
+
+		return this.header?.extensions[ "3DTILES_draco_point_compression" ]?.properties;
+
+	};
 }
 
 export class BatchTable extends FeatureTable {

--- a/src/utilities/FeatureTable.js
+++ b/src/utilities/FeatureTable.js
@@ -143,13 +143,14 @@ export class FeatureTable {
 
 	isDraco() {
 
-		return !!this.header?.extensions[ "3DTILES_draco_point_compression" ];
+		const { extensions } = this.header;
+		return extensions && !! extensions[ '3DTILES_draco_point_compression' ];
 
 	}
 
 	getDracoBuffer() {
 
-		if ( !this.isDraco() ) {
+		if ( ! this.isDraco() ) {
 
 			throw new Error( 'FeatureTable: Feature data is not draco encoded' );
 
@@ -157,7 +158,7 @@ export class FeatureTable {
 
 		const { buffer, binOffset } = this;
 
-		const { byteOffset, byteLength } = this.header?.extensions["3DTILES_draco_point_compression"];
+		const { byteOffset, byteLength } = this.header.extensions[ '3DTILES_draco_point_compression' ];
 
 		return buffer.slice( binOffset + byteOffset, binOffset + byteOffset + byteLength );
 
@@ -165,15 +166,16 @@ export class FeatureTable {
 
 	getDracoProperties() {
 
-		if ( !this.isDraco() ) {
+		if ( ! this.isDraco() ) {
 
 			throw new Error( 'FeatureTable: Feature data is not draco encoded' );
 
 		}
 
-		return this.header?.extensions[ "3DTILES_draco_point_compression" ]?.properties;
+		return this.header.extensions[ '3DTILES_draco_point_compression' ].properties;
 
-	};
+	}
+
 }
 
 export class BatchTable extends FeatureTable {


### PR DESCRIPTION
This PR provides support for PNTs files that are using the `3DTILES_draco_point_compression` extension.

It only supports Positions & Colors currently.
This seemed fine because 3DTilesRendererJS only supports those attributes currently. 
It also allowed me to use the three.js DRACOLoader class which I don't think supports arbitrary Draco attributes either (I could be wrong there).

I'm not 100% happy with the way in which I inject the Draco loader (via the the .drc handler) but it seemed like the lightest touch method that vaguely makes sense.