### PR TITLE
Add OBB frustum check

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -26,6 +26,7 @@ const tempVector = new Vector3();
 const vecX = new Vector3();
 const vecY = new Vector3();
 const vecZ = new Vector3();
+const boxVectors = new Array( 8 ).fill().map( () => new Vector3() );
 
 const X_AXIS = new Vector3( 1, 0, 0 );
 const Y_AXIS = new Vector3( 0, 1, 0 );
@@ -39,6 +40,57 @@ function updateFrustumCulled( object, toInitialValue ) {
 	} );
 
 }
+
+// based on three.js' Box3 "intersects frustum" function
+// TODO: could cache box corners in group frame to improve performance
+function obbIntersectsFrustum( obb, matrix, frustum ) {
+
+	const { min, max } = obb;
+	const { planes } = frustum;
+	let index = 0;
+	for ( let x = - 1; x <= 1; x += 2 ) {
+
+		for ( let y = - 1; y <= 1; y += 2 ) {
+
+			for ( let z = - 1; z <= 1; z += 2 ) {
+
+				boxVectors[ index ].set(
+					x < 0 ? min.x : max.x,
+					y < 0 ? min.y : max.y,
+					z < 0 ? min.z : max.z,
+				).applyMatrix4( matrix );
+				index ++;
+
+			}
+
+		}
+
+	}
+
+	for ( let i = 0; i < 6; i ++ ) {
+
+		const plane = planes[ i ];
+		let maxDistance = - Infinity;
+		for ( let j = 0; j < 6; j ++ ) {
+
+			const v = boxVectors[ j ];
+			const dist = plane.distanceToPoint( v );
+			maxDistance = maxDistance < dist ? dist : maxDistance;
+
+		}
+
+		if ( maxDistance < 0 ) {
+
+			return false;
+
+		}
+
+	}
+
+	return true;
+
+}
+
 
 export class TilesRenderer extends TilesRendererBase {
 
@@ -996,7 +1048,8 @@ export class TilesRenderer extends TilesRendererBase {
 		// Use separating axis theorem for frustum and obb
 
 		const cached = tile.cached;
-		const sphere = cached.sphere;
+		const { sphere, box, boxTransform } = cached;
+
 		const inFrustum = cached.inFrustum;
 		if ( sphere ) {
 
@@ -1007,7 +1060,20 @@ export class TilesRenderer extends TilesRendererBase {
 				// Track which camera frustums this tile is in so we can use it
 				// to ignore the error calculations for cameras that can't see it
 				const frustum = cameraInfo[ i ].frustum;
-				if ( frustum.intersectsSphere( sphere ) ) {
+				let intersected = true;
+				if ( sphere && ! frustum.intersectsSphere( sphere ) ) {
+
+					intersected = false;
+
+				}
+
+				if ( box && ! obbIntersectsFrustum( box, boxTransform, frustum ) ) {
+
+					intersected = false;
+
+				}
+
+				if ( intersected ) {
 
 					inView = true;
 					inFrustum[ i ] = true;

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -1060,7 +1060,7 @@ export class TilesRenderer extends TilesRendererBase {
 				// Track which camera frustums this tile is in so we can use it
 				// to ignore the error calculations for cameras that can't see it
 				const frustum = cameraInfo[ i ].frustum;
-				let intersected = true;
+				let intersected = Boolean( sphere || box );
 				if ( sphere && ! frustum.intersectsSphere( sphere ) ) {
 
 					intersected = false;


### PR DESCRIPTION
Fix #363
Fix #35 

Significant improvements to number of loaded and rendered tiles by checking OBB instead just Sphere bounding volume.

**Stats Around Tokyo Tower**
| | Before | After | % Decrease |
|---|---|---|---|
| Rendered | 259 | 205 | ~20% |
| Loaded | 745 | 537 | ~30% |

<img width="857" alt="image" src="https://github.com/NASA-AMMOS/3DTilesRendererJS/assets/734200/bfe812a0-67df-4505-aab2-2d5bb958e3e6">
