### PR TITLE
Update googleMapsExample.js with default apiKey

### DIFF
--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -26,6 +26,7 @@ const params = {
 	'enableUpdate': true,
 	'enableCacheDisplay': false,
 	'enableRendererStats': false,
+	'apiKey': 'put-your-api-key-here',
 
 
 	'displayBoxBounds': false,


### PR DESCRIPTION
Add default `apiKey` into params with value `put-your-api-key-here`. Otherwise gui.add wont add that parameter to the controls and it cannot be edited.