### PR TITLE
fix: if bounding box not available use bounding sphere for raycast hit

### DIFF
--- a/src/three/raycastTraverse.js
+++ b/src/three/raycastTraverse.js
@@ -70,7 +70,7 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 
 			_sphere.copy( sphere );
 			_sphere.applyMatrix4( _mat );
-			if ( ! raycaster.ray.intersectsSphere( _sphere ) ) {
+			if ( ! raycaster.ray.intersectSphere( _sphere, _vec ) ) {
 
 				continue;
 
@@ -87,44 +87,46 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 			_mat.multiply( obbMat ).invert();
 			_ray.copy( raycaster.ray );
 			_ray.applyMatrix4( _mat );
-			if ( _ray.intersectBox( boundingBox, _vec ) ) {
-
-				// account for tile scale
-				_vec2.setFromMatrixScale( _mat );
-				const invScale = _vec2.x;
-
-				if ( Math.abs( Math.max( _vec2.x - _vec2.y, _vec2.x - _vec2.z ) ) > 1e-6 ) {
-
-					console.warn( 'ThreeTilesRenderer : Non uniform scale used for tile which may cause issues when raycasting.' );
-
-				}
-
-				// if we intersect the box save the distance to the tile bounds
-				const data = {
-					distance: Infinity,
-					tile: null
-				};
-				array.push( data );
-
-				if ( boundingBox.containsPoint( _ray.origin ) ) {
-
-					data.distance = 0;
-
-				} else {
-
-					data.distance = _vec.distanceToSquared( _ray.origin ) * invScale * invScale;
-
-				}
-
-				data.tile = tile;
-
-			} else {
+			if ( ! _ray.intersectBox( boundingBox, _vec ) ) {
 
 				continue;
 
 			}
 
+		} else {
+
+			_mat.invert();
+
 		}
+
+		// account for tile scale
+		_vec2.setFromMatrixScale( _mat );
+		const invScale = _vec2.x;
+
+		if ( Math.abs( Math.max( _vec2.x - _vec2.y, _vec2.x - _vec2.z ) ) > 1e-6 ) {
+
+			console.warn( 'ThreeTilesRenderer : Non uniform scale used for tile which may cause issues when raycasting.' );
+
+		}
+
+		// if we intersect the tightest available bound save the distance to the tile bounds
+		const data = {
+			distance: Infinity,
+			tile: null
+		};
+		array.push( data );
+
+		if ( ( boundingBox && boundingBox.containsPoint( _ray.origin ) ) || ( ! boundingBox && sphere && sphere.containsPoint( _ray.origin ) ) ) {
+
+			data.distance = 0;
+
+		} else {
+
+			data.distance = _vec.distanceToSquared( _ray.origin ) * invScale * invScale;
+
+		}
+
+		data.tile = tile;
 
 	}
 

--- a/src/three/raycastTraverse.js
+++ b/src/three/raycastTraverse.js
@@ -61,7 +61,7 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 		const tile = children[ i ];
 		const cached = tile.cached;
 		const groupMatrixWorld = group.matrixWorld;
-		let distance = Infinity;
+		let distance = - Infinity;
 
 		// if we don't hit the sphere then skip
 		const sphere = cached.sphere;
@@ -71,7 +71,7 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 			_sphere.copy( sphere ).applyMatrix4( groupMatrixWorld );
 			if ( raycaster.ray.intersectSphere( _sphere, _vec ) ) {
 
-				distance = Math.min(
+				distance = Math.max(
 					distance,
 					_sphere.containsPoint( raycaster.ray.origin ) ? 0 : raycaster.ray.origin.distanceToSquared( _vec ),
 				);
@@ -105,7 +105,7 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 
 				}
 
-				distance = Math.min(
+				distance = Math.max(
 					distance,
 					boundingBox.containsPoint( raycaster.ray.origin )
 						? 0
@@ -123,7 +123,7 @@ export function raycastTraverseFirstHit( root, group, activeTiles, raycaster ) {
 		// TODO: check region?
 
 		// track the tile and hit distance for sorting
-		if ( distance !== Infinity ) {
+		if ( distance !== - Infinity ) {
 
 			array.push( { distance, tile } );
 


### PR DESCRIPTION
The following code runs as follows:

- Check bounding sphere for raycast hit
  - If raycast miss, continue to next tile
- Check if bounding box exists
  - If bounding box exists, check for raycast hit
    - If raycast miss, continue to next tile
- If we haven't continue to next tile that means either 1) bounding sphere had a raycast hit and bounding box does not exist or 2) bounding box exists and had a hit

Now we can run the normal logic of saving a raycast hit only using the bounding sphere raycast hit if the bounding box does not exist (if bounding box exists we will still use that as primary hit detection).

Previously if a bounding box did not exist we would assume the raycast missed. The logic now states that if a bounding box **does not** exist, the bounding sphere is assumed to be the tightest bounding volume and a valid intersect results in a hit. If the bounding box **does** exist that will still require an intersect in the bounding box for a valid hit, even if the bounding sphere has an intersect.