### PR TITLE
Set script type to module in googleMapsExample.html

### DIFF
--- a/example/googleMapsExample.html
+++ b/example/googleMapsExample.html
@@ -61,6 +61,6 @@
 		</div>
 		<div id="credits">
 		</div>
-        <script src="./googleMapsExample.js"></script>
+        <script type="module" src="./googleMapsExample.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Set script type to module in googleMapsExample.html page
This should fix the `Cannot use import statement outside a module (at googleMapsExample.js:1:1)` at [this url](https://nasa-ammos.github.io/3DTilesRendererJS/example/googleMapsExample.html)