### PR TITLE
Fix CesiumIon shadeless MeshStandardMaterial and readme typo preprocessURL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ fetch( url, { mode: 'cors' } )
 
 		// Prefilter each model fetch by setting the cesium Ion version to the search
 		// parameters of the url.
-		tiles.onPreprocessURL = uri => {
+		tiles.preprocessURL = uri => {
 
 			uri = new URL( uri );
 			uri.searchParams.append( 'v', version );
-			return uri;
+			return uri.toString();
 
 		};
 
@@ -368,10 +368,10 @@ If true then the `raycast` functions of the loaded tile objects are overriden to
 
 If you would like to manage raycasting against tiles yourself this behavior can be disabled if needed by setting `optizeRaycast` to false.
 
-### .onPreprocessURL
+### .preprocessURL
 
 ```js
-onPreprocessURL = null : ( uri : string | URL ) => string | URL;
+preprocessURL = null : ( uri : string | URL ) => string | URL;
 ```
 
 Function to preprocess the url for each individual tile geometry or child tile set to be loaded. If null then the url is used directly.

--- a/example/ionExample.js
+++ b/example/ionExample.js
@@ -5,7 +5,6 @@ import {
 	PerspectiveCamera,
 	Vector3,
 	Quaternion,
-	Group,
 	Sphere,
 } from 'three';
 import { FlyOrbitControls } from './src/controls/FlyOrbitControls.js';
@@ -16,11 +15,10 @@ import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 let camera, controls, scene, renderer, tiles;
 
 const params = {
-
-	'ionAssetId': '40866',
-	'ionAccessToken': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJmYmE2YWEzOS1lZDUyLTQ0YWMtOTlkNS0wN2VhZWI3NTc4MmEiLCJpZCI6MjU5LCJpYXQiOjE2ODU2MzQ0Njl9.AswCMxsN03WYwuZL-r183OZicN64Ks9aPExWhA3fuLY',
-	'reload': reinstantiateTiles,
-
+	ionAssetId: '40866',
+	ionAccessToken:
+		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJmYmE2YWEzOS1lZDUyLTQ0YWMtOTlkNS0wN2VhZWI3NTc4MmEiLCJpZCI6MjU5LCJpYXQiOjE2ODU2MzQ0Njl9.AswCMxsN03WYwuZL-r183OZicN64Ks9aPExWhA3fuLY',
+	reload: reinstantiateTiles,
 };
 
 init();
@@ -47,7 +45,9 @@ function setupTiles() {
 	// Note the DRACO compression files need to be supplied via an explicit source.
 	// We use unpkg here but in practice should be provided by the application.
 	const dracoLoader = new DRACOLoader();
-	dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/' );
+	dracoLoader.setDecoderPath(
+		'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/'
+	);
 
 	const loader = new GLTFLoader( tiles.manager );
 	loader.setDRACOLoader( dracoLoader );
@@ -92,18 +92,26 @@ function reinstantiateTiles() {
 	};
 
 	// Some Cesium Ion tilesets have wrong materials - or should add a light to the scene
-        tiles.onLoadModel = (scene, tile) => {
-          scene.traverse((c) => {
-            if (c.isMesh) {
-              if (c.material.isMeshStandardMaterial) {
-                // Option 1: use an emissiveMap within PBR MeshStandardMaterial
-                c.material.emissiveMap = c?.material?.map;
-                c.material.emissive = new THREE.Color(0xffffff); 
-                // Option 2: redefine a classic MeshBasicMaterial with map
-                // c.material = new THREE.MeshBasicMaterial({map: c?.material?.map});
-              }
-	    }
-	  });
+	tiles.onLoadModel = ( scene, tile ) => {
+
+		scene.traverse( ( c ) => {
+
+			if ( c.isMesh ) {
+
+				if ( c.material.isMeshStandardMaterial ) {
+
+					// Option 1: use an emissiveMap within PBR MeshStandardMaterial
+					c.material.emissiveMap = c?.material?.map;
+					c.material.emissive = new THREE.Color( 0xffffff );
+					// Option 2: redefine a classic MeshBasicMaterial with map
+					// c.material = new THREE.MeshBasicMaterial({map: c?.material?.map});
+
+				}
+
+			}
+
+		} );
+
 	};
 
 	setupTiles();
@@ -115,8 +123,8 @@ function init() {
 	scene = new Scene();
 
 	// Add scene light for MeshStandardMaterial to react properly
-        const light = new THREE.AmbientLight(0xffffff, 1);
-        scene.add(light);
+	const light = new THREE.AmbientLight( 0xffffff, 1 );
+	scene.add( light );
 
 	// primary camera view
 	renderer = new WebGLRenderer( { antialias: true } );
@@ -125,7 +133,12 @@ function init() {
 	document.body.appendChild( renderer.domElement );
 	renderer.domElement.tabIndex = 1;
 
-	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 4000 );
+	camera = new PerspectiveCamera(
+		60,
+		window.innerWidth / window.innerHeight,
+		1,
+		4000
+	);
 	camera.position.set( 400, 400, 400 );
 
 	// controls

--- a/example/ionExample.js
+++ b/example/ionExample.js
@@ -91,6 +91,20 @@ function reinstantiateTiles() {
 
 	};
 
+	// Some Cesium Ion tilesets have wrong materials - or should add a light to the scene
+        tiles.onLoadModel = function (scene, tile) {
+          scene.traverse((c) => {
+            if (c.isMesh) {
+              if (c.material.isMeshStandardMaterial) {
+                // Option 1: use an emissiveMap within PBR MeshStandardMaterial
+                c.material.emissiveMap = c?.material?.map;
+                c.material.emissive = new THREE.Color(0xffffff); 
+                // Option 2: redefine a classic MeshBasicMaterial with map
+                // c.material = new THREE.MeshBasicMaterial({map: c?.material?.map});
+              }
+	    }
+	  }
+
 	setupTiles();
 
 }
@@ -98,6 +112,10 @@ function reinstantiateTiles() {
 function init() {
 
 	scene = new Scene();
+
+	// Add scene light for MeshStandardMaterial to react properly
+        const light = new THREE.AmbientLight(0xffffff, 1);
+        scene.add(light);
 
 	// primary camera view
 	renderer = new WebGLRenderer( { antialias: true } );

--- a/example/ionExample.js
+++ b/example/ionExample.js
@@ -7,6 +7,8 @@ import {
 	Quaternion,
 	Sphere,
 	AmbientLight,
+	DataTexture,
+	EquirectangularReflectionMapping
 } from 'three';
 import { FlyOrbitControls } from './src/controls/FlyOrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -92,31 +94,6 @@ function reinstantiateTiles() {
 
 	};
 
-	// Some Cesium Ion tilesets have wrong materials - or should add a light to the scene
-	tiles.onLoadModel = ( scene, tile ) => {
-
-		scene.traverse( ( c ) => {
-
-			if ( c.isMesh ) {
-
-				if ( c.material.isMeshStandardMaterial ) {
-
-					// Option 1
-					c.material.metalness = 0;
-					// Option 2: use an emissiveMap within PBR MeshStandardMaterial
-					// c.material.emissiveMap = c?.material?.map;
-					// c.material.emissive = new Color( 0xffffff );
-					// Option 3: redefine a classic MeshBasicMaterial with map
-					// c.material = new MeshBasicMaterial( { map: c?.material?.map } );
-
-				}
-
-			}
-
-		} );
-
-	};
-
 	setupTiles();
 
 }
@@ -128,6 +105,12 @@ function init() {
 	// Add scene light for MeshStandardMaterial to react properly if its metalness is set to 0
 	const light = new AmbientLight( 0xffffff, 1 );
 	scene.add( light );
+
+	const env = new DataTexture( new Uint8Array( 64 * 64 * 4 ).fill( 255 ), 64, 64 );
+	env.mapping = EquirectangularReflectionMapping;
+	env.needsUpdate = true;
+	scene.background = env;
+	scene.environment = env;
 
 	// primary camera view
 	renderer = new WebGLRenderer( { antialias: true } );

--- a/example/ionExample.js
+++ b/example/ionExample.js
@@ -109,7 +109,6 @@ function init() {
 	const env = new DataTexture( new Uint8Array( 64 * 64 * 4 ).fill( 255 ), 64, 64 );
 	env.mapping = EquirectangularReflectionMapping;
 	env.needsUpdate = true;
-	scene.background = env;
 	scene.environment = env;
 
 	// primary camera view

--- a/example/ionExample.js
+++ b/example/ionExample.js
@@ -92,7 +92,7 @@ function reinstantiateTiles() {
 	};
 
 	// Some Cesium Ion tilesets have wrong materials - or should add a light to the scene
-        tiles.onLoadModel = function (scene, tile) {
+        tiles.onLoadModel = (scene, tile) => {
           scene.traverse((c) => {
             if (c.isMesh) {
               if (c.material.isMeshStandardMaterial) {
@@ -103,7 +103,8 @@ function reinstantiateTiles() {
                 // c.material = new THREE.MeshBasicMaterial({map: c?.material?.map});
               }
 	    }
-	  }
+	  });
+	};
 
 	setupTiles();
 

--- a/example/ionExample.js
+++ b/example/ionExample.js
@@ -6,6 +6,7 @@ import {
 	Vector3,
 	Quaternion,
 	Sphere,
+	AmbientLight,
 } from 'three';
 import { FlyOrbitControls } from './src/controls/FlyOrbitControls.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -100,11 +101,13 @@ function reinstantiateTiles() {
 
 				if ( c.material.isMeshStandardMaterial ) {
 
-					// Option 1: use an emissiveMap within PBR MeshStandardMaterial
-					c.material.emissiveMap = c?.material?.map;
-					c.material.emissive = new THREE.Color( 0xffffff );
-					// Option 2: redefine a classic MeshBasicMaterial with map
-					// c.material = new THREE.MeshBasicMaterial({map: c?.material?.map});
+					// Option 1
+					c.material.metalness = 0;
+					// Option 2: use an emissiveMap within PBR MeshStandardMaterial
+					// c.material.emissiveMap = c?.material?.map;
+					// c.material.emissive = new Color( 0xffffff );
+					// Option 3: redefine a classic MeshBasicMaterial with map
+					// c.material = new MeshBasicMaterial( { map: c?.material?.map } );
 
 				}
 
@@ -122,8 +125,8 @@ function init() {
 
 	scene = new Scene();
 
-	// Add scene light for MeshStandardMaterial to react properly
-	const light = new THREE.AmbientLight( 0xffffff, 1 );
+	// Add scene light for MeshStandardMaterial to react properly if its metalness is set to 0
+	const light = new AmbientLight( 0xffffff, 1 );
 	scene.add( light );
 
 	// primary camera view


### PR DESCRIPTION
 - Fixes black tilesets loaded from Cesium ion as described in [this issue](https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/475)
 - Updates README.md typo code blocks with preprocessURL instead of onPreprocessURL

