### PR TITLE
fix: use bounding sphere when bounding box not available

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -23,7 +23,6 @@ const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
 const tempMat2 = new Matrix4();
 const tempVector = new Vector3();
-const tempSphere = new Sphere();
 const vecX = new Vector3();
 const vecY = new Vector3();
 const vecZ = new Vector3();
@@ -913,7 +912,6 @@ export class TilesRenderer extends TilesRendererBase {
 		const boundingSphere = cached.sphere;
 		const boundingBox = cached.box;
 		const boxTransformInverse = cached.boxTransformInverse;
-		const transformInverse = cached.transformInverse;
 		const useBox = boundingBox && boxTransformInverse;
 
 		let maxError = - Infinity;
@@ -949,13 +947,10 @@ export class TilesRenderer extends TilesRendererBase {
 
 				} else {
 
-					tempVector.applyMatrix4( transformInverse );
-					tempSphere.copy( boundingSphere );
-					tempSphere.applyMatrix4( transformInverse );
 					// Sphere#distanceToPoint is negative inside the sphere, whereas Box3#distanceToPoint is
 					// zero inside the box. Clipping the distance to a minimum of zero ensures that both
 					// types of bounding volume behave the same way.
-					distance = Math.max( tempSphere.distanceToPoint( tempVector ), 0 );
+					distance = Math.max( boundingSphere.distanceToPoint( tempVector ), 0 );
 
 				}
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -170,6 +170,17 @@ export class TilesRenderer extends TilesRendererBase {
 
 		} else {
 
+			const boundingSphere = cached.sphere;
+
+			if ( boundingSphere ) {
+
+				boundingSphere.getBoundingBox( box );
+				matrix.identity();
+
+				return true;
+
+			}
+
 			return false;
 
 		}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -23,6 +23,7 @@ const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
 const tempMat2 = new Matrix4();
 const tempVector = new Vector3();
+const tempSphere = new Sphere();
 const vecX = new Vector3();
 const vecY = new Vector3();
 const vecZ = new Vector3();
@@ -132,6 +133,16 @@ export class TilesRenderer extends TilesRendererBase {
 			return true;
 
 		} else {
+
+			const boundingSphere = cached.sphere;
+
+			if ( boundingSphere ) {
+
+				boundingSphere.getBoundingBox( box );
+
+				return true;
+
+			}
 
 			return false;
 
@@ -939,10 +950,12 @@ export class TilesRenderer extends TilesRendererBase {
 				} else {
 
 					tempVector.applyMatrix4( transformInverse );
+					tempSphere.copy( boundingSphere );
+					tempSphere.applyMatrix4( transformInverse );
 					// Sphere#distanceToPoint is negative inside the sphere, whereas Box3#distanceToPoint is
 					// zero inside the box. Clipping the distance to a minimum of zero ensures that both
 					// types of bounding volume behave the same way.
-					distance = Math.max( boundingSphere.distanceToPoint( tempVector ), 0 );
+					distance = Math.max( tempSphere.distanceToPoint( tempVector ), 0 );
 
 				}
 

--- a/src/three/raycastTraverse.js
+++ b/src/three/raycastTraverse.js
@@ -70,7 +70,7 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 
 			_sphere.copy( sphere );
 			_sphere.applyMatrix4( _mat );
-			if ( ! raycaster.ray.intersectsSphere( _sphere ) ) {
+			if ( ! raycaster.ray.intersectsSphere( _sphere, _vec ) ) {
 
 				continue;
 
@@ -87,44 +87,46 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 			_mat.multiply( obbMat ).invert();
 			_ray.copy( raycaster.ray );
 			_ray.applyMatrix4( _mat );
-			if ( _ray.intersectBox( boundingBox, _vec ) ) {
-
-				// account for tile scale
-				_vec2.setFromMatrixScale( _mat );
-				const invScale = _vec2.x;
-
-				if ( Math.abs( Math.max( _vec2.x - _vec2.y, _vec2.x - _vec2.z ) ) > 1e-6 ) {
-
-					console.warn( 'ThreeTilesRenderer : Non uniform scale used for tile which may cause issues when raycasting.' );
-
-				}
-
-				// if we intersect the box save the distance to the tile bounds
-				const data = {
-					distance: Infinity,
-					tile: null
-				};
-				array.push( data );
-
-				if ( boundingBox.containsPoint( _ray.origin ) ) {
-
-					data.distance = 0;
-
-				} else {
-
-					data.distance = _vec.distanceToSquared( _ray.origin ) * invScale * invScale;
-
-				}
-
-				data.tile = tile;
-
-			} else {
+			if ( ! _ray.intersectBox( boundingBox, _vec ) ) {
 
 				continue;
 
 			}
 
+		} else {
+
+			_mat.invert();
+
 		}
+
+		// account for tile scale
+		_vec2.setFromMatrixScale( _mat );
+		const invScale = _vec2.x;
+
+		if ( Math.abs( Math.max( _vec2.x - _vec2.y, _vec2.x - _vec2.z ) ) > 1e-6 ) {
+
+			console.warn( 'ThreeTilesRenderer : Non uniform scale used for tile which may cause issues when raycasting.' );
+
+		}
+
+		// if we intersect the tightest available bound save the distance to the tile bounds
+		const data = {
+			distance: Infinity,
+			tile: null
+		};
+		array.push( data );
+
+		if ( ( boundingBox && boundingBox.containsPoint( _ray.origin ) ) || ( ! boundingBox && sphere && sphere.containsPoint( _ray.origin ) ) ) {
+
+			data.distance = 0;
+
+		} else {
+
+			data.distance = _vec.distanceToSquared( _ray.origin ) * invScale * invScale;
+
+		}
+
+		data.tile = tile;
 
 	}
 

--- a/src/three/raycastTraverse.js
+++ b/src/three/raycastTraverse.js
@@ -70,7 +70,7 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 
 			_sphere.copy( sphere );
 			_sphere.applyMatrix4( _mat );
-			if ( ! raycaster.ray.intersectsSphere( _sphere, _vec ) ) {
+			if ( ! raycaster.ray.intersectsSphere( _sphere ) ) {
 
 				continue;
 
@@ -87,46 +87,44 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 			_mat.multiply( obbMat ).invert();
 			_ray.copy( raycaster.ray );
 			_ray.applyMatrix4( _mat );
-			if ( ! _ray.intersectBox( boundingBox, _vec ) ) {
+			if ( _ray.intersectBox( boundingBox, _vec ) ) {
+
+				// account for tile scale
+				_vec2.setFromMatrixScale( _mat );
+				const invScale = _vec2.x;
+
+				if ( Math.abs( Math.max( _vec2.x - _vec2.y, _vec2.x - _vec2.z ) ) > 1e-6 ) {
+
+					console.warn( 'ThreeTilesRenderer : Non uniform scale used for tile which may cause issues when raycasting.' );
+
+				}
+
+				// if we intersect the box save the distance to the tile bounds
+				const data = {
+					distance: Infinity,
+					tile: null
+				};
+				array.push( data );
+
+				if ( boundingBox.containsPoint( _ray.origin ) ) {
+
+					data.distance = 0;
+
+				} else {
+
+					data.distance = _vec.distanceToSquared( _ray.origin ) * invScale * invScale;
+
+				}
+
+				data.tile = tile;
+
+			} else {
 
 				continue;
 
 			}
 
-		} else {
-
-			_mat.invert();
-
 		}
-
-		// account for tile scale
-		_vec2.setFromMatrixScale( _mat );
-		const invScale = _vec2.x;
-
-		if ( Math.abs( Math.max( _vec2.x - _vec2.y, _vec2.x - _vec2.z ) ) > 1e-6 ) {
-
-			console.warn( 'ThreeTilesRenderer : Non uniform scale used for tile which may cause issues when raycasting.' );
-
-		}
-
-		// if we intersect the tightest available bound save the distance to the tile bounds
-		const data = {
-			distance: Infinity,
-			tile: null
-		};
-		array.push( data );
-
-		if ( ( boundingBox && boundingBox.containsPoint( _ray.origin ) ) || ( ! boundingBox && sphere && sphere.containsPoint( _ray.origin ) ) ) {
-
-			data.distance = 0;
-
-		} else {
-
-			data.distance = _vec.distanceToSquared( _ray.origin ) * invScale * invScale;
-
-		}
-
-		data.tile = tile;
 
 	}
 


### PR DESCRIPTION
- getBounds now returns a bounding box from the bounding sphere when a cached bounding box is not available
- calculateError now correctly applies the inverse transform matrix to the bounding sphere before calculating distance