### PR TITLE
Add initial google maps 3D tiles example implementation

### DIFF
--- a/example/GlobeOrbitControls.js
+++ b/example/GlobeOrbitControls.js
@@ -25,7 +25,7 @@ class GlobeOrbitControls extends EventDispatcher {
 
 		super();
 
-    this.geoid = geoid;
+		this.geoid = geoid;
 
 		this.object = camera;
 		this.domElement = domElement;
@@ -165,7 +165,7 @@ class GlobeOrbitControls extends EventDispatcher {
 			const quat = new Quaternion().setFromUnitVectors( camera.up, new Vector3( 0, 1, 0 ) );
 			const quatInverse = quat.clone().invert();
 
-				// TODO: use surface normal as camera pivot
+			// TODO: use surface normal as camera pivot
 			// const up = new Vector3();
 
 			const lastPosition = new Vector3();
@@ -397,7 +397,7 @@ class GlobeOrbitControls extends EventDispatcher {
 
 		}
 
-    const dir = new Vector3();
+		const dir = new Vector3();
 
 		const panLeft = function () {
 
@@ -427,17 +427,13 @@ class GlobeOrbitControls extends EventDispatcher {
 
 				v.setFromMatrixColumn( objectMatrix, 0 );
 
-					scope.geoid.getPositionToNormal( scope.object.position, dir );
-					scope.geoid.getPositionToNormal( scope.object.position, dir );
-					// scope.object.getWorldDirection(dir);
-					// dir.negate();
-
-					v.setFromMatrixColumn( objectMatrix, 0 );
 				scope.geoid.getPositionToNormal( scope.object.position, dir );
-					// scope.object.getWorldDirection(dir);
-					// dir.negate();
+				scope.geoid.getPositionToNormal( scope.object.position, dir );
 
-					v.setFromMatrixColumn( objectMatrix, 0 );
+				v.setFromMatrixColumn( objectMatrix, 0 );
+				scope.geoid.getPositionToNormal( scope.object.position, dir );
+
+				v.setFromMatrixColumn( objectMatrix, 0 );
 				v.crossVectors( dir, v );
 
 				v.multiplyScalar( distance );

--- a/example/GlobeOrbitControls.js
+++ b/example/GlobeOrbitControls.js
@@ -1,0 +1,1283 @@
+import {
+	EventDispatcher,
+	MOUSE,
+	Quaternion,
+	Spherical,
+	TOUCH,
+	Vector2,
+	Vector3
+} from 'three';
+
+// OrbitControls performs orbiting, dollying (zooming), and panning.
+// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
+//
+//    Orbit - left mouse / touch: one-finger move
+//    Zoom - middle mouse, or mousewheel / touch: two-finger spread or squish
+//    Pan - right mouse, or left mouse + ctrl/meta/shiftKey, or arrow keys / touch: two-finger move
+
+const _changeEvent = { type: 'change' };
+const _startEvent = { type: 'start' };
+const _endEvent = { type: 'end' };
+
+class GlobeOrbitControls extends EventDispatcher {
+
+	constructor( camera, geoid, domElement ) {
+
+		super();
+
+    this.geoid = geoid;
+
+		this.object = camera;
+		this.domElement = domElement;
+		this.domElement.style.touchAction = 'none'; // disable touch scroll
+
+		// Set to false to disable this control
+		this.enabled = true;
+
+		// "target" sets the location of focus, where the object orbits around
+		this.target = new Vector3();
+
+		// How far you can dolly in and out ( PerspectiveCamera only )
+		this.minDistance = 0;
+		this.maxDistance = Infinity;
+
+		// How far you can zoom in and out ( OrthographicCamera only )
+		this.minZoom = 0;
+		this.maxZoom = Infinity;
+
+		// How far you can orbit vertically, upper and lower limits.
+		// Range is 0 to Math.PI radians.
+		this.minPolarAngle = 0; // radians
+		this.maxPolarAngle = Math.PI; // radians
+
+		// How far you can orbit horizontally, upper and lower limits.
+		// If set, the interval [ min, max ] must be a sub-interval of [ - 2 PI, 2 PI ], with ( max - min < 2 PI )
+		this.minAzimuthAngle = - Infinity; // radians
+		this.maxAzimuthAngle = Infinity; // radians
+
+		// Set to true to enable damping (inertia)
+		// If damping is enabled, you must call controls.update() in your animation loop
+		this.enableDamping = false;
+		this.dampingFactor = 0.05;
+
+		// This option actually enables dollying in and out; left as "zoom" for backwards compatibility.
+		// Set to false to disable zooming
+		this.enableZoom = true;
+		this.zoomSpeed = 1.0;
+
+		// Set to false to disable rotating
+		this.enableRotate = true;
+		this.rotateSpeed = 1.0;
+
+		// Set to false to disable panning
+		this.enablePan = true;
+		this.panSpeed = 1.0;
+		this.keyPanSpeed = 7.0;	// pixels moved per arrow key push
+
+		// Set to true to automatically rotate around the target
+		// If auto-rotate is enabled, you must call controls.update() in your animation loop
+		this.autoRotate = false;
+		this.autoRotateSpeed = 2.0; // 30 seconds per orbit when fps is 60
+
+		// The four arrow keys
+		this.keys = { LEFT: 'ArrowLeft', UP: 'ArrowUp', RIGHT: 'ArrowRight', BOTTOM: 'ArrowDown' };
+
+		// Mouse buttons
+		this.mouseButtons = { LEFT: MOUSE.ROTATE, MIDDLE: MOUSE.DOLLY, RIGHT: MOUSE.PAN };
+
+		// Touch fingers
+		this.touches = { ONE: TOUCH.ROTATE, TWO: TOUCH.DOLLY_PAN };
+
+		// for reset
+		this.target0 = this.target.clone();
+		this.position0 = this.object.position.clone();
+		this.zoom0 = this.object.zoom;
+
+		// the target DOM element for key events
+		this._domElementKeyEvents = null;
+
+		//
+		// public methods
+		//
+
+		this.getPolarAngle = function () {
+
+			return spherical.phi;
+
+		};
+
+		this.getAzimuthalAngle = function () {
+
+			return spherical.theta;
+
+		};
+
+		this.getDistance = function () {
+
+			return this.object.position.distanceTo( this.target );
+
+		};
+
+		this.listenToKeyEvents = function ( domElement ) {
+
+			domElement.addEventListener( 'keydown', onKeyDown );
+			this._domElementKeyEvents = domElement;
+
+		};
+
+		this.stopListenToKeyEvents = function () {
+
+			this._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown );
+			this._domElementKeyEvents = null;
+
+		};
+
+		this.saveState = function () {
+
+			scope.target0.copy( scope.target );
+			scope.position0.copy( scope.object.position );
+			scope.zoom0 = scope.object.zoom;
+
+		};
+
+		this.reset = function () {
+
+			scope.target.copy( scope.target0 );
+			scope.object.position.copy( scope.position0 );
+			scope.object.zoom = scope.zoom0;
+
+			scope.object.updateProjectionMatrix();
+			scope.dispatchEvent( _changeEvent );
+
+			scope.update();
+
+			state = STATE.NONE;
+
+		};
+
+		// this method is exposed, but perhaps it would be better if we can make it private...
+		this.update = function () {
+
+			const offset = new Vector3();
+
+			// TODO: use surface normal as camera pivot
+			// so camera.up is the orbit axis
+			const quat = new Quaternion().setFromUnitVectors( camera.up, new Vector3( 0, 1, 0 ) );
+			const quatInverse = quat.clone().invert();
+
+				// TODO: use surface normal as camera pivot
+			// const up = new Vector3();
+
+			const lastPosition = new Vector3();
+			const lastQuaternion = new Quaternion();
+
+			const twoPI = 2 * Math.PI;
+
+			return function update() {
+
+				const position = scope.object.position;
+
+				offset.copy( position ).sub( scope.target );
+
+				// TODO: use surface normal as camera pivot
+				// scope.geoid.getPositionToNormal( scope.object.position, up );
+				// quat.setFromUnitVectors( up, camera.up );
+				// quatInverse.invert(quat);
+
+				// rotate offset to "y-axis-is-up" space
+				offset.applyQuaternion( quat );
+
+				// angle from z-axis around y-axis
+				spherical.setFromVector3( offset );
+
+				if ( scope.autoRotate && state === STATE.NONE ) {
+
+					rotateLeft( getAutoRotationAngle() );
+
+				}
+
+				if ( scope.enableDamping ) {
+
+					spherical.theta += sphericalDelta.theta * scope.dampingFactor;
+					spherical.phi += sphericalDelta.phi * scope.dampingFactor;
+
+				} else {
+
+					spherical.theta += sphericalDelta.theta;
+					spherical.phi += sphericalDelta.phi;
+
+				}
+
+				// restrict theta to be between desired limits
+
+				let min = scope.minAzimuthAngle;
+				let max = scope.maxAzimuthAngle;
+
+				if ( isFinite( min ) && isFinite( max ) ) {
+
+					if ( min < - Math.PI ) min += twoPI; else if ( min > Math.PI ) min -= twoPI;
+
+					if ( max < - Math.PI ) max += twoPI; else if ( max > Math.PI ) max -= twoPI;
+
+					if ( min <= max ) {
+
+						spherical.theta = Math.max( min, Math.min( max, spherical.theta ) );
+
+					} else {
+
+						spherical.theta = ( spherical.theta > ( min + max ) / 2 ) ?
+							Math.max( min, spherical.theta ) :
+							Math.min( max, spherical.theta );
+
+					}
+
+				}
+
+				// restrict phi to be between desired limits
+				spherical.phi = Math.max( scope.minPolarAngle, Math.min( scope.maxPolarAngle, spherical.phi ) );
+
+				spherical.makeSafe();
+
+
+				spherical.radius *= scale;
+
+				// restrict radius to be between desired limits
+				spherical.radius = Math.max( scope.minDistance, Math.min( scope.maxDistance, spherical.radius ) );
+
+				// move target to panned location
+
+				if ( scope.enableDamping === true ) {
+
+					scope.target.addScaledVector( panOffset, scope.dampingFactor );
+
+				} else {
+
+					scope.target.add( panOffset );
+
+				}
+
+				offset.setFromSpherical( spherical );
+
+				// rotate offset back to "camera-up-vector-is-up" space
+				offset.applyQuaternion( quatInverse );
+
+				position.copy( scope.target ).add( offset );
+
+				scope.object.lookAt( scope.target );
+
+				if ( scope.enableDamping === true ) {
+
+					sphericalDelta.theta *= ( 1 - scope.dampingFactor );
+					sphericalDelta.phi *= ( 1 - scope.dampingFactor );
+
+					panOffset.multiplyScalar( 1 - scope.dampingFactor );
+
+				} else {
+
+					sphericalDelta.set( 0, 0, 0 );
+
+					panOffset.set( 0, 0, 0 );
+
+				}
+
+				scale = 1;
+
+				// update condition is:
+				// min(camera displacement, camera rotation in radians)^2 > EPS
+				// using small-angle approximation cos(x/2) = 1 - x^2 / 8
+
+				if ( zoomChanged ||
+					lastPosition.distanceToSquared( scope.object.position ) > EPS ||
+					8 * ( 1 - lastQuaternion.dot( scope.object.quaternion ) ) > EPS ) {
+
+					scope.dispatchEvent( _changeEvent );
+
+					lastPosition.copy( scope.object.position );
+					lastQuaternion.copy( scope.object.quaternion );
+					zoomChanged = false;
+
+					return true;
+
+				}
+
+				return false;
+
+			};
+
+		}();
+
+		this.dispose = function () {
+
+			scope.domElement.removeEventListener( 'contextmenu', onContextMenu );
+
+			scope.domElement.removeEventListener( 'pointerdown', onPointerDown );
+			scope.domElement.removeEventListener( 'pointercancel', onPointerUp );
+			scope.domElement.removeEventListener( 'wheel', onMouseWheel );
+
+			scope.domElement.removeEventListener( 'pointermove', onPointerMove );
+			scope.domElement.removeEventListener( 'pointerup', onPointerUp );
+
+
+			if ( scope._domElementKeyEvents !== null ) {
+
+				scope._domElementKeyEvents.removeEventListener( 'keydown', onKeyDown );
+				scope._domElementKeyEvents = null;
+
+			}
+
+			//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
+
+		};
+
+		//
+		// internals
+		//
+
+		const scope = this;
+
+		const STATE = {
+			NONE: - 1,
+			ROTATE: 0,
+			DOLLY: 1,
+			PAN: 2,
+			TOUCH_ROTATE: 3,
+			TOUCH_PAN: 4,
+			TOUCH_DOLLY_PAN: 5,
+			TOUCH_DOLLY_ROTATE: 6
+		};
+
+		let state = STATE.NONE;
+
+		const EPS = 0.000001;
+
+		// current position in spherical coordinates
+		const spherical = new Spherical();
+		const sphericalDelta = new Spherical();
+
+		let scale = 1;
+		const panOffset = new Vector3();
+		let zoomChanged = false;
+
+		const rotateStart = new Vector2();
+		const rotateEnd = new Vector2();
+		const rotateDelta = new Vector2();
+
+		const panStart = new Vector2();
+		const panEnd = new Vector2();
+		const panDelta = new Vector2();
+
+		const dollyStart = new Vector2();
+		const dollyEnd = new Vector2();
+		const dollyDelta = new Vector2();
+
+		const pointers = [];
+		const pointerPositions = {};
+
+		function getAutoRotationAngle() {
+
+			return 2 * Math.PI / 60 / 60 * scope.autoRotateSpeed;
+
+		}
+
+		function getZoomScale() {
+
+			return Math.pow( 0.95, scope.zoomSpeed );
+
+		}
+
+		function rotateLeft( angle ) {
+
+			sphericalDelta.theta -= angle;
+
+		}
+
+		function rotateUp( angle ) {
+
+			sphericalDelta.phi -= angle;
+
+		}
+
+    const dir = new Vector3();
+
+		const panLeft = function () {
+
+			const v = new Vector3();
+			const u = new Vector3();
+
+			return function panLeft( distance, objectMatrix ) {
+
+				v.setFromMatrixColumn( objectMatrix, 0 ); // get X column of objectMatrix
+				v.multiplyScalar( distance );
+
+				scope.geoid.getPositionToNormal( scope.object.position, dir );
+				u.crossVectors( dir, v );
+				v.crossVectors( dir, u );
+
+				panOffset.add( v );
+
+			};
+
+		}();
+
+		const panUp = function () {
+
+			const v = new Vector3();
+
+			return function panUp( distance, objectMatrix ) {
+
+				v.setFromMatrixColumn( objectMatrix, 0 );
+
+					scope.geoid.getPositionToNormal( scope.object.position, dir );
+					scope.geoid.getPositionToNormal( scope.object.position, dir );
+					// scope.object.getWorldDirection(dir);
+					// dir.negate();
+
+					v.setFromMatrixColumn( objectMatrix, 0 );
+				scope.geoid.getPositionToNormal( scope.object.position, dir );
+					// scope.object.getWorldDirection(dir);
+					// dir.negate();
+
+					v.setFromMatrixColumn( objectMatrix, 0 );
+				v.crossVectors( dir, v );
+
+				v.multiplyScalar( distance );
+
+				panOffset.add( v );
+
+			};
+
+		}();
+
+		// deltaX and deltaY are in pixels; right and down are positive
+		const pan = function () {
+
+			const offset = new Vector3();
+
+			return function pan( deltaX, deltaY ) {
+
+				const element = scope.domElement;
+
+				if ( scope.object.isPerspectiveCamera ) {
+
+					// perspective
+					const position = scope.object.position;
+					offset.copy( position ).sub( scope.target );
+					let targetDistance = offset.length();
+
+					// half of the fov is center to top of screen
+					targetDistance *= Math.tan( ( scope.object.fov / 2 ) * Math.PI / 180.0 );
+
+					// we use only clientHeight here so aspect ratio does not distort speed
+					panLeft( 2 * deltaX * targetDistance / element.clientHeight, scope.object.matrix );
+					panUp( 2 * deltaY * targetDistance / element.clientHeight, scope.object.matrix );
+
+				} else if ( scope.object.isOrthographicCamera ) {
+
+					// orthographic
+					panLeft( deltaX * ( scope.object.right - scope.object.left ) / scope.object.zoom / element.clientWidth, scope.object.matrix );
+					panUp( deltaY * ( scope.object.top - scope.object.bottom ) / scope.object.zoom / element.clientHeight, scope.object.matrix );
+
+				} else {
+
+					// camera neither orthographic nor perspective
+					console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - pan disabled.' );
+					scope.enablePan = false;
+
+				}
+
+			};
+
+		}();
+
+		function dollyOut( dollyScale ) {
+
+			if ( scope.object.isPerspectiveCamera ) {
+
+				scale /= dollyScale;
+
+			} else if ( scope.object.isOrthographicCamera ) {
+
+				scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom * dollyScale ) );
+				scope.object.updateProjectionMatrix();
+				zoomChanged = true;
+
+			} else {
+
+				console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+				scope.enableZoom = false;
+
+			}
+
+		}
+
+		function dollyIn( dollyScale ) {
+
+			if ( scope.object.isPerspectiveCamera ) {
+
+				scale *= dollyScale;
+
+			} else if ( scope.object.isOrthographicCamera ) {
+
+				scope.object.zoom = Math.max( scope.minZoom, Math.min( scope.maxZoom, scope.object.zoom / dollyScale ) );
+				scope.object.updateProjectionMatrix();
+				zoomChanged = true;
+
+			} else {
+
+				console.warn( 'WARNING: OrbitControls.js encountered an unknown camera type - dolly/zoom disabled.' );
+				scope.enableZoom = false;
+
+			}
+
+		}
+
+		//
+		// event callbacks - update the object state
+		//
+
+		function handleMouseDownRotate( event ) {
+
+			rotateStart.set( event.clientX, event.clientY );
+
+		}
+
+		function handleMouseDownDolly( event ) {
+
+			dollyStart.set( event.clientX, event.clientY );
+
+		}
+
+		function handleMouseDownPan( event ) {
+
+			panStart.set( event.clientX, event.clientY );
+
+		}
+
+		function handleMouseMoveRotate( event ) {
+
+			rotateEnd.set( event.clientX, event.clientY );
+
+			rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
+
+			const element = scope.domElement;
+
+			rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
+
+			rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
+
+			rotateStart.copy( rotateEnd );
+
+			scope.update();
+
+		}
+
+		function handleMouseMoveDolly( event ) {
+
+			dollyEnd.set( event.clientX, event.clientY );
+
+			dollyDelta.subVectors( dollyEnd, dollyStart );
+
+			if ( dollyDelta.y > 0 ) {
+
+				dollyOut( getZoomScale() );
+
+			} else if ( dollyDelta.y < 0 ) {
+
+				dollyIn( getZoomScale() );
+
+			}
+
+			dollyStart.copy( dollyEnd );
+
+			scope.update();
+
+		}
+
+		function handleMouseMovePan( event ) {
+
+			panEnd.set( event.clientX, event.clientY );
+
+			panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
+
+			pan( panDelta.x, panDelta.y );
+
+			panStart.copy( panEnd );
+
+			scope.update();
+
+		}
+
+		function handleMouseWheel( event ) {
+
+			if ( event.deltaY < 0 ) {
+
+				dollyIn( getZoomScale() );
+
+			} else if ( event.deltaY > 0 ) {
+
+				dollyOut( getZoomScale() );
+
+			}
+
+			scope.update();
+
+		}
+
+		function handleKeyDown( event ) {
+
+			let needsUpdate = false;
+
+			switch ( event.code ) {
+
+				case scope.keys.UP:
+
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+						rotateUp( 2 * Math.PI * scope.rotateSpeed / scope.domElement.clientHeight );
+
+					} else {
+
+						pan( 0, scope.keyPanSpeed );
+
+					}
+
+					needsUpdate = true;
+					break;
+
+				case scope.keys.BOTTOM:
+
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+						rotateUp( - 2 * Math.PI * scope.rotateSpeed / scope.domElement.clientHeight );
+
+					} else {
+
+						pan( 0, - scope.keyPanSpeed );
+
+					}
+
+					needsUpdate = true;
+					break;
+
+				case scope.keys.LEFT:
+
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+						rotateLeft( 2 * Math.PI * scope.rotateSpeed / scope.domElement.clientHeight );
+
+					} else {
+
+						pan( scope.keyPanSpeed, 0 );
+
+					}
+
+					needsUpdate = true;
+					break;
+
+				case scope.keys.RIGHT:
+
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+						rotateLeft( - 2 * Math.PI * scope.rotateSpeed / scope.domElement.clientHeight );
+
+					} else {
+
+						pan( - scope.keyPanSpeed, 0 );
+
+					}
+
+					needsUpdate = true;
+					break;
+
+			}
+
+			if ( needsUpdate ) {
+
+				// prevent the browser from scrolling on cursor keys
+				event.preventDefault();
+
+				scope.update();
+
+			}
+
+
+		}
+
+		function handleTouchStartRotate() {
+
+			if ( pointers.length === 1 ) {
+
+				rotateStart.set( pointers[ 0 ].pageX, pointers[ 0 ].pageY );
+
+			} else {
+
+				const x = 0.5 * ( pointers[ 0 ].pageX + pointers[ 1 ].pageX );
+				const y = 0.5 * ( pointers[ 0 ].pageY + pointers[ 1 ].pageY );
+
+				rotateStart.set( x, y );
+
+			}
+
+		}
+
+		function handleTouchStartPan() {
+
+			if ( pointers.length === 1 ) {
+
+				panStart.set( pointers[ 0 ].pageX, pointers[ 0 ].pageY );
+
+			} else {
+
+				const x = 0.5 * ( pointers[ 0 ].pageX + pointers[ 1 ].pageX );
+				const y = 0.5 * ( pointers[ 0 ].pageY + pointers[ 1 ].pageY );
+
+				panStart.set( x, y );
+
+			}
+
+		}
+
+		function handleTouchStartDolly() {
+
+			const dx = pointers[ 0 ].pageX - pointers[ 1 ].pageX;
+			const dy = pointers[ 0 ].pageY - pointers[ 1 ].pageY;
+
+			const distance = Math.sqrt( dx * dx + dy * dy );
+
+			dollyStart.set( 0, distance );
+
+		}
+
+		function handleTouchStartDollyPan() {
+
+			if ( scope.enableZoom ) handleTouchStartDolly();
+
+			if ( scope.enablePan ) handleTouchStartPan();
+
+		}
+
+		function handleTouchStartDollyRotate() {
+
+			if ( scope.enableZoom ) handleTouchStartDolly();
+
+			if ( scope.enableRotate ) handleTouchStartRotate();
+
+		}
+
+		function handleTouchMoveRotate( event ) {
+
+			if ( pointers.length == 1 ) {
+
+				rotateEnd.set( event.pageX, event.pageY );
+
+			} else {
+
+				const position = getSecondPointerPosition( event );
+
+				const x = 0.5 * ( event.pageX + position.x );
+				const y = 0.5 * ( event.pageY + position.y );
+
+				rotateEnd.set( x, y );
+
+			}
+
+			rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
+
+			const element = scope.domElement;
+
+			rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
+
+			rotateUp( 2 * Math.PI * rotateDelta.y / element.clientHeight );
+
+			rotateStart.copy( rotateEnd );
+
+		}
+
+		function handleTouchMovePan( event ) {
+
+			if ( pointers.length === 1 ) {
+
+				panEnd.set( event.pageX, event.pageY );
+
+			} else {
+
+				const position = getSecondPointerPosition( event );
+
+				const x = 0.5 * ( event.pageX + position.x );
+				const y = 0.5 * ( event.pageY + position.y );
+
+				panEnd.set( x, y );
+
+			}
+
+			panDelta.subVectors( panEnd, panStart ).multiplyScalar( scope.panSpeed );
+
+			pan( panDelta.x, panDelta.y );
+
+			panStart.copy( panEnd );
+
+		}
+
+		function handleTouchMoveDolly( event ) {
+
+			const position = getSecondPointerPosition( event );
+
+			const dx = event.pageX - position.x;
+			const dy = event.pageY - position.y;
+
+			const distance = Math.sqrt( dx * dx + dy * dy );
+
+			dollyEnd.set( 0, distance );
+
+			dollyDelta.set( 0, Math.pow( dollyEnd.y / dollyStart.y, scope.zoomSpeed ) );
+
+			dollyOut( dollyDelta.y );
+
+			dollyStart.copy( dollyEnd );
+
+		}
+
+		function handleTouchMoveDollyPan( event ) {
+
+			if ( scope.enableZoom ) handleTouchMoveDolly( event );
+
+			if ( scope.enablePan ) handleTouchMovePan( event );
+
+		}
+
+		function handleTouchMoveDollyRotate( event ) {
+
+			if ( scope.enableZoom ) handleTouchMoveDolly( event );
+
+			if ( scope.enableRotate ) handleTouchMoveRotate( event );
+
+		}
+
+		//
+		// event handlers - FSM: listen for events and reset state
+		//
+
+		function onPointerDown( event ) {
+
+			if ( scope.enabled === false ) return;
+
+			if ( pointers.length === 0 ) {
+
+				scope.domElement.setPointerCapture( event.pointerId );
+
+				scope.domElement.addEventListener( 'pointermove', onPointerMove );
+				scope.domElement.addEventListener( 'pointerup', onPointerUp );
+
+			}
+
+			//
+
+			addPointer( event );
+
+			if ( event.pointerType === 'touch' ) {
+
+				onTouchStart( event );
+
+			} else {
+
+				onMouseDown( event );
+
+			}
+
+		}
+
+		function onPointerMove( event ) {
+
+			if ( scope.enabled === false ) return;
+
+			if ( event.pointerType === 'touch' ) {
+
+				onTouchMove( event );
+
+			} else {
+
+				onMouseMove( event );
+
+			}
+
+		}
+
+		function onPointerUp( event ) {
+
+			removePointer( event );
+
+			if ( pointers.length === 0 ) {
+
+				scope.domElement.releasePointerCapture( event.pointerId );
+
+				scope.domElement.removeEventListener( 'pointermove', onPointerMove );
+				scope.domElement.removeEventListener( 'pointerup', onPointerUp );
+
+			}
+
+			scope.dispatchEvent( _endEvent );
+
+			state = STATE.NONE;
+
+		}
+
+		function onMouseDown( event ) {
+
+			let mouseAction;
+
+			switch ( event.button ) {
+
+				case 0:
+
+					mouseAction = scope.mouseButtons.LEFT;
+					break;
+
+				case 1:
+
+					mouseAction = scope.mouseButtons.MIDDLE;
+					break;
+
+				case 2:
+
+					mouseAction = scope.mouseButtons.RIGHT;
+					break;
+
+				default:
+
+					mouseAction = - 1;
+
+			}
+
+			switch ( mouseAction ) {
+
+				case MOUSE.DOLLY:
+
+					if ( scope.enableZoom === false ) return;
+
+					handleMouseDownDolly( event );
+
+					state = STATE.DOLLY;
+
+					break;
+
+				case MOUSE.ROTATE:
+
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+						if ( scope.enablePan === false ) return;
+
+						handleMouseDownPan( event );
+
+						state = STATE.PAN;
+
+					} else {
+
+						if ( scope.enableRotate === false ) return;
+
+						handleMouseDownRotate( event );
+
+						state = STATE.ROTATE;
+
+					}
+
+					break;
+
+				case MOUSE.PAN:
+
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+						if ( scope.enableRotate === false ) return;
+
+						handleMouseDownRotate( event );
+
+						state = STATE.ROTATE;
+
+					} else {
+
+						if ( scope.enablePan === false ) return;
+
+						handleMouseDownPan( event );
+
+						state = STATE.PAN;
+
+					}
+
+					break;
+
+				default:
+
+					state = STATE.NONE;
+
+			}
+
+			if ( state !== STATE.NONE ) {
+
+				scope.dispatchEvent( _startEvent );
+
+			}
+
+		}
+
+		function onMouseMove( event ) {
+
+			switch ( state ) {
+
+				case STATE.ROTATE:
+
+					if ( scope.enableRotate === false ) return;
+
+					handleMouseMoveRotate( event );
+
+					break;
+
+				case STATE.DOLLY:
+
+					if ( scope.enableZoom === false ) return;
+
+					handleMouseMoveDolly( event );
+
+					break;
+
+				case STATE.PAN:
+
+					if ( scope.enablePan === false ) return;
+
+					handleMouseMovePan( event );
+
+					break;
+
+			}
+
+		}
+
+		function onMouseWheel( event ) {
+
+			if ( scope.enabled === false || scope.enableZoom === false || state !== STATE.NONE ) return;
+
+			event.preventDefault();
+
+			scope.dispatchEvent( _startEvent );
+
+			handleMouseWheel( event );
+
+			scope.dispatchEvent( _endEvent );
+
+		}
+
+		function onKeyDown( event ) {
+
+			if ( scope.enabled === false || scope.enablePan === false ) return;
+
+			handleKeyDown( event );
+
+		}
+
+		function onTouchStart( event ) {
+
+			trackPointer( event );
+
+			switch ( pointers.length ) {
+
+				case 1:
+
+					switch ( scope.touches.ONE ) {
+
+						case TOUCH.ROTATE:
+
+							if ( scope.enableRotate === false ) return;
+
+							handleTouchStartRotate();
+
+							state = STATE.TOUCH_ROTATE;
+
+							break;
+
+						case TOUCH.PAN:
+
+							if ( scope.enablePan === false ) return;
+
+							handleTouchStartPan();
+
+							state = STATE.TOUCH_PAN;
+
+							break;
+
+						default:
+
+							state = STATE.NONE;
+
+					}
+
+					break;
+
+				case 2:
+
+					switch ( scope.touches.TWO ) {
+
+						case TOUCH.DOLLY_PAN:
+
+							if ( scope.enableZoom === false && scope.enablePan === false ) return;
+
+							handleTouchStartDollyPan();
+
+							state = STATE.TOUCH_DOLLY_PAN;
+
+							break;
+
+						case TOUCH.DOLLY_ROTATE:
+
+							if ( scope.enableZoom === false && scope.enableRotate === false ) return;
+
+							handleTouchStartDollyRotate();
+
+							state = STATE.TOUCH_DOLLY_ROTATE;
+
+							break;
+
+						default:
+
+							state = STATE.NONE;
+
+					}
+
+					break;
+
+				default:
+
+					state = STATE.NONE;
+
+			}
+
+			if ( state !== STATE.NONE ) {
+
+				scope.dispatchEvent( _startEvent );
+
+			}
+
+		}
+
+		function onTouchMove( event ) {
+
+			trackPointer( event );
+
+			switch ( state ) {
+
+				case STATE.TOUCH_ROTATE:
+
+					if ( scope.enableRotate === false ) return;
+
+					handleTouchMoveRotate( event );
+
+					scope.update();
+
+					break;
+
+				case STATE.TOUCH_PAN:
+
+					if ( scope.enablePan === false ) return;
+
+					handleTouchMovePan( event );
+
+					scope.update();
+
+					break;
+
+				case STATE.TOUCH_DOLLY_PAN:
+
+					if ( scope.enableZoom === false && scope.enablePan === false ) return;
+
+					handleTouchMoveDollyPan( event );
+
+					scope.update();
+
+					break;
+
+				case STATE.TOUCH_DOLLY_ROTATE:
+
+					if ( scope.enableZoom === false && scope.enableRotate === false ) return;
+
+					handleTouchMoveDollyRotate( event );
+
+					scope.update();
+
+					break;
+
+				default:
+
+					state = STATE.NONE;
+
+			}
+
+		}
+
+		function onContextMenu( event ) {
+
+			if ( scope.enabled === false ) return;
+
+			event.preventDefault();
+
+		}
+
+		function addPointer( event ) {
+
+			pointers.push( event );
+
+		}
+
+		function removePointer( event ) {
+
+			delete pointerPositions[ event.pointerId ];
+
+			for ( let i = 0; i < pointers.length; i ++ ) {
+
+				if ( pointers[ i ].pointerId == event.pointerId ) {
+
+					pointers.splice( i, 1 );
+					return;
+
+				}
+
+			}
+
+		}
+
+		function trackPointer( event ) {
+
+			let position = pointerPositions[ event.pointerId ];
+
+			if ( position === undefined ) {
+
+				position = new Vector2();
+				pointerPositions[ event.pointerId ] = position;
+
+			}
+
+			position.set( event.pageX, event.pageY );
+
+		}
+
+		function getSecondPointerPosition( event ) {
+
+			const pointer = ( event.pointerId === pointers[ 0 ].pointerId ) ? pointers[ 1 ] : pointers[ 0 ];
+
+			return pointerPositions[ pointer.pointerId ];
+
+		}
+
+		//
+
+		scope.domElement.addEventListener( 'contextmenu', onContextMenu );
+
+		scope.domElement.addEventListener( 'pointerdown', onPointerDown );
+		scope.domElement.addEventListener( 'pointercancel', onPointerUp );
+		scope.domElement.addEventListener( 'wheel', onMouseWheel, { passive: false } );
+
+		// force an update at start
+
+		this.update();
+
+	}
+
+}
+
+export { GlobeOrbitControls };

--- a/example/googleMapsExample.html
+++ b/example/googleMapsExample.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+		<meta charset="utf-8"/>
+
+		<title>3D Tiles Renderer Options Example</title>
+
+		<style>
+			* {
+				margin: 0;
+				padding: 0;
+			}
+
+			html {
+				overflow: hidden;
+				font-family: Arial, Helvetica, sans-serif;
+				user-select: none;
+			}
+
+			canvas {
+				image-rendering: pixelated;
+				outline: none;
+			}
+
+			#info {
+				position: absolute;
+				top: 0;
+				left: 0;
+				color: white;
+				width: 100%;
+				text-align: center;
+				padding: 5px;
+				pointer-events: none;
+				line-height: 1.5em;
+			}
+
+			#info a {
+				color: white;
+				pointer-events: all;
+			}
+        </style>
+    </head>
+    <body>
+		<div id="info">
+			<div>
+				Google Maps 3D tiles example.
+				<br/>
+			</div>
+		</div>
+        <script src="./googleMapsExample.js"></script>
+    </body>
+</html>

--- a/example/googleMapsExample.html
+++ b/example/googleMapsExample.html
@@ -4,7 +4,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 		<meta charset="utf-8"/>
 
-		<title>3D Tiles Renderer Options Example</title>
+		<title>Google 3D Tiles Example</title>
 
 		<style>
 			* {
@@ -44,7 +44,7 @@
     <body>
 		<div id="info">
 			<div>
-				Google Maps 3D tiles example.
+				Google Maps 3D tiles example. Double click to refocus the camera.
 				<br/>
 			</div>
 		</div>

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -216,7 +216,7 @@ function init() {
 
 	document.body.appendChild( renderer.domElement );
 
-	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1600000 );
+	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 160000000 );
 	camera.position.set( 7326000, 10279000, -823000 );
 	cameraHelper = new CameraHelper( camera );
 	scene.add( cameraHelper );
@@ -225,7 +225,7 @@ function init() {
 	controls = new OrbitControls( camera, renderer.domElement );
 	controls.enablePan = false;
 	controls.minDistance = 6500000;
-	controls.maxDistance = 13315000;
+	controls.maxDistance = Infinity;
 
 	// lights
 	const dirLight = new DirectionalLight( 0xffffff );
@@ -258,7 +258,6 @@ function init() {
 	tileOptions.add( params, 'displayActiveTiles' );
 	tileOptions.add( params, 'errorTarget' ).min( 0 ).max( 50 );
 	tileOptions.add( params, 'maxDepth' ).min( 1 ).max( 100 );
-	tileOptions.add( params, 'up', [ '+Y', '+Z', '-Z' ] );
 
 	const debug = gui.addFolder( 'Debug Options' );
 	debug.add( params, 'displayBoxBounds' );

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -23,7 +23,6 @@ import Stats from 'three/examples/jsm/libs/stats.module.js';
 
 const apiOrigin = 'https://tile.googleapis.com';
 
-const hashUrl = window.location.hash.replace( /^#/, '' );
 let camera, controls, scene, renderer, tiles, cameraHelper;
 let offsetParent;
 let statsContainer, stats;
@@ -91,14 +90,6 @@ function isInt( input ) {
 
 function reinstantiateTiles() {
 
-	let url = hashUrl || '../data/tileset.json';
-
-	if ( hashUrl ) {
-
-		params.ionAssetId = isInt( hashUrl ) ? hashUrl : '';
-
-	}
-
 	if ( tiles ) {
 
 		offsetParent.remove( tiles.group );
@@ -107,10 +98,10 @@ function reinstantiateTiles() {
 
 	}
 
-	url = new URL( `${apiOrigin}/v1/3dtiles/root.json?key=${ params.apiKey }` );
+	const url = new URL( `${apiOrigin}/v1/3dtiles/root.json?key=${ params.apiKey }` );
 
 	fetch( url, { mode: 'cors' } )
-		.then( ( res ) => {
+		.then( res => {
 
 			if ( res.ok ) {
 
@@ -118,12 +109,12 @@ function reinstantiateTiles() {
 
 			} else {
 
-				return Promise.reject( `${res.status} : ${res.statusText}` );
+				return Promise.reject( new Error( `${res.status} : ${res.statusText}` ) );
 
 			}
 
 		} )
-		.then( ( json ) => {
+		.then( json => {
 
 			if ( !json.root ) {
 				throw new Error( `malformed response: ${ json }` );

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -324,7 +324,6 @@ function animate() {
 	tiles.displayActiveTiles = params.displayActiveTiles;
 	tiles.maxDepth = params.maxDepth;
 	tiles.displayBoxBounds = params.displayBoxBounds;
-	tiles.colorMode = parseFloat( params.colorMode );
 
 	// TODO: required every raf?
 	tiles.setResolutionFromRenderer( camera, renderer );

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -142,7 +142,6 @@ function reinstantiateTiles() {
 			console.log('session', session);
 
 			tiles = new TilesRenderer( url.toString() );
-
 			tiles.preprocessURL = uri => {
 
 				uri = new URL( uri );
@@ -156,42 +155,9 @@ function reinstantiateTiles() {
 
 			};
 
-			tiles.onLoadTileSet = () => {
-
-				const box = new Box3();
-				const sphere = new Sphere();
-				const matrix = new Matrix4();
-
-				let position;
-				let distanceToEllipsoidCenter;
-
-				if ( tiles.getOrientedBounds( box, matrix ) ) {
-
-					position = new Vector3().setFromMatrixPosition( matrix );
-					distanceToEllipsoidCenter = position.length();
-
-				} else if ( tiles.getBoundingSphere( sphere ) ) {
-
-					position = sphere.center.clone();
-					distanceToEllipsoidCenter = position.length();
-
-				}
-
-				const surfaceDirection = position.normalize();
-				const up = new Vector3( 0, 1, 0 );
-				const rotationToNorthPole = rotationBetweenDirections( surfaceDirection, up );
-
-				tiles.group.quaternion.x = rotationToNorthPole.x;
-				tiles.group.quaternion.y = rotationToNorthPole.y;
-				tiles.group.quaternion.z = rotationToNorthPole.z;
-				tiles.group.quaternion.w = rotationToNorthPole.w;
-
-				tiles.group.position.y = - distanceToEllipsoidCenter;
-
-			};
-
 			tiles.lruCache.minSize = 3000;
 			tiles.lruCache.maxSize = 5000;
+			tiles.group.rotation.x = - Math.PI / 2;
 
 			setupTiles();
 
@@ -216,7 +182,7 @@ function init() {
 
 	document.body.appendChild( renderer.domElement );
 
-	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 160000000 );
+	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1000, 16000000 );
 	camera.position.set( 7326000, 10279000, -823000 );
 	cameraHelper = new CameraHelper( camera );
 	scene.add( cameraHelper );

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -10,9 +10,6 @@ import {
 	Quaternion,
 	Group,
 	sRGBEncoding,
-	Matrix4,
-	Box3,
-	Sphere,
 } from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -252,7 +252,7 @@ function init() {
 	document.body.appendChild( renderer.domElement );
 	renderer.domElement.tabIndex = 1;
 
-	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 16000000 );
+	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 1600000 );
 	camera.position.set( 7326000, 10279000, -823000 );
 	cameraHelper = new CameraHelper( camera );
 	scene.add( cameraHelper );
@@ -280,31 +280,10 @@ function init() {
 	offsetParent = new Group();
 	scene.add( offsetParent );
 
-	// Raycasting init
-	raycaster = new Raycaster();
-	mouse = new Vector2();
-
-	rayIntersect = new Group();
-
-	const rayIntersectMat = new MeshBasicMaterial( { color: 0xe91e63 } );
-	const rayMesh = new Mesh( new CylinderBufferGeometry( 0.25, 0.25, 6 ), rayIntersectMat );
-	rayMesh.rotation.x = Math.PI / 2;
-	rayMesh.position.z += 3;
-	rayIntersect.add( rayMesh );
-
-	const rayRing = new Mesh( new TorusBufferGeometry( 1.5, 0.2, 16, 100 ), rayIntersectMat );
-	rayIntersect.add( rayRing );
-	scene.add( rayIntersect );
-	rayIntersect.visible = false;
-
 	reinstantiateTiles();
 
 	onWindowResize();
 	window.addEventListener( 'resize', onWindowResize, false );
-	renderer.domElement.addEventListener( 'mousemove', onMouseMove, false );
-	renderer.domElement.addEventListener( 'mousedown', onMouseDown, false );
-	renderer.domElement.addEventListener( 'mouseup', onMouseUp, false );
-	renderer.domElement.addEventListener( 'mouseleave', onMouseLeave, false );
 
 	// GUI
 	const gui = new GUI();
@@ -354,7 +333,6 @@ function init() {
 		}
 
 	} );
-	exampleOptions.add( params, 'raycast', { NONE, ALL_HITS, FIRST_HIT_ONLY } );
 	exampleOptions.add( params, 'enableCacheDisplay' );
 	exampleOptions.add( params, 'enableRendererStats' );
 
@@ -380,78 +358,6 @@ function onWindowResize() {
 
 }
 
-function onMouseLeave( e ) {
-
-	lastHoveredElement = null;
-
-}
-
-function onMouseMove( e ) {
-
-	const bounds = this.getBoundingClientRect();
-	mouse.x = e.clientX - bounds.x;
-	mouse.y = e.clientY - bounds.y;
-	mouse.x = ( mouse.x / bounds.width ) * 2 - 1;
-	mouse.y = - ( mouse.y / bounds.height ) * 2 + 1;
-
-	lastHoveredElement = this;
-
-}
-
-const startPos = new Vector2();
-const endPos = new Vector2();
-function onMouseDown( e ) {
-
-	const bounds = this.getBoundingClientRect();
-	startPos.set( e.clientX - bounds.x, e.clientY - bounds.y );
-
-}
-
-function onMouseUp( e ) {
-
-	const bounds = this.getBoundingClientRect();
-	endPos.set( e.clientX - bounds.x, e.clientY - bounds.y );
-	if ( startPos.distanceTo( endPos ) > 2 ) {
-
-		return;
-
-	}
-
-	raycaster.setFromCamera( mouse, camera );
-
-	raycaster.firstHitOnly = true;
-	const results = raycaster.intersectObject( tiles.group, true );
-	if ( results.length ) {
-
-		const object = results[ 0 ].object;
-		const info = tiles.getTileInformationFromActiveObject( object );
-
-		let str = '';
-		for ( const key in info ) {
-
-			let val = info[ key ];
-			if ( typeof val === 'number' ) {
-
-				val = Math.floor( val * 1e5 ) / 1e5;
-
-			}
-
-			let name = key;
-			while ( name.length < 20 ) {
-
-				name += ' ';
-
-			}
-
-			str += `${ name } : ${ val }\n`;
-
-		}
-		console.log( str );
-
-	}
-
-}
-
 function animate() {
 
 	requestAnimationFrame( animate );
@@ -460,7 +366,7 @@ function animate() {
 
 	// update options
 	tiles.errorTarget = params.errorTarget;
-	tiles.errorThreshold = params.errorThreshold;
+	// tiles.errorThreshold = params.errorThreshold;
 	tiles.loadSiblings = params.loadSiblings;
 	tiles.stopAtEmptyTiles = params.stopAtEmptyTiles;
 	tiles.displayActiveTiles = params.displayActiveTiles;

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -32,7 +32,6 @@ const params = {
 
 	'apiKey': 'put-your-google-api-key-here',
 	'errorTarget': 6,
-	'maxDepth': 15,
 	'loadSiblings': true,
 	'stopAtEmptyTiles': true,
 	'resolutionScale': 1.0,
@@ -218,9 +217,7 @@ function init() {
 	const tileOptions = gui.addFolder( 'Tiles Options' );
 	tileOptions.add( params, 'loadSiblings' );
 	tileOptions.add( params, 'stopAtEmptyTiles' );
-	tileOptions.add( params, 'displayActiveTiles' );
 	tileOptions.add( params, 'errorTarget' ).min( 0 ).max( 50 );
-	tileOptions.add( params, 'maxDepth' ).min( 1 ).max( 100 );
 
 	const debug = gui.addFolder( 'Debug Options' );
 	debug.add( params, 'displayBoxBounds' );
@@ -275,7 +272,6 @@ function animate() {
 	tiles.loadSiblings = params.loadSiblings;
 	tiles.stopAtEmptyTiles = params.stopAtEmptyTiles;
 	tiles.displayActiveTiles = params.displayActiveTiles;
-	tiles.maxDepth = params.maxDepth;
 	tiles.displayBoxBounds = params.displayBoxBounds;
 
 	// TODO: required every raf?

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -1,0 +1,605 @@
+import {
+	DebugTilesRenderer as TilesRenderer,
+	NONE,
+	SCREEN_ERROR,
+	GEOMETRIC_ERROR,
+	DISTANCE,
+	DEPTH,
+	RELATIVE_DEPTH,
+	IS_LEAF,
+	RANDOM_COLOR,
+} from '../src/index.js';
+import {
+	Scene,
+	DirectionalLight,
+	AmbientLight,
+	WebGLRenderer,
+	PerspectiveCamera,
+	CameraHelper,
+	Raycaster,
+	Vector2,
+	Vector3,
+	Quaternion,
+	Mesh,
+	CylinderBufferGeometry,
+	MeshBasicMaterial,
+	Group,
+	TorusBufferGeometry,
+	sRGBEncoding,
+	Matrix4,
+	Box3,
+	Sphere,
+	SphereGeometry,
+} from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import Stats from 'three/examples/jsm/libs/stats.module.js';
+
+const ALL_HITS = 1;
+const FIRST_HIT_ONLY = 2;
+
+const apiOrigin = 'https://tile.googleapis.com';
+
+const hashUrl = window.location.hash.replace( /^#/, '' );
+let camera, controls, scene, renderer, tiles, cameraHelper;
+let raycaster, mouse, rayIntersect, lastHoveredElement;
+let offsetParent;
+let statsContainer, stats;
+
+const params = {
+
+	'enableUpdate': true,
+	'raycast': NONE,
+	'enableCacheDisplay': false,
+	'enableRendererStats': false,
+
+	'apiKey': 'put-your-google-api-key-here',
+	'errorTarget': 6,
+	'errorThreshold': 60,
+	'maxDepth': 15,
+	'loadSiblings': true,
+	'stopAtEmptyTiles': true,
+	'displayActiveTiles': false,
+	'resolutionScale': 1.0,
+
+	'up': '+Y',
+	'displayBoxBounds': false,
+	'colorMode': 0,
+	'reload': reinstantiateTiles,
+
+};
+
+init();
+animate();
+
+function rotationBetweenDirections( dir1, dir2 ) {
+
+	const rotation = new Quaternion();
+	const a = new Vector3().crossVectors( dir1, dir2 );
+	rotation.x = a.x;
+	rotation.y = a.y;
+	rotation.z = a.z;
+	rotation.w = 1 + dir1.clone().dot( dir2 );
+	rotation.normalize();
+
+	return rotation;
+
+}
+
+function setupTiles() {
+
+	tiles.fetchOptions.mode = 'cors';
+
+	// Note the DRACO compression files need to be supplied via an explicit source.
+	// We use unpkg here but in practice should be provided by the application.
+	const dracoLoader = new DRACOLoader();
+	dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.123.0/examples/js/libs/draco/gltf/' );
+
+	const loader = new GLTFLoader( tiles.manager );
+	loader.setDRACOLoader( dracoLoader );
+
+	tiles.manager.addHandler( /\.gltf$/, loader );
+	offsetParent.add( tiles.group );
+
+	tiles.setResolutionFromRenderer( camera, renderer );
+	tiles.setCamera( camera );
+
+}
+
+function isInt( input ) {
+
+	return ( typeof input === 'string' ) ? ! isNaN( input ) && ! isNaN( parseFloat( input ) ) && Number.isInteger( parseFloat( input ) ) : Number.isInteger( input );
+
+}
+
+function reinstantiateTiles() {
+
+	let url = hashUrl || '../data/tileset.json';
+
+	if ( hashUrl ) {
+
+		params.ionAssetId = isInt( hashUrl ) ? hashUrl : '';
+
+	}
+
+	if ( tiles ) {
+
+		offsetParent.remove( tiles.group );
+		tiles.dispose();
+		tiles = null;
+
+	}
+
+	url = new URL( `${apiOrigin}/v1/3dtiles/root.json?key=${ params.apiKey }` );
+
+	fetch( url, { mode: 'cors' } )
+		.then( ( res ) => {
+
+			if ( res.ok ) {
+
+				return res.json();
+
+			} else {
+
+				return Promise.reject( `${res.status} : ${res.statusText}` );
+
+			}
+
+		} )
+		.then( ( json ) => {
+
+			if ( !json.root ) {
+				throw new Error( `malformed response: ${ json }` );
+			}
+
+			// TODO: check this is correct
+			// find first node with uri and treat that as root
+			let uri = undefined;
+			const toVisit = [];
+			for ( let curr = json.root; curr !== undefined; curr = toVisit.pop() ) {
+				if ( curr.content?.uri ) {
+					uri = new URL( `${ apiOrigin }${ curr.content.uri }` );
+					uri.searchParams.append( 'key', params.apiKey );
+					break;
+				}
+
+				toVisit.push( ...curr.children );
+			}
+
+			if ( !uri ) {
+				throw new Error( `can't find session string in response: ${ json }` );
+			}
+
+			const session = uri.searchParams.get( 'session' );
+			console.log('session', session);
+
+			tiles = new TilesRenderer( url.toString() );
+
+			tiles.preprocessURL = uri => {
+
+				uri = new URL( uri );
+				if ( /^http/.test( uri.protocol ) ) {
+
+					uri.searchParams.append( 'session', session );
+					uri.searchParams.append( 'key', params.apiKey );
+
+				}
+				return uri.toString();
+
+			};
+
+			tiles.onLoadTileSet = () => {
+
+				const box = new Box3();
+				const sphere = new Sphere();
+				const matrix = new Matrix4();
+
+				let position;
+				let distanceToEllipsoidCenter;
+
+				if ( tiles.getOrientedBounds( box, matrix ) ) {
+
+					position = new Vector3().setFromMatrixPosition( matrix );
+					distanceToEllipsoidCenter = position.length();
+
+				} else if ( tiles.getBoundingSphere( sphere ) ) {
+
+					position = sphere.center.clone();
+					distanceToEllipsoidCenter = position.length();
+
+				}
+
+				const surfaceDirection = position.normalize();
+				const up = new Vector3( 0, 1, 0 );
+				const rotationToNorthPole = rotationBetweenDirections( surfaceDirection, up );
+
+				tiles.group.quaternion.x = rotationToNorthPole.x;
+				tiles.group.quaternion.y = rotationToNorthPole.y;
+				tiles.group.quaternion.z = rotationToNorthPole.z;
+				tiles.group.quaternion.w = rotationToNorthPole.w;
+
+				tiles.group.position.y = - distanceToEllipsoidCenter;
+
+			};
+
+			tiles.lruCache.minSize = 3000;
+			tiles.lruCache.maxSize = 5000;
+
+			setupTiles();
+
+			} )
+			.catch( err => {
+
+				console.error( 'Unable to get gmaps tileset:', err );
+
+			} );
+
+}
+
+function init() {
+	scene = new Scene();
+
+	// primary camera view
+	renderer = new WebGLRenderer( { antialias: true } );
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.setClearColor( 0x151c1f );
+	renderer.outputEncoding = sRGBEncoding;
+
+	document.body.appendChild( renderer.domElement );
+	renderer.domElement.tabIndex = 1;
+
+	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 16000000 );
+	camera.position.set( 7326000, 10279000, -823000 );
+	cameraHelper = new CameraHelper( camera );
+	scene.add( cameraHelper );
+
+	const geom = new SphereGeometry(1, 32, 8);
+	const mat = new MeshBasicMaterial( { color: 0xff0000 } );
+	const mesh = new Mesh(geom, mat);
+	mesh.position.x = 4;
+	scene.add(mesh);
+
+	// controls
+	controls = new OrbitControls( camera, renderer.domElement );
+	controls.enablePan = false;
+	controls.minDistance = 6500000;
+	controls.maxDistance = 13315000;
+
+	// lights
+	const dirLight = new DirectionalLight( 0xffffff );
+	dirLight.position.set( 1, 2, 3 );
+	scene.add( dirLight );
+
+	const ambLight = new AmbientLight( 0xffffff, 0.2 );
+	scene.add( ambLight );
+
+	offsetParent = new Group();
+	scene.add( offsetParent );
+
+	// Raycasting init
+	raycaster = new Raycaster();
+	mouse = new Vector2();
+
+	rayIntersect = new Group();
+
+	const rayIntersectMat = new MeshBasicMaterial( { color: 0xe91e63 } );
+	const rayMesh = new Mesh( new CylinderBufferGeometry( 0.25, 0.25, 6 ), rayIntersectMat );
+	rayMesh.rotation.x = Math.PI / 2;
+	rayMesh.position.z += 3;
+	rayIntersect.add( rayMesh );
+
+	const rayRing = new Mesh( new TorusBufferGeometry( 1.5, 0.2, 16, 100 ), rayIntersectMat );
+	rayIntersect.add( rayRing );
+	scene.add( rayIntersect );
+	rayIntersect.visible = false;
+
+	reinstantiateTiles();
+
+	onWindowResize();
+	window.addEventListener( 'resize', onWindowResize, false );
+	renderer.domElement.addEventListener( 'mousemove', onMouseMove, false );
+	renderer.domElement.addEventListener( 'mousedown', onMouseDown, false );
+	renderer.domElement.addEventListener( 'mouseup', onMouseUp, false );
+	renderer.domElement.addEventListener( 'mouseleave', onMouseLeave, false );
+
+	// GUI
+	const gui = new GUI();
+	gui.width = 300;
+
+	const ionOptions = gui.addFolder( 'gmaps' );
+	ionOptions.add( params, 'apiKey' );
+	ionOptions.add( params, 'reload' );
+	ionOptions.open();
+
+	const tileOptions = gui.addFolder( 'Tiles Options' );
+	tileOptions.add( params, 'loadSiblings' );
+	tileOptions.add( params, 'stopAtEmptyTiles' );
+	tileOptions.add( params, 'displayActiveTiles' );
+	tileOptions.add( params, 'errorTarget' ).min( 0 ).max( 50 );
+	tileOptions.add( params, 'errorThreshold' ).min( 0 ).max( 1000 );
+	tileOptions.add( params, 'maxDepth' ).min( 1 ).max( 100 );
+	tileOptions.add( params, 'up', [ '+Y', '+Z', '-Z' ] );
+
+	const debug = gui.addFolder( 'Debug Options' );
+	debug.add( params, 'displayBoxBounds' );
+	debug.add( params, 'colorMode', {
+
+		NONE,
+		SCREEN_ERROR,
+		GEOMETRIC_ERROR,
+		DISTANCE,
+		DEPTH,
+		RELATIVE_DEPTH,
+		IS_LEAF,
+		RANDOM_COLOR,
+
+	} );
+
+	const exampleOptions = gui.addFolder( 'Example Options' );
+	exampleOptions.add( params, 'resolutionScale' ).min( 0.01 ).max( 2.0 ).step( 0.01 ).onChange( onWindowResize );
+	exampleOptions.add( params, 'enableUpdate' ).onChange( v => {
+
+		tiles.parseQueue.autoUpdate = v;
+		tiles.downloadQueue.autoUpdate = v;
+
+		if ( v ) {
+
+			tiles.parseQueue.scheduleJobRun();
+			tiles.downloadQueue.scheduleJobRun();
+
+		}
+
+	} );
+	exampleOptions.add( params, 'raycast', { NONE, ALL_HITS, FIRST_HIT_ONLY } );
+	exampleOptions.add( params, 'enableCacheDisplay' );
+	exampleOptions.add( params, 'enableRendererStats' );
+
+	gui.open();
+
+	statsContainer = document.createElement( 'div' );
+	document.getElementById( 'info' ).appendChild( statsContainer );
+
+	// Stats
+	stats = new Stats();
+	stats.showPanel( 0 );
+	document.body.appendChild( stats.dom );
+
+}
+
+function onWindowResize() {
+
+	camera.aspect = window.innerWidth / window.innerHeight;
+	renderer.setSize( window.innerWidth, window.innerHeight );
+
+	camera.updateProjectionMatrix();
+	renderer.setPixelRatio( window.devicePixelRatio * params.resolutionScale );
+
+}
+
+function onMouseLeave( e ) {
+
+	lastHoveredElement = null;
+
+}
+
+function onMouseMove( e ) {
+
+	const bounds = this.getBoundingClientRect();
+	mouse.x = e.clientX - bounds.x;
+	mouse.y = e.clientY - bounds.y;
+	mouse.x = ( mouse.x / bounds.width ) * 2 - 1;
+	mouse.y = - ( mouse.y / bounds.height ) * 2 + 1;
+
+	lastHoveredElement = this;
+
+}
+
+const startPos = new Vector2();
+const endPos = new Vector2();
+function onMouseDown( e ) {
+
+	const bounds = this.getBoundingClientRect();
+	startPos.set( e.clientX - bounds.x, e.clientY - bounds.y );
+
+}
+
+function onMouseUp( e ) {
+
+	const bounds = this.getBoundingClientRect();
+	endPos.set( e.clientX - bounds.x, e.clientY - bounds.y );
+	if ( startPos.distanceTo( endPos ) > 2 ) {
+
+		return;
+
+	}
+
+	raycaster.setFromCamera( mouse, camera );
+
+	raycaster.firstHitOnly = true;
+	const results = raycaster.intersectObject( tiles.group, true );
+	if ( results.length ) {
+
+		const object = results[ 0 ].object;
+		const info = tiles.getTileInformationFromActiveObject( object );
+
+		let str = '';
+		for ( const key in info ) {
+
+			let val = info[ key ];
+			if ( typeof val === 'number' ) {
+
+				val = Math.floor( val * 1e5 ) / 1e5;
+
+			}
+
+			let name = key;
+			while ( name.length < 20 ) {
+
+				name += ' ';
+
+			}
+
+			str += `${ name } : ${ val }\n`;
+
+		}
+		console.log( str );
+
+	}
+
+}
+
+function animate() {
+
+	requestAnimationFrame( animate );
+
+	if ( ! tiles ) return;
+
+	// update options
+	tiles.errorTarget = params.errorTarget;
+	tiles.errorThreshold = params.errorThreshold;
+	tiles.loadSiblings = params.loadSiblings;
+	tiles.stopAtEmptyTiles = params.stopAtEmptyTiles;
+	tiles.displayActiveTiles = params.displayActiveTiles;
+	tiles.maxDepth = params.maxDepth;
+	tiles.displayBoxBounds = params.displayBoxBounds;
+	tiles.colorMode = parseFloat( params.colorMode );
+
+	// TODO: required every raf?
+	tiles.setResolutionFromRenderer( camera, renderer );
+	tiles.setCamera( camera );
+
+	offsetParent.rotation.set( 0, 0, 0 );
+	if ( params.up === '-Z' ) {
+
+		offsetParent.rotation.x = Math.PI / 2;
+
+	} else if ( params.up === '+Z' ) {
+
+		offsetParent.rotation.x = - Math.PI / 2;
+
+	}
+
+	offsetParent.updateMatrixWorld( true );
+
+	if ( parseFloat( params.raycast ) !== NONE && lastHoveredElement !== null ) {
+
+		if ( lastHoveredElement === renderer.domElement ) {
+
+			raycaster.setFromCamera( mouse, camera );
+
+		}
+
+		raycaster.firstHitOnly = parseFloat( params.raycast ) === FIRST_HIT_ONLY;
+
+		const results = raycaster.intersectObject( tiles.group, true );
+		if ( results.length ) {
+
+			const closestHit = results[ 0 ];
+			const point = closestHit.point;
+			rayIntersect.position.copy( point );
+
+			// If the display bounds are visible they get intersected
+			if ( closestHit.face ) {
+
+				const normal = closestHit.face.normal;
+				normal.transformDirection( closestHit.object.matrixWorld );
+				rayIntersect.lookAt(
+					point.x + normal.x,
+					point.y + normal.y,
+					point.z + normal.z
+				);
+
+			}
+
+			rayIntersect.visible = true;
+
+		} else {
+
+			rayIntersect.visible = false;
+
+		}
+
+	} else {
+
+		rayIntersect.visible = false;
+
+	}
+
+	// update tiles
+	window.tiles = tiles;
+	if ( params.enableUpdate ) {
+
+		camera.updateMatrixWorld();
+		tiles.update();
+
+	}
+
+	render();
+	stats.update();
+
+}
+
+function render() {
+
+	cameraHelper.visible = false;
+
+	// render primary view
+	const dist = camera.position.distanceTo( rayIntersect.position );
+	rayIntersect.scale.setScalar( dist * camera.fov / 6000 );
+
+	renderer.render( scene, camera );
+
+	const cacheFullness = tiles.lruCache.itemList.length / tiles.lruCache.maxSize;
+	let str = `Downloading: ${ tiles.stats.downloading } Parsing: ${ tiles.stats.parsing } Visible: ${ tiles.group.children.length - 2 }`;
+
+	if ( params.enableCacheDisplay ) {
+
+		const geomSet = new Set();
+		tiles.traverse( tile => {
+
+			const scene = tile.cached.scene;
+			if ( scene ) {
+
+				scene.traverse( c => {
+
+					if ( c.geometry ) {
+
+						geomSet.add( c.geometry );
+
+					}
+
+				} );
+
+			}
+
+		} );
+
+		let count = 0;
+		geomSet.forEach( g => {
+
+			count += BufferGeometryUtils.estimateBytesUsed( g );
+
+		} );
+		str += `<br/>Cache: ${ ( 100 * cacheFullness ).toFixed( 2 ) }% ~${ ( count / 1000 / 1000 ).toFixed( 2 ) }mb`;
+
+	}
+
+	if ( params.enableRendererStats ) {
+
+		const memory = renderer.info.memory;
+		const programCount = renderer.info.programs.length;
+		str += `<br/>Geometries: ${ memory.geometries } Textures: ${ memory.textures } Programs: ${ programCount }`;
+
+	}
+
+	if ( statsContainer.innerHTML !== str ) {
+
+		statsContainer.innerHTML = str;
+
+	}
+
+}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -614,23 +614,24 @@ export class TilesRenderer extends TilesRendererBase {
 		const cached = tile.cached;
 		const cachedTransform = cached.transform;
 
+		const upAdjustment = new Matrix4();
 		switch ( upAxis.toLowerCase() ) {
 
 			case 'x':
-				tempMat.makeRotationAxis( Y_AXIS, - Math.PI / 2 );
+				upAdjustment.makeRotationAxis( Y_AXIS, - Math.PI / 2 );
 				break;
 
 			case 'y':
-				tempMat.makeRotationAxis( X_AXIS, Math.PI / 2 );
+				upAdjustment.makeRotationAxis( X_AXIS, Math.PI / 2 );
 				break;
 
 			case 'z':
-				tempMat.identity();
+				upAdjustment.identity();
 				break;
 
 		}
 
-		const fileType = readMagicBytes( buffer ) || extension;
+		const fileType = ( readMagicBytes( buffer ) || extension ).toLowerCase();
 		switch ( fileType ) {
 
 			case 'b3dm': {
@@ -639,7 +640,7 @@ export class TilesRenderer extends TilesRendererBase {
 				loader.workingPath = workingPath;
 				loader.fetchOptions = fetchOptions;
 
-				loader.adjustmentTransform.copy( tempMat );
+				loader.adjustmentTransform.copy( upAdjustment );
 
 				promise = loader
 					.parse( buffer )
@@ -666,7 +667,7 @@ export class TilesRenderer extends TilesRendererBase {
 				loader.workingPath = workingPath;
 				loader.fetchOptions = fetchOptions;
 
-				loader.adjustmentTransform.copy( tempMat );
+				loader.adjustmentTransform.copy( upAdjustment );
 
 				promise = loader
 					.parse( buffer )
@@ -681,7 +682,7 @@ export class TilesRenderer extends TilesRendererBase {
 				loader.workingPath = workingPath;
 				loader.fetchOptions = fetchOptions;
 
-				loader.adjustmentTransform.copy( tempMat );
+				loader.adjustmentTransform.copy( upAdjustment );
 
 				promise = loader
 					.parse( buffer )
@@ -725,7 +726,7 @@ export class TilesRenderer extends TilesRendererBase {
 			// rotation fix which is why "multiply" happens here.
 			if ( fileType === 'glb' || fileType === 'gltf' ) {
 
-				scene.matrix.multiply( tempMat );
+				scene.matrix.multiply( upAdjustment );
 
 			}
 

--- a/src/three/math/Ellipsoid.js
+++ b/src/three/math/Ellipsoid.js
@@ -106,6 +106,7 @@ export class Ellipsoid {
 		normal.z *= this.radius.z;
 
 		return target;
+
 	}
 
 }

--- a/src/three/math/Ellipsoid.js
+++ b/src/three/math/Ellipsoid.js
@@ -98,4 +98,14 @@ export class Ellipsoid {
 
 	}
 
+	getPositionToSurfacePoint( pos, target ) {
+
+		const normal = this.getPositionToNormal( pos, target );
+		normal.x *= this.radius.x;
+		normal.y *= this.radius.y;
+		normal.z *= this.radius.z;
+
+		return target;
+	}
+
 }


### PR DESCRIPTION
Example added (googleMapsExample.html) rendering the new [google maps tileset](https://cloud.google.com/blog/products/maps-platform/create-immersive-3d-map-experiences-photorealistic-3d-tiles).

To use this, you need to get a google api key and add it to the slot in the UI panel (I worked out how to make a free key from the links in the tiles landing page [here](https://cloud.google.com/blog/products/maps-platform/create-immersive-3d-map-experiences-photorealistic-3d-tiles)).

~This appears to successfully download a limited (which is expected) number of gltf files from the [google maps tile api](https://developers.google.com/maps/documentation/tile/create-renderer), however none of them render and there are no error messages for me to know where to start looking. I added a test sphere mesh to the scene just to make sure the camera etc were working correctly.~