### PR TITLE
Added onLoadStart & onLoadComplete callbacks

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -68,6 +68,7 @@ export class TilesRenderer extends TilesRendererBase {
 		this.visibleTiles = new Set();
 		this._autoDisableRendererCulling = true;
 		this.optimizeRaycast = true;
+		this.loading = false;
 
 		this.onLoadTileSet = null;
 		this.onLoadModel = null;
@@ -674,6 +675,29 @@ export class TilesRenderer extends TilesRendererBase {
 			cached.textures = textures;
 			cached.scene = scene;
 			cached.metadata = metadata;
+
+			if ( ! this.loading ) {
+
+				if ( this.onLoadStart ) {
+
+					this.onLoadStart( );
+
+				}
+				this.loading = true;
+
+			}
+
+			if ( this.parseQueue.items.length === 0 && this.downloadQueue.items.length === this.parseQueue.items.length ) {
+
+				if ( this.onLoadComplete ) {
+
+					this.onLoadComplete( );
+					this.loading = false;
+
+				}
+
+			}
+
 
 			if ( this.onLoadModel ) {
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -676,7 +676,7 @@ export class TilesRenderer extends TilesRendererBase {
 			cached.scene = scene;
 			cached.metadata = metadata;
 
-			if ( ! this.loading ) {
+			if ( ! this.loading && this.parseQueue.items.length > 0 ) {
 
 				if ( this.onLoadStart ) {
 
@@ -687,7 +687,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 			}
 
-			if ( this.parseQueue.items.length === 0 && this.downloadQueue.items.length === this.parseQueue.items.length ) {
+			if ( this.loading && this.parseQueue.items.length === 0 && this.downloadQueue.items.length === this.parseQueue.items.length ) {
 
 				if ( this.onLoadComplete ) {
 


### PR DESCRIPTION
This pr adds the callback `onLoadStart` & `onLoadComplete` for all loading starts and ends.
#389 

How to test:
I used mars.js example for the test and assigned `onLoadStart` & `onLoadComplete` callbacks to the tiles.