### PR TITLE
Add dither fade example

### DIFF
--- a/example/fadingTiles.html
+++ b/example/fadingTiles.html
@@ -4,7 +4,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 		<meta charset="utf-8"/>
 
-		<title>Dingo Gap Tile Set</title>
+		<title>Dither Fade Tiles</title>
 
 		<style>
             * {

--- a/example/fadingTiles.html
+++ b/example/fadingTiles.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+		<meta charset="utf-8"/>
+
+		<title>Dingo Gap Tile Set</title>
+
+		<style>
+            * {
+                margin: 0;
+                padding: 0;
+            }
+
+            html {
+                overflow: hidden;
+				font-family: Arial, Helvetica, sans-serif;
+				user-select: none;
+            }
+
+			canvas {
+				image-rendering: pixelated;
+				outline: none;
+			}
+
+			#info {
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				text-align: center;
+				padding: 5px;
+				pointer-events: none;
+				line-height: 1.5em;
+			}
+
+			#info, #info a {
+				color: #234;
+			}
+
+			#info a {
+				pointer-events: all;
+			}
+        </style>
+    </head>
+    <body>
+		<div id="info">
+			Demonstration of tiles use a dither fade to change, smoothing out the transition.
+		</div>
+        <script src="./fadingTiles.js"></script>
+    </body>
+</html>

--- a/example/fadingTiles.js
+++ b/example/fadingTiles.js
@@ -8,7 +8,6 @@ import {
 	WebGLRenderer,
 	PerspectiveCamera,
 	Group,
-	FogExp2,
 } from 'three';
 import { FlyOrbitControls } from './FlyOrbitControls.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
@@ -23,6 +22,7 @@ const params = {
 	fadeDuration: 0.25,
 	renderScale: 1,
 	displayActiveTiles: true,
+	fadingTiles: '0 tiles',
 
 };
 
@@ -31,7 +31,6 @@ render();
 
 function init() {
 
-	const fog = new FogExp2( 0xd8cec0, .0075, 250 );
 	scene = new Scene();
 
 	// primary camera view
@@ -85,17 +84,11 @@ function init() {
 	window.addEventListener( 'resize', onWindowResize, false );
 
 	const gui = new GUI();
-	gui.add( params, 'fog' ).onChange( v => {
-
-		scene.fog = v ? fog : null;
-
-	} );
-
 	gui.add( params, 'displayActiveTiles' );
-
 	gui.add( params, 'errorTarget', 0, 100 );
 	gui.add( params, 'fadeDuration', 0, 5 );
 	gui.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
+	gui.add( params, 'fadingTiles' ).listen();
 	gui.open();
 
 }
@@ -130,5 +123,7 @@ function render() {
 	skyTiles.fadeDuration = params.fadeDuration * 1000;
 
 	renderer.render( scene, camera );
+
+	params.fadingTiles = groundTiles._fadeGroup.children.length + ' tiles';
 
 }

--- a/example/fadingTiles.js
+++ b/example/fadingTiles.js
@@ -17,11 +17,10 @@ let groundTiles, skyTiles;
 
 const params = {
 
-	fog: false,
+	useFade: true,
 	errorTarget: 12,
-	fadeDuration: 0.25,
+	fadeDuration: 0.5,
 	renderScale: 1,
-	displayActiveTiles: true,
 	fadingGroundTiles: '0 tiles',
 
 };
@@ -71,12 +70,10 @@ function init() {
 	groundTiles.lruCache.minSize = 900;
 	groundTiles.lruCache.maxSize = 1300;
 	groundTiles.errorTarget = 12;
-	groundTiles.displayActiveTiles = true;
 
 	skyTiles = new FadeTilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_sky/0528_0260184_to_s64o256_sky_tileset.json' );
 	skyTiles.fetchOptions.mode = 'cors';
 	skyTiles.lruCache = groundTiles.lruCache;
-	skyTiles.displayActiveTiles = true;
 
 	tilesParent.add( groundTiles.group, skyTiles.group );
 
@@ -84,14 +81,14 @@ function init() {
 	window.addEventListener( 'resize', onWindowResize, false );
 
 	const gui = new GUI();
-	gui.add( params, 'displayActiveTiles' );
-	gui.add( params, 'errorTarget', 0, 100 );
+	gui.add( params, 'useFade' );
+	gui.add( params, 'errorTarget', 0, 1000 );
 	gui.add( params, 'fadeDuration', 0, 5 );
 	gui.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
 	gui.add( params, 'fadingGroundTiles' ).listen().disable();
 	gui.open();
 
-	gui.children[ 4 ].domElement.style.opacity = 1.0;
+	gui.children[ 3 ].domElement.style.opacity = 1.0;
 
 }
 
@@ -113,16 +110,14 @@ function render() {
 
 	groundTiles.setCamera( camera );
 	groundTiles.setResolutionFromRenderer( camera, renderer );
-	groundTiles.displayActiveTiles = params.displayActiveTiles;
 	groundTiles.update();
 
 	skyTiles.setCamera( camera );
 	skyTiles.setResolutionFromRenderer( camera, renderer );
-	skyTiles.displayActiveTiles = params.displayActiveTiles;
 	skyTiles.update();
 
-	groundTiles.fadeDuration = params.fadeDuration * 1000;
-	skyTiles.fadeDuration = params.fadeDuration * 1000;
+	groundTiles.fadeDuration = params.useFade ? params.fadeDuration * 1000 : 0;
+	skyTiles.fadeDuration = params.useFade ? params.fadeDuration * 1000 : 0;
 
 	renderer.render( scene, camera );
 

--- a/example/fadingTiles.js
+++ b/example/fadingTiles.js
@@ -13,10 +13,11 @@ import { FlyOrbitControls } from './FlyOrbitControls.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 
 let camera, controls, scene, renderer;
-let groundTiles, skyTiles;
+let groundTiles, skyTiles, tilesParent;
 
 const params = {
 
+	reinstantiateTiles,
 	useFade: true,
 	errorTarget: 12,
 	fadeDuration: 0.5,
@@ -61,9 +62,38 @@ function init() {
 	const ambLight = new AmbientLight( 0xffffff, 0.2 );
 	scene.add( ambLight );
 
-	const tilesParent = new Group();
+	tilesParent = new Group();
 	tilesParent.rotation.set( Math.PI / 2, 0, 0 );
 	scene.add( tilesParent );
+
+	reinstantiateTiles();
+
+	onWindowResize();
+	window.addEventListener( 'resize', onWindowResize, false );
+
+	const gui = new GUI();
+	gui.add( params, 'useFade' );
+	gui.add( params, 'errorTarget', 0, 1000 );
+	gui.add( params, 'fadeDuration', 0, 5 );
+	gui.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
+
+	const textController = gui.add( params, 'fadingGroundTiles' ).listen().disable();
+	textController.domElement.style.opacity = 1.0;
+
+	gui.add( params, 'reinstantiateTiles' );
+
+	gui.open();
+
+}
+
+function reinstantiateTiles() {
+
+	if ( groundTiles ) {
+
+		groundTiles.dispose();
+		skyTiles.dispose();
+
+	}
 
 	groundTiles = new FadeTilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize_tileset.json' );
 	groundTiles.fetchOptions.mode = 'cors';
@@ -76,19 +106,6 @@ function init() {
 	skyTiles.lruCache = groundTiles.lruCache;
 
 	tilesParent.add( groundTiles.group, skyTiles.group );
-
-	onWindowResize();
-	window.addEventListener( 'resize', onWindowResize, false );
-
-	const gui = new GUI();
-	gui.add( params, 'useFade' );
-	gui.add( params, 'errorTarget', 0, 1000 );
-	gui.add( params, 'fadeDuration', 0, 5 );
-	gui.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
-	gui.add( params, 'fadingGroundTiles' ).listen().disable();
-	gui.open();
-
-	gui.children[ 3 ].domElement.style.opacity = 1.0;
 
 }
 

--- a/example/fadingTiles.js
+++ b/example/fadingTiles.js
@@ -1,0 +1,134 @@
+import {
+	FadeTilesRenderer,
+} from './src/FadeTilesRenderer.js';
+import {
+	Scene,
+	DirectionalLight,
+	AmbientLight,
+	WebGLRenderer,
+	PerspectiveCamera,
+	Group,
+	FogExp2,
+} from 'three';
+import { FlyOrbitControls } from './FlyOrbitControls.js';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+
+let camera, controls, scene, renderer;
+let groundTiles, skyTiles;
+
+const params = {
+
+	fog: false,
+	errorTarget: 12,
+	fadeDuration: 0.25,
+	renderScale: 1,
+	displayActiveTiles: true,
+
+};
+
+init();
+render();
+
+function init() {
+
+	const fog = new FogExp2( 0xd8cec0, .0075, 250 );
+	scene = new Scene();
+
+	// primary camera view
+	renderer = new WebGLRenderer( { antialias: true } );
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.setClearColor( 0xd8cec0 );
+
+	document.body.appendChild( renderer.domElement );
+	renderer.domElement.tabIndex = 1;
+
+	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 4000 );
+	camera.position.set( 20, 10, 20 );
+
+	// controls
+	controls = new FlyOrbitControls( camera, renderer.domElement );
+	controls.screenSpacePanning = false;
+	controls.minDistance = 1;
+	controls.maxDistance = 2000;
+	controls.maxPolarAngle = Math.PI / 2;
+	controls.baseSpeed = 0.1;
+	controls.fastSpeed = 0.2;
+
+	// lights
+	const dirLight = new DirectionalLight( 0xffffff );
+	dirLight.position.set( 1, 2, 3 );
+	scene.add( dirLight );
+
+	const ambLight = new AmbientLight( 0xffffff, 0.2 );
+	scene.add( ambLight );
+
+	const tilesParent = new Group();
+	tilesParent.rotation.set( Math.PI / 2, 0, 0 );
+	scene.add( tilesParent );
+
+	groundTiles = new FadeTilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize_tileset.json' );
+	groundTiles.fetchOptions.mode = 'cors';
+	groundTiles.lruCache.minSize = 900;
+	groundTiles.lruCache.maxSize = 1300;
+	groundTiles.errorTarget = 12;
+	groundTiles.displayActiveTiles = true;
+
+	skyTiles = new FadeTilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_sky/0528_0260184_to_s64o256_sky_tileset.json' );
+	skyTiles.fetchOptions.mode = 'cors';
+	skyTiles.lruCache = groundTiles.lruCache;
+	skyTiles.displayActiveTiles = true;
+
+	tilesParent.add( groundTiles.group, skyTiles.group );
+
+	onWindowResize();
+	window.addEventListener( 'resize', onWindowResize, false );
+
+	const gui = new GUI();
+	gui.add( params, 'fog' ).onChange( v => {
+
+		scene.fog = v ? fog : null;
+
+	} );
+
+	gui.add( params, 'displayActiveTiles' );
+
+	gui.add( params, 'errorTarget', 0, 100 );
+	gui.add( params, 'fadeDuration', 0, 5 );
+	gui.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
+	gui.open();
+
+}
+
+function onWindowResize() {
+
+	camera.aspect = window.innerWidth / window.innerHeight;
+	camera.updateProjectionMatrix();
+	renderer.setSize( window.innerWidth, window.innerHeight );
+
+}
+
+function render() {
+
+	requestAnimationFrame( render );
+
+	camera.updateMatrixWorld();
+
+	groundTiles.errorTarget = params.errorTarget;
+
+	groundTiles.setCamera( camera );
+	groundTiles.setResolutionFromRenderer( camera, renderer );
+	groundTiles.displayActiveTiles = params.displayActiveTiles;
+	groundTiles.update();
+
+	skyTiles.setCamera( camera );
+	skyTiles.setResolutionFromRenderer( camera, renderer );
+	skyTiles.displayActiveTiles = params.displayActiveTiles;
+	skyTiles.update();
+
+	groundTiles.fadeDuration = params.fadeDuration * 1000;
+	skyTiles.fadeDuration = params.fadeDuration * 1000;
+
+	renderer.render( scene, camera );
+
+}

--- a/example/fadingTiles.js
+++ b/example/fadingTiles.js
@@ -22,7 +22,7 @@ const params = {
 	fadeDuration: 0.25,
 	renderScale: 1,
 	displayActiveTiles: true,
-	fadingTiles: '0 tiles',
+	fadingGroundTiles: '0 tiles',
 
 };
 
@@ -88,7 +88,7 @@ function init() {
 	gui.add( params, 'errorTarget', 0, 100 );
 	gui.add( params, 'fadeDuration', 0, 5 );
 	gui.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
-	gui.add( params, 'fadingTiles' ).listen().disable();
+	gui.add( params, 'fadingGroundTiles' ).listen().disable();
 	gui.open();
 
 	gui.children[ 4 ].domElement.style.opacity = 1.0;
@@ -126,6 +126,6 @@ function render() {
 
 	renderer.render( scene, camera );
 
-	params.fadingTiles = groundTiles._fadeGroup.children.length + ' tiles';
+	params.fadingGroundTiles = groundTiles._fadeGroup.children.length + ' tiles';
 
 }

--- a/example/fadingTiles.js
+++ b/example/fadingTiles.js
@@ -88,8 +88,10 @@ function init() {
 	gui.add( params, 'errorTarget', 0, 100 );
 	gui.add( params, 'fadeDuration', 0, 5 );
 	gui.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
-	gui.add( params, 'fadingTiles' ).listen();
+	gui.add( params, 'fadingTiles' ).listen().disable();
 	gui.open();
+
+	gui.children[ 4 ].domElement.style.opacity = 1.0;
 
 }
 

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -170,6 +170,18 @@ export class FadeManager {
 		if ( ! fadeState.has( object ) ) return;
 
 		fadeState.delete( object );
+		object.traverse( child => {
+
+			const material = child.material;
+			if ( material.defines.FEATURE_FADE !== 0 ) {
+
+				material.defines.FEATURE_FADE = 0;
+				material.needsUpdate = true;
+
+			}
+
+		} );
+
 		this.onFadeFinish( object );
 
 	}
@@ -242,8 +254,8 @@ export class FadeManager {
 
 					if ( defineValue !== material.defines.FEATURE_FADE ) {
 
-						// material.defines.FEATURE_FADE = defineValue;
-						// material.needsUpdate = true;
+						material.defines.FEATURE_FADE = defineValue;
+						material.needsUpdate = true;
 
 					}
 

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -243,11 +243,6 @@ export class FadeManager {
 			state.fadeIn = fadeIn;
 			state.fadeOut = fadeOut;
 
-			// TODO: if we're at a "stable" state - ie reached the target values, then we
-			// should adjust the material define
-			// TODO: properly remove the tiles once the fade out has finished
-			// TODO: don't dispose of tiles until they've been faded out
-
 			// update the material fields
 			const defineValue = Number( fadeOut !== fadeOutTarget || fadeIn !== fadeInTarget );
 			object.traverse( child => {
@@ -270,7 +265,7 @@ export class FadeManager {
 
 			} );
 
-			if ( fadeOut === 1.0 ) {
+			if ( fadeOut === 1.0 || fadeOut > fadeIn ) {
 
 				this.completeFade( object );
 

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -251,7 +251,6 @@ export class FadeManager {
 
 			} );
 
-
 			if ( fadeOut === 1.0 ) {
 
 				this.completeFade( object );

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -76,8 +76,6 @@ export class FadeManager {
 				...params,
 			};
 
-			material.PARAMS = params;
-
 			shader.fragmentShader = shader.fragmentShader
 				.replace( /void main\(/, value => /* glsl */`
 					#if FEATURE_FADE
@@ -265,7 +263,7 @@ export class FadeManager {
 
 			} );
 
-			if ( fadeOut === 1.0 || fadeOut > fadeIn ) {
+			if ( fadeOut === 1.0 || fadeOut >= fadeIn ) {
 
 				this.completeFade( object );
 

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -139,7 +139,7 @@ export class FadeManager {
 		const fadeState = this._fadeState;
 		if ( fadeState.has( object ) ) {
 
-			return;
+			return false;
 
 		}
 
@@ -165,6 +165,8 @@ export class FadeManager {
 			}
 
 		} );
+
+		return true;
 
 	}
 
@@ -203,10 +205,15 @@ export class FadeManager {
 
 	fadeOut( object ) {
 
-		this.guaranteeState( object );
-
+		const noState = this.guaranteeState( object );
 		const state = this._fadeState.get( object );
 		state.fadeOutTarget = 1;
+		if ( noState ) {
+
+			state.fadeInTarget = 1;
+			state.fadeIn = 1;
+
+		}
 
 	}
 

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -1,0 +1,265 @@
+import { MathUtils } from 'three';
+
+const { clamp } = MathUtils;
+export class FadeManager {
+
+	constructor() {
+
+		this.duration = 250;
+		this._lastTick = - 1;
+		this._fadeState = new Map();
+		this._fadeParams = new WeakMap();
+		this.onFadeFinish = () => {};
+
+	}
+
+	// initialize materials in the object
+	prepareObject( object ) {
+
+		object.traverse( child => {
+
+			if ( child.material ) {
+
+				this.prepareMaterial( child.material );
+
+			}
+
+		} );
+
+	}
+
+	deleteObject( object ) {
+
+		this._fadeParams.delete( object );
+		object.traverse( child => {
+
+			const material = child.material;
+			if ( material ) {
+
+				this._fadeParams.delete( material );
+
+			}
+
+		} );
+
+	}
+
+	// initialize the material
+	prepareMaterial( material ) {
+
+		const fadeParams = this._fadeParams;
+		if ( fadeParams.has( material ) ) {
+
+			return;
+
+		}
+
+		const params = {
+			fadeIn: { value: 0 },
+			fadeOut: { value: 0 },
+		};
+
+		material.defines = {
+			FEATURE_FADE: 1,
+		};
+
+		material.onBeforeCompile = shader => {
+
+			shader.uniforms = {
+				...shader.uniforms,
+				...params,
+			};
+
+			material.PARAMS = params;
+
+			shader.fragmentShader = shader.fragmentShader
+				.replace( /void main\(/, value => /* glsl */`
+					#if FEATURE_FADE
+
+					// adapted from https://www.shadertoy.com/view/Mlt3z8
+					float bayerDither2x2( vec2 v ) {
+
+						return mod( 3.0 * v.y + 2.0 * v.x, 4.0 );
+
+					}
+
+					float bayerDither4x4( vec2 v ) {
+
+						vec2 P1 = mod( v, 2.0 );
+						vec2 P2 = floor( 0.5 * mod( v, 4.0 ) );
+						return 4.0 * bayerDither2x2( P1 ) + bayerDither2x2( P2 );
+
+					}
+
+					uniform float fadeIn;
+					uniform float fadeOut;
+					#endif
+
+					${ value }
+				` )
+				.replace( /#include <dithering_fragment>/, value => /* glsl */`
+
+					${ value }
+
+					#if FEATURE_FADE
+
+					float bayerValue = bayerDither4x4( floor( mod( gl_FragCoord.xy, 4.0 ) ) );
+					float bayerBins = 16.0;
+					float dither = ( 0.5 + bayerValue ) / bayerBins;
+					if ( dither >= fadeIn ) {
+
+						discard;
+
+					}
+
+					if ( dither < fadeOut ) {
+
+						discard;
+
+					}
+
+					#endif
+
+
+				` );
+
+
+		};
+
+		fadeParams.set( material, params );
+
+	}
+
+	guaranteeState( object ) {
+
+		const fadeState = this._fadeState;
+		if ( fadeState.has( object ) ) {
+
+			return;
+
+		}
+
+		const state = {
+			fadeInTarget: 0,
+			fadeOutTarget: 0,
+			fadeIn: 0,
+			fadeOut: 0,
+		};
+
+		fadeState.set( object, state );
+
+		const fadeParams = this._fadeParams;
+		object.traverse( child => {
+
+			const material = child.material;
+			if ( material && fadeParams.has( material ) ) {
+
+				const params = fadeParams.get( material );
+				params.fadeIn.value = 0;
+				params.fadeOut.value = 0;
+
+			}
+
+		} );
+
+	}
+
+	completeFade( object ) {
+
+		const fadeState = this._fadeState;
+		if ( ! fadeState.has( object ) ) return;
+
+		fadeState.delete( object );
+		this.onFadeFinish( object );
+
+	}
+
+	fadeIn( object ) {
+
+		this.guaranteeState( object );
+
+		const state = this._fadeState.get( object );
+		state.fadeInTarget = 1;
+		state.fadeOutTarget = 0;
+		state.fadeOut = 0;
+
+	}
+
+	fadeOut( object ) {
+
+		this.guaranteeState( object );
+
+		const state = this._fadeState.get( object );
+		state.fadeOutTarget = 1;
+
+	}
+
+	update() {
+
+		const time = window.performance.now();
+		const delta = ( time - this._lastTick ) / this.duration;
+		this._lastTick = time;
+
+		const fadeState = this._fadeState;
+		const fadeParams = this._fadeParams;
+		fadeState.forEach( ( state, object ) => {
+
+			// tick the fade values
+			const {
+				fadeOutTarget,
+				fadeInTarget,
+			} = state;
+
+			let {
+				fadeOut,
+				fadeIn,
+			} = state;
+
+			const fadeInSign = Math.sign( fadeInTarget - fadeIn );
+			fadeIn = clamp( fadeIn + fadeInSign * delta, 0, 1 );
+
+			const fadeOutSign = Math.sign( fadeOutTarget - fadeOut );
+			fadeOut = clamp( fadeOut + fadeOutSign * delta, 0, 1 );
+
+			state.fadeIn = fadeIn;
+			state.fadeOut = fadeOut;
+
+			// TODO: if we're at a "stable" state - ie reached the target values, then we
+			// should adjust the material define
+			// TODO: properly remove the tiles once the fade out has finished
+			// TODO: don't dispose of tiles until they've been faded out
+
+			// update the material fields
+			const defineValue = Number( fadeOut !== fadeOutTarget || fadeIn !== fadeInTarget );
+			object.traverse( child => {
+
+				const material = child.material;
+				if ( material && fadeParams.has( material ) ) {
+
+					const uniforms = fadeParams.get( material );
+					uniforms.fadeIn.value = fadeIn;
+					uniforms.fadeOut.value = fadeOut;
+
+					if ( defineValue !== material.defines.FEATURE_FADE ) {
+
+						// material.defines.FEATURE_FADE = defineValue;
+						// material.needsUpdate = true;
+
+					}
+
+				}
+
+			} );
+
+
+			if ( fadeOut === 1.0 ) {
+
+				this.completeFade( object );
+
+			}
+
+		} );
+
+	}
+
+}

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -30,6 +30,12 @@ export class FadeManager {
 
 	deleteObject( object ) {
 
+		if ( ! object ) {
+
+			return;
+
+		}
+
 		this._fadeParams.delete( object );
 		object.traverse( child => {
 
@@ -60,7 +66,7 @@ export class FadeManager {
 		};
 
 		material.defines = {
-			FEATURE_FADE: 1,
+			FEATURE_FADE: 0,
 		};
 
 		material.onBeforeCompile = shader => {
@@ -173,7 +179,7 @@ export class FadeManager {
 		object.traverse( child => {
 
 			const material = child.material;
-			if ( material.defines.FEATURE_FADE !== 0 ) {
+			if ( material && material.defines.FEATURE_FADE !== 0 ) {
 
 				material.defines.FEATURE_FADE = 0;
 				material.needsUpdate = true;
@@ -208,8 +214,9 @@ export class FadeManager {
 
 	update() {
 
+		// clamp delta in case duration is really small or 0
 		const time = window.performance.now();
-		const delta = ( time - this._lastTick ) / this.duration;
+		const delta = clamp( ( time - this._lastTick ) / this.duration, 0, 1 );
 		this._lastTick = time;
 
 		const fadeState = this._fadeState;

--- a/example/src/FadeTilesRenderer.js
+++ b/example/src/FadeTilesRenderer.js
@@ -4,9 +4,6 @@ import { FadeManager } from './FadeManager.js';
 
 function onTileVisibilityChange( scene, tile, visible ) {
 
-
-
-
 	if ( ! visible ) {
 
 		this._fadeGroup.add( scene );
@@ -68,7 +65,7 @@ function onFadeFinish( object ) {
 
 }
 
-export class FadeTilesRenderer extends TilesRenderer {
+export const FadeTilesRendererMixin = base => class extends base {
 
 	get fadeDuration() {
 
@@ -127,4 +124,6 @@ export class FadeTilesRenderer extends TilesRenderer {
 
 	}
 
-}
+};
+
+export const FadeTilesRenderer = FadeTilesRendererMixin( TilesRenderer );

--- a/example/src/FadeTilesRenderer.js
+++ b/example/src/FadeTilesRenderer.js
@@ -1,0 +1,82 @@
+import { Group } from 'three';
+import { TilesRenderer } from '../..';
+import { FadeManager } from './FadeManager.js';
+
+function onTileVisibilityChange( scene, tile, visible ) {
+
+	// TODO: we should only do this when jumping from parent to child tiles.
+	// do not fade when a tile is made visible from frustum culling
+	if ( ! visible ) {
+
+		this._fadeGroup.add( scene );
+		this._fadeManager.fadeOut( scene );
+
+	} else {
+
+		this._fadeManager.fadeIn( scene );
+
+	}
+
+}
+
+function onLoadModel( scene ) {
+
+	this._fadeManager.prepareObject( scene );
+
+}
+
+function onDisposeModel( scene ) {
+
+	this._fadeManager.deleteObject( scene );
+
+}
+
+export class FadeTilesRenderer extends TilesRenderer {
+
+	get fadeDuration() {
+
+		return this._fadeManager.duration;
+
+	}
+
+	set fadeDuration( value ) {
+
+		this._fadeManager.duration = Number( value );
+
+	}
+
+	constructor( ...args ) {
+
+		super( ...args );
+
+		const fadeGroup = new Group();
+		this.group.add( fadeGroup );
+
+		const fadeManager = new FadeManager();
+		fadeManager.onFadeOutFinish = object => {
+
+			if ( object.parent === fadeGroup ) {
+
+				fadeGroup.remove( object );
+
+			}
+
+		};
+
+		this._fadeManager = fadeManager;
+		this._fadeGroup = fadeGroup;
+
+		this.onLoadModel = onLoadModel.bind( this );
+		this.onDisposeModel = onDisposeModel.bind( this );
+		this.onTileVisibilityChange = onTileVisibilityChange.bind( this );
+
+	}
+
+	update( ...args ) {
+
+		super.update( ...args );
+		this._fadeManager.update();
+
+	}
+
+}

--- a/example/src/FadeTilesRenderer.js
+++ b/example/src/FadeTilesRenderer.js
@@ -4,6 +4,13 @@ import { FadeManager } from './FadeManager.js';
 
 function onTileVisibilityChange( scene, tile, visible ) {
 
+	if ( tile.__wasInFrustum !== tile.__inFrustum ) {
+
+		// TODO: possibly need to cancel fade?
+		return;
+
+	}
+
 	// TODO: we should only do this when jumping from parent to child tiles.
 	// do not fade when a tile is made visible from frustum culling
 	if ( ! visible ) {
@@ -53,7 +60,7 @@ export class FadeTilesRenderer extends TilesRenderer {
 		this.group.add( fadeGroup );
 
 		const fadeManager = new FadeManager();
-		fadeManager.onFadeOutFinish = object => {
+		fadeManager.onFadeFinish = object => {
 
 			if ( object.parent === fadeGroup ) {
 

--- a/example/src/FadeTilesRenderer.js
+++ b/example/src/FadeTilesRenderer.js
@@ -6,13 +6,6 @@ function onTileVisibilityChange( scene, tile, visible ) {
 
 	scene.visible = true;
 
-	if ( this.isMovingFast ) {
-
-		this._fadeManager.completeFade( scene );
-		return;
-
-	}
-
 	if ( ! visible ) {
 
 		this._fadeGroup.add( scene );
@@ -21,6 +14,12 @@ function onTileVisibilityChange( scene, tile, visible ) {
 	} else {
 
 		this._fadeManager.fadeIn( scene );
+
+	}
+
+	if ( this.isMovingFast ) {
+
+		this._fadeManager.completeFade( scene );
 
 	}
 

--- a/example/src/FadeTilesRenderer.js
+++ b/example/src/FadeTilesRenderer.js
@@ -4,6 +4,8 @@ import { FadeManager } from './FadeManager.js';
 
 function onTileVisibilityChange( scene, tile, visible ) {
 
+	scene.visible = true;
+
 	if ( ! visible ) {
 
 		this._fadeGroup.add( scene );
@@ -103,6 +105,19 @@ export const FadeTilesRendererMixin = base => class extends base {
 
 		super.update( ...args );
 		this._fadeManager.update();
+		this.displayActiveTiles = displayActiveTiles;
+
+		if ( ! displayActiveTiles ) {
+
+			// update the visibility of tiles based on visibility since we must use
+			// the active tiles for rendering fade
+			this.visibleTiles.forEach( t => {
+
+				t.cached.scene.visible = t.__inFrustum;
+
+			} );
+
+		}
 
 	}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -429,6 +429,7 @@ export function toggleTiles( tile, renderer ) {
 		tile.__wasSetActive = setActive;
 		tile.__wasSetVisible = setVisible;
 		tile.__usedLastFrame = isUsed;
+		tile.__wasInFrustum = tile.__inFrustum;
 
 		const children = tile.children;
 		for ( let i = 0, l = children.length; i < l; i ++ ) {

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -429,7 +429,6 @@ export function toggleTiles( tile, renderer ) {
 		tile.__wasSetActive = setActive;
 		tile.__wasSetVisible = setVisible;
 		tile.__usedLastFrame = isUsed;
-		tile.__wasInFrustum = tile.__inFrustum;
 
 		const children = tile.children;
 		for ( let i = 0, l = children.length; i < l; i ++ ) {


### PR DESCRIPTION
Related to #297 

**TODO**
- ~Don't fade in if tile is shown due to frustum culling change~
  - Handled by hiding tiles that are not visible
- Is there a way to fade only on first load?
  - need to know when children have been removed and the traversal is awaiting a new load
- Detect high-speed cameras and don't fade in with high camera movement
- Consider searching for the fading in / out parent tiles and removing those in between / jumping the animation state
- Add potential cap of fade