### PR TITLE
Threejs version updated to 0.154.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "jest-cli": "^27.1.1",
         "parcel-bundler": "^1.12.5",
         "static-server": "^2.2.1",
-        "three": "^0.153.0",
+        "three": "^0.154.0",
         "typescript": "^5.1.3"
       },
       "peerDependencies": {
@@ -17179,9 +17179,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==",
+      "version": "0.154.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.154.0.tgz",
+      "integrity": "sha512-Uzz8C/5GesJzv8i+Y2prEMYUwodwZySPcNhuJUdsVMH2Yn4Nm8qlbQe6qRN5fOhg55XB0WiLfTPBxVHxpE60ug==",
       "dev": true
     },
     "node_modules/throat": {
@@ -31946,9 +31946,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.153.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.153.0.tgz",
-      "integrity": "sha512-OCP2/uQR6GcDpSLnJt/3a4mdS0kNWcbfUXIwLoEMgLzEUIVIYsSDwskpmOii/AkDM+BBwrl6+CKgrjX9+E2aWg==",
+      "version": "0.154.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.154.0.tgz",
+      "integrity": "sha512-Uzz8C/5GesJzv8i+Y2prEMYUwodwZySPcNhuJUdsVMH2Yn4Nm8qlbQe6qRN5fOhg55XB0WiLfTPBxVHxpE60ug==",
       "dev": true
     },
     "throat": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jest-cli": "^27.1.1",
     "parcel-bundler": "^1.12.5",
     "static-server": "^2.2.1",
-    "three": "^0.153.0",
+    "three": "^0.154.0",
     "typescript": "^5.1.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
This pr updates the threejs version from 0.153.0 to 0.154.0 and fixes the issue in vr.html example where on clicking Enter VR it shows a white screen.

Fixes: #459

**How to test:** 
- First run `npm install` to update dependencies.
- Then run `npm  start` 
- Then go to `example/dev-bundle/vr.html` to test it.