### PR TITLE
call updateMatrixWorld after performing setLatLonToYUp

### DIFF
--- a/src/three/renderers/GoogleTilesRenderer.js
+++ b/src/three/renderers/GoogleTilesRenderer.js
@@ -108,6 +108,8 @@ const GoogleTilesRendererMixin = base => class extends base {
 				group.scale,
 			);
 
+		group.updateMatrixWorld(true);
+
 	}
 
 };

--- a/src/three/renderers/GoogleTilesRenderer.js
+++ b/src/three/renderers/GoogleTilesRenderer.js
@@ -108,7 +108,7 @@ const GoogleTilesRendererMixin = base => class extends base {
 				group.scale,
 			);
 
-		group.updateMatrixWorld(true);
+		group.updateMatrixWorld( true );
 
 	}
 


### PR DESCRIPTION
In case other components rely on the matrixWorld of the group they might only get the correct value after the next rendered frame. This might cause short "blips" with one frame being out of place, offset by the distance between the previous and current (lat,lon).