### PR TITLE
GlobeControls limit Frustum with horizon for performance

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -16,6 +16,7 @@ import {
 import { raycastTraverse, raycastTraverseFirstHit } from './raycastTraverse.js';
 import { readMagicBytes } from '../utilities/readMagicBytes.js';
 import { TileBoundingVolume } from './math/TileBoundingVolume.js';
+import { AdvFrustum } from './math/AdvFrustum.js';
 
 const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
@@ -369,7 +370,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 			cameraInfo.push( {
 
-				frustum: new Frustum(),
+				frustum: new AdvFrustum(),
 				isOrthographic: false,
 				sseDenominator: - 1, // used if isOrthographic:false
 				position: new Vector3(),

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -16,7 +16,7 @@ import {
 import { raycastTraverse, raycastTraverseFirstHit } from './raycastTraverse.js';
 import { readMagicBytes } from '../utilities/readMagicBytes.js';
 import { TileBoundingVolume } from './math/TileBoundingVolume.js';
-import { AdvFrustum } from './math/AdvFrustum.js';
+import { ExtendedFrustum } from './math/ExtendedFrustum.js';
 
 const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
@@ -370,7 +370,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 			cameraInfo.push( {
 
-				frustum: new AdvFrustum(),
+				frustum: new ExtendedFrustum(),
 				isOrthographic: false,
 				sseDenominator: - 1, // used if isOrthographic:false
 				position: new Vector3(),

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -152,7 +152,13 @@ export class GlobeControls extends EnvironmentControls {
 		// update the projection matrix
 		const largestDistance = Math.max( ...ellipsoid.radius );
 		camera.near = Math.max( 1, distanceToCenter - largestDistance * 1.25 );
-		camera.far = distanceToCenter + largestDistance + 0.1;
+
+		// update the far plane to the horizon distance
+		ellipsoid.getPositionToCartographic( camera.position, _vec );
+		const elevation = ellipsoid.getPositionElevation( camera.position );
+		const horizonDistance = ellipsoid.calculateHorizonDistance( _vec.lat, elevation );
+		camera.far = horizonDistance + 0.1;
+
 		camera.updateProjectionMatrix();
 
 	}

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -155,15 +155,16 @@ export class GlobeControls extends EnvironmentControls {
 		camera.near = Math.max( 1, distanceToCenter - largestDistance * 1.25 );
 
 		// update the far plane to the horizon distance
-		ellipsoid.getPositionToCartographic( camera.position, _vec );
+		const res = {};
 		const invMatrix = _invMatrix.copy( tilesGroup.matrixWorld ).invert();
 		_pos.copy( camera.position ).applyMatrix4( invMatrix );
+		ellipsoid.getPositionToCartographic( _pos, res );
 		const elevation = ellipsoid.getPositionElevation( _pos );
 		// due to the level of prescision of the tiles / sphere
 		// we can get an elevation that will be higher than the actual elevation.
 		// when we end up below the surface of the ellipsoid the elevation is returned as positive instead of negative
 		// resulting in a horizon distance that is too large.
-		const horizonDistance = ellipsoid.calculateHorizonDistance( _vec.lat, elevation );
+		const horizonDistance = ellipsoid.calculateHorizonDistance( res.lat, elevation );
 		camera.far = horizonDistance + 0.1;
 
 		camera.updateProjectionMatrix();

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -19,6 +19,7 @@ const _right = new Vector3();
 const _targetRight = new Vector3();
 const _globalUp = new Vector3();
 const _quaternion = new Quaternion();
+const _latLon = {};
 
 const _pointer = new Vector2();
 const _prevPointer = new Vector2();
@@ -155,16 +156,16 @@ export class GlobeControls extends EnvironmentControls {
 		camera.near = Math.max( 1, distanceToCenter - largestDistance * 1.25 );
 
 		// update the far plane to the horizon distance
-		const res = {};
 		const invMatrix = _invMatrix.copy( tilesGroup.matrixWorld ).invert();
 		_pos.copy( camera.position ).applyMatrix4( invMatrix );
-		ellipsoid.getPositionToCartographic( _pos, res );
+		ellipsoid.getPositionToCartographic( _pos, _latLon );
 		const elevation = ellipsoid.getPositionElevation( _pos );
-		// due to the level of prescision of the tiles / sphere
+
+		// due to the level of precision of the tiles / sphere
 		// we can get an elevation that will be higher than the actual elevation.
 		// when we end up below the surface of the ellipsoid the elevation is returned as positive instead of negative
 		// resulting in a horizon distance that is too large.
-		const horizonDistance = ellipsoid.calculateHorizonDistance( res.lat, elevation );
+		const horizonDistance = ellipsoid.calculateHorizonDistance( _latLon.lat, elevation );
 		camera.far = horizonDistance + 0.1;
 
 		camera.updateProjectionMatrix();

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -10,6 +10,7 @@ import { makeRotateAroundPoint } from './utils.js';
 
 const _invMatrix = new Matrix4();
 const _rotMatrix = new Matrix4();
+const _pos = new Vector3();
 const _vec = new Vector3();
 const _center = new Vector3();
 const _up = new Vector3();
@@ -155,7 +156,9 @@ export class GlobeControls extends EnvironmentControls {
 
 		// update the far plane to the horizon distance
 		ellipsoid.getPositionToCartographic( camera.position, _vec );
-		const elevation = ellipsoid.getPositionElevation( camera.position );
+		const invMatrix = _invMatrix.copy( tilesGroup.matrixWorld ).invert();
+		_pos.copy( camera.position ).applyMatrix4( invMatrix );
+		const elevation = ellipsoid.getPositionElevation( _pos );
 		const horizonDistance = ellipsoid.calculateHorizonDistance( _vec.lat, elevation );
 		camera.far = horizonDistance + 0.1;
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -159,6 +159,10 @@ export class GlobeControls extends EnvironmentControls {
 		const invMatrix = _invMatrix.copy( tilesGroup.matrixWorld ).invert();
 		_pos.copy( camera.position ).applyMatrix4( invMatrix );
 		const elevation = ellipsoid.getPositionElevation( _pos );
+		// due to the level of prescision of the tiles / sphere
+		// we can get an elevation that will be higher than the actual elevation.
+		// when we end up below the surface of the ellipsoid the elevation is returned as positive instead of negative
+		// resulting in a horizon distance that is too large.
 		const horizonDistance = ellipsoid.calculateHorizonDistance( _vec.lat, elevation );
 		camera.far = horizonDistance + 0.1;
 

--- a/src/three/math/AdvFrustum.js
+++ b/src/three/math/AdvFrustum.js
@@ -1,0 +1,78 @@
+import { Frustum, Matrix3, Vector3 } from 'three';
+
+const _mat3 = new Matrix3();
+const _constants = new Vector3();
+
+class AdvFrustum extends Frustum {
+
+	constructor() {
+
+		super();
+		this.mPoints = Array( 8 ).fill().map( () => new Vector3() );
+
+	}
+
+	setFromProjectionMatrix( m, coordinateSystem ) {
+
+		super.setFromProjectionMatrix( m, coordinateSystem );
+		this.calculateFrustumPoints();
+
+	}
+
+	calculateFrustumPoints() {
+
+		const planeIntersections = [
+			[ this.planes[ 0 ], this.planes[ 3 ], this.planes[ 4 ] ], // Near top left
+			[ this.planes[ 1 ], this.planes[ 3 ], this.planes[ 4 ] ], // Near top right
+			[ this.planes[ 0 ], this.planes[ 2 ], this.planes[ 4 ] ], // Near bottom left
+			[ this.planes[ 1 ], this.planes[ 2 ], this.planes[ 4 ] ], // Near bottom right
+			[ this.planes[ 0 ], this.planes[ 3 ], this.planes[ 5 ] ], // Far top left
+			[ this.planes[ 1 ], this.planes[ 3 ], this.planes[ 5 ] ], // Far top right
+			[ this.planes[ 0 ], this.planes[ 2 ], this.planes[ 5 ] ], // Far bottom left
+			[ this.planes[ 1 ], this.planes[ 2 ], this.planes[ 5 ] ] // Far bottom right
+		];
+
+		planeIntersections.forEach( ( planes, index ) => {
+
+			this.mPoints[ index ].fromArray( this.findIntersectionPointThree( planes[ 0 ], planes[ 1 ], planes[ 2 ] ) );
+
+		} );
+
+	}
+
+	findIntersectionPointThree( plane1, plane2, plane3 ) {
+
+		// Create the matrix A using the normals of the planes
+		const A = _mat3.set(
+			plane1.normal.x, plane1.normal.y, plane1.normal.z,
+			plane2.normal.x, plane2.normal.y, plane2.normal.z,
+			plane3.normal.x, plane3.normal.y, plane3.normal.z
+		);
+
+		// Create the vector B using the constants of the planes
+		const B = _constants.set( - plane1.constant, - plane2.constant, - plane3.constant );
+
+		// Solve for X by applying the inverse matrix to B
+		const X = B.applyMatrix3( A.invert() );
+
+		return [ X.x, X.y, X.z ];
+
+	}
+
+	boxInFrustum( box ) {
+
+		let out;
+		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].x > box.max.x ) ? 1 : 0 ); if ( out == 8 ) return false;
+		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].x < box.min.x ) ? 1 : 0 ); if ( out == 8 ) return false;
+		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].y > box.max.y ) ? 1 : 0 ); if ( out == 8 ) return false;
+		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].y < box.min.y ) ? 1 : 0 ); if ( out == 8 ) return false;
+		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].z > box.max.z ) ? 1 : 0 ); if ( out == 8 ) return false;
+		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].z < box.min.z ) ? 1 : 0 ); if ( out == 8 ) return false;
+
+		return true;
+
+	}
+
+}
+
+export { AdvFrustum };

--- a/src/three/math/AdvFrustum.js
+++ b/src/three/math/AdvFrustum.js
@@ -59,20 +59,6 @@ class AdvFrustum extends Frustum {
 
 	}
 
-	boxInFrustum( box ) {
-
-		let out;
-		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].x > box.max.x ) ? 1 : 0 ); if ( out == 8 ) return false;
-		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].x < box.min.x ) ? 1 : 0 ); if ( out == 8 ) return false;
-		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].y > box.max.y ) ? 1 : 0 ); if ( out == 8 ) return false;
-		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].y < box.min.y ) ? 1 : 0 ); if ( out == 8 ) return false;
-		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].z > box.max.z ) ? 1 : 0 ); if ( out == 8 ) return false;
-		out = 0; for ( let i = 0; i < 8; i ++ ) out += ( ( this.mPoints[ i ].z < box.min.z ) ? 1 : 0 ); if ( out == 8 ) return false;
-
-		return true;
-
-	}
-
 }
 
 export { AdvFrustum };

--- a/src/three/math/Ellipsoid.js
+++ b/src/three/math/Ellipsoid.js
@@ -205,7 +205,8 @@ export class Ellipsoid {
 
 	calculateHorizonDistance( latitude, elevation ) {
 
-		// elevation relative to the surface of the ellipsoid at the specified latitude
+		// from https://aty.sdsu.edu/explain/atmos_refr/horizon.html
+		// OG = sqrt ( 2 R h + h2 ) .
 		const effectiveRadius = this.calculateEffectiveRadius( latitude );
 		return Math.sqrt( 2 * effectiveRadius * elevation + elevation ** 2 );
 
@@ -213,6 +214,9 @@ export class Ellipsoid {
 
 	calculateEffectiveRadius( latitude ) {
 
+		// This radius represents the distance from the center of the ellipsoid to the surface along the normal at the given latitude.
+		// from https://en.wikipedia.org/wiki/Earth_radius#Prime_vertical
+		// N = a / sqrt(1 - e^2 * sin^2(phi))
 		const semiMajorAxis = this.radius.x;
 		const semiMinorAxis = this.radius.z;
 		const eSquared = 1 - ( semiMinorAxis ** 2 / semiMajorAxis ** 2 );

--- a/src/three/math/Ellipsoid.js
+++ b/src/three/math/Ellipsoid.js
@@ -1,4 +1,4 @@
-import { Vector3, Spherical, MathUtils, Euler, Quaternion } from 'three';
+import { Vector3, Spherical, MathUtils } from 'three';
 import { swapToGeoFrame, latitudeToSphericalPhi } from './GeoUtils.js';
 
 const _spherical = new Spherical();

--- a/src/three/math/Ellipsoid.js
+++ b/src/three/math/Ellipsoid.js
@@ -12,9 +12,6 @@ const _vecY = new Vector3();
 const _vecZ = new Vector3();
 const _pos = new Vector3();
 
-const toLocalEuler = new Euler( - Math.PI / 2, 0, 0, 'XYZ' );
-const toLocalQuaternion = new Quaternion().setFromEuler( toLocalEuler );
-
 const EPSILON12 = 1e-12;
 const CENTER_EPS = 0.1;
 
@@ -228,19 +225,11 @@ export class Ellipsoid {
 
 	}
 
-	worldToLocal( pos ) {
-
-		pos.applyQuaternion( toLocalQuaternion );
-
-	}
-
 	getPositionElevation( pos ) {
 
-		_pos.copy( pos );
-		this.worldToLocal( _pos );
+		this.getPositionToSurfacePoint( pos, _vec3 );
 
-		this.getPositionToSurfacePoint( _pos, _vec3 );
-		const elevation = _vec3.distanceTo( _pos );
+		const elevation = _vec3.distanceTo( pos );
 
 		return elevation;
 

--- a/src/three/math/ExtendedFrustum.js
+++ b/src/three/math/ExtendedFrustum.js
@@ -2,9 +2,10 @@ import { Frustum, Matrix3, Vector3 } from 'three';
 
 const _mat3 = new Matrix3();
 
+// Solve a system of equations to find the point where the three planes intersect
 function findIntersectionPoint( plane1, plane2, plane3, target ) {
 
-	// Create the matrix A using the normals of the planes
+	// Create the matrix A using the normals of the planes as rows
 	const A = _mat3.set(
 		plane1.normal.x, plane1.normal.y, plane1.normal.z,
 		plane2.normal.x, plane2.normal.y, plane2.normal.z,
@@ -39,20 +40,21 @@ class ExtendedFrustum extends Frustum {
 
 	calculateFrustumPoints() {
 
+		const { planes, points } = this;
 		const planeIntersections = [
-			[ this.planes[ 0 ], this.planes[ 3 ], this.planes[ 4 ] ], // Near top left
-			[ this.planes[ 1 ], this.planes[ 3 ], this.planes[ 4 ] ], // Near top right
-			[ this.planes[ 0 ], this.planes[ 2 ], this.planes[ 4 ] ], // Near bottom left
-			[ this.planes[ 1 ], this.planes[ 2 ], this.planes[ 4 ] ], // Near bottom right
-			[ this.planes[ 0 ], this.planes[ 3 ], this.planes[ 5 ] ], // Far top left
-			[ this.planes[ 1 ], this.planes[ 3 ], this.planes[ 5 ] ], // Far top right
-			[ this.planes[ 0 ], this.planes[ 2 ], this.planes[ 5 ] ], // Far bottom left
-			[ this.planes[ 1 ], this.planes[ 2 ], this.planes[ 5 ] ] // Far bottom right
+			[ planes[ 0 ], planes[ 3 ], planes[ 4 ] ], // Near top left
+			[ planes[ 1 ], planes[ 3 ], planes[ 4 ] ], // Near top right
+			[ planes[ 0 ], planes[ 2 ], planes[ 4 ] ], // Near bottom left
+			[ planes[ 1 ], planes[ 2 ], planes[ 4 ] ], // Near bottom right
+			[ planes[ 0 ], planes[ 3 ], planes[ 5 ] ], // Far top left
+			[ planes[ 1 ], planes[ 3 ], planes[ 5 ] ], // Far top right
+			[ planes[ 0 ], planes[ 2 ], planes[ 5 ] ], // Far bottom left
+			[ planes[ 1 ], planes[ 2 ], planes[ 5 ] ], // Far bottom right
 		];
 
 		planeIntersections.forEach( ( planes, index ) => {
 
-			findIntersectionPoint( planes[ 0 ], planes[ 1 ], planes[ 2 ], this.points[ index ] );
+			findIntersectionPoint( planes[ 0 ], planes[ 1 ], planes[ 2 ], points[ index ] );
 
 		} );
 

--- a/src/three/math/ExtendedFrustum.js
+++ b/src/three/math/ExtendedFrustum.js
@@ -1,14 +1,32 @@
 import { Frustum, Matrix3, Vector3 } from 'three';
 
 const _mat3 = new Matrix3();
-const _constants = new Vector3();
 
-class AdvFrustum extends Frustum {
+function findIntersectionPoint( plane1, plane2, plane3, target ) {
+
+	// Create the matrix A using the normals of the planes
+	const A = _mat3.set(
+		plane1.normal.x, plane1.normal.y, plane1.normal.z,
+		plane2.normal.x, plane2.normal.y, plane2.normal.z,
+		plane3.normal.x, plane3.normal.y, plane3.normal.z
+	);
+
+	// Create the vector B using the constants of the planes
+	target.set( - plane1.constant, - plane2.constant, - plane3.constant );
+
+	// Solve for X by applying the inverse matrix to B
+	target.applyMatrix3( A.invert() );
+
+	return target;
+
+}
+
+class ExtendedFrustum extends Frustum {
 
 	constructor() {
 
 		super();
-		this.mPoints = Array( 8 ).fill().map( () => new Vector3() );
+		this.points = Array( 8 ).fill().map( () => new Vector3() );
 
 	}
 
@@ -34,31 +52,12 @@ class AdvFrustum extends Frustum {
 
 		planeIntersections.forEach( ( planes, index ) => {
 
-			this.mPoints[ index ].fromArray( this.findIntersectionPointThree( planes[ 0 ], planes[ 1 ], planes[ 2 ] ) );
+			findIntersectionPoint( planes[ 0 ], planes[ 1 ], planes[ 2 ], this.points[ index ] );
 
 		} );
 
 	}
 
-	findIntersectionPointThree( plane1, plane2, plane3 ) {
-
-		// Create the matrix A using the normals of the planes
-		const A = _mat3.set(
-			plane1.normal.x, plane1.normal.y, plane1.normal.z,
-			plane2.normal.x, plane2.normal.y, plane2.normal.z,
-			plane3.normal.x, plane3.normal.y, plane3.normal.z
-		);
-
-		// Create the vector B using the constants of the planes
-		const B = _constants.set( - plane1.constant, - plane2.constant, - plane3.constant );
-
-		// Solve for X by applying the inverse matrix to B
-		const X = B.applyMatrix3( A.invert() );
-
-		return [ X.x, X.y, X.z ];
-
-	}
-
 }
 
-export { AdvFrustum };
+export { ExtendedFrustum };

--- a/src/three/math/OBB.js
+++ b/src/three/math/OBB.js
@@ -1,43 +1,63 @@
-import { Matrix4, Box3, Vector3 } from 'three';
+import { Matrix4, Box3, Vector3, Plane } from 'three';
+
+const _normal1 = new Vector3();
+const _normal2 = new Vector3();
+const _normal3 = new Vector3();
+const _vec3 = new Vector3();
 
 export class OBB {
 
 	constructor( box = new Box3(), transform = new Matrix4() ) {
 
 		this.box = box.clone();
-		this.orientedBox = box.clone();
 		this.transform = transform.clone();
-		this.inverseTransform = new Matrix4();
 		this.points = new Array( 8 ).fill().map( () => new Vector3() );
+		this.planes = new Array( 6 ).fill().map( () => new Plane() );
+		this.planeNeedsUpdate = false;
 
 	}
 
 	update() {
 
-		const { points, inverseTransform, transform, box, orientedBox } = this;
-		inverseTransform.copy( transform ).invert();
+		const { points, transform, box } = this;
 
-		orientedBox.copy( box ).applyMatrix4( transform );
 		const { min, max } = box;
-		let index = 0;
-		for ( let x = - 1; x <= 1; x += 2 ) {
+		points[ 0 ].set( min.x, min.y, min.z ).applyMatrix4( transform ); // Front-bottom-left
+		points[ 1 ].set( max.x, min.y, min.z ).applyMatrix4( transform ); // Front-bottom-right
+		points[ 2 ].set( max.x, max.y, min.z ).applyMatrix4( transform ); // Front-top-right
+		points[ 3 ].set( min.x, max.y, min.z ).applyMatrix4( transform ); // Front-top-left
 
-			for ( let y = - 1; y <= 1; y += 2 ) {
+		points[ 4 ].set( min.x, min.y, max.z ).applyMatrix4( transform ); // Back-bottom-left
+		points[ 5 ].set( max.x, min.y, max.z ).applyMatrix4( transform ); // Back-bottom-right
+		points[ 6 ].set( max.x, max.y, max.z ).applyMatrix4( transform ); // Back-top-right
+		points[ 7 ].set( min.x, max.y, max.z ).applyMatrix4( transform ); // Back-top-left
+		this.planeNeedsUpdate = true;
 
-				for ( let z = - 1; z <= 1; z += 2 ) {
+	}
 
-					points[ index ].set(
-						x < 0 ? min.x : max.x,
-						y < 0 ? min.y : max.y,
-						z < 0 ? min.z : max.z,
-					).applyMatrix4( transform );
-					index ++;
+	updatePlanes() {
 
-				}
+		if ( ! this.planeNeedsUpdate ) return;
 
-			}
+		const normals = [
+			_normal1.subVectors( this.points[ 1 ], this.points[ 0 ] ).cross( _vec3.subVectors( this.points[ 2 ], this.points[ 0 ] ) ).normalize(),
+			_normal2.subVectors( this.points[ 4 ], this.points[ 0 ] ).cross( _vec3.subVectors( this.points[ 1 ], this.points[ 0 ] ) ).normalize(),
+			_normal3.subVectors( this.points[ 2 ], this.points[ 0 ] ).cross( _vec3.subVectors( this.points[ 4 ], this.points[ 0 ] ) ).normalize()
+		];
 
-		}
+		// Front and back
+		this.planes[ 0 ].setFromNormalAndCoplanarPoint( normals[ 0 ], this.points[ 0 ] );
+		this.planes[ 1 ].setFromNormalAndCoplanarPoint( normals[ 0 ].negate(), this.points[ 6 ] );
+
+		// Left and right
+		this.planes[ 2 ].setFromNormalAndCoplanarPoint( normals[ 1 ], this.points[ 0 ] );
+		this.planes[ 3 ].setFromNormalAndCoplanarPoint( normals[ 1 ].negate(), this.points[ 2 ] );
+
+		// Top and bottom
+		this.planes[ 4 ].setFromNormalAndCoplanarPoint( normals[ 2 ], this.points[ 0 ] );
+		this.planes[ 5 ].setFromNormalAndCoplanarPoint( normals[ 2 ].negate(), this.points[ 1 ] );
+
+		this.planeNeedsUpdate = false;
 
 	}
 
@@ -66,10 +86,25 @@ export class OBB {
 
 		}
 
-		const boxInFrustum = frustum.boxInFrustum( this.orientedBox );
-		if ( ! boxInFrustum ) {
+		// do the opposite check using the obb planes to avoid false positives
+		this.updatePlanes();
+		for ( let i = 0; i < 6; i ++ ) {
 
-			return false;
+			const plane = this.planes[ i ];
+			let maxDistance = - Infinity;
+			for ( let j = 0; j < 8; j ++ ) {
+
+				const v = frustum.mPoints[ j ];
+				const dist = plane.distanceToPoint( v );
+				maxDistance = maxDistance < dist ? dist : maxDistance;
+
+			}
+
+			if ( maxDistance < 0 ) {
+
+				return false;
+
+			}
 
 		}
 

--- a/src/three/math/OBB.js
+++ b/src/three/math/OBB.js
@@ -11,6 +11,7 @@ export class OBB {
 
 		this.box = box.clone();
 		this.transform = transform.clone();
+		this.inverseTransform = new Matrix4();
 		this.points = new Array( 8 ).fill().map( () => new Vector3() );
 		this.planes = new Array( 6 ).fill().map( () => new Plane() );
 		this.planeNeedsUpdate = false;
@@ -19,7 +20,8 @@ export class OBB {
 
 	update() {
 
-		const { points, transform, box } = this;
+		const { points, inverseTransform, transform, box } = this;
+		inverseTransform.copy( transform ).invert();
 
 		const { min, max } = box;
 		points[ 0 ].set( min.x, min.y, min.z ).applyMatrix4( transform ); // Front-bottom-left

--- a/src/three/math/OBB.js
+++ b/src/three/math/OBB.js
@@ -1,9 +1,8 @@
 import { Matrix4, Box3, Vector3, Plane } from 'three';
 
-const _normal1 = new Vector3();
-const _normal2 = new Vector3();
-const _normal3 = new Vector3();
-const _vec3 = new Vector3();
+const _worldMin = new Vector3();
+const _worldMax = new Vector3();
+const _norm = new Vector3();
 
 export class OBB {
 
@@ -41,23 +40,20 @@ export class OBB {
 
 		if ( ! this.planeNeedsUpdate ) return;
 
-		const normals = [
-			_normal1.subVectors( this.points[ 1 ], this.points[ 0 ] ).cross( _vec3.subVectors( this.points[ 2 ], this.points[ 0 ] ) ).normalize(),
-			_normal2.subVectors( this.points[ 0 ], this.points[ 3 ] ).cross( _vec3.subVectors( this.points[ 4 ], this.points[ 0 ] ) ).normalize(),
-			_normal3.subVectors( this.points[ 2 ], this.points[ 3 ] ).cross( _vec3.subVectors( this.points[ 6 ], this.points[ 2 ] ) ).normalize(),
-		];
+		_worldMin.copy( this.box.min ).applyMatrix4( this.transform );
+		_worldMax.copy( this.box.max ).applyMatrix4( this.transform );
 
-		// Front and back
-		this.planes[ 0 ].setFromNormalAndCoplanarPoint( normals[ 0 ], this.points[ 0 ] );
-		this.planes[ 1 ].setFromNormalAndCoplanarPoint( normals[ 0 ].negate(), this.points[ 6 ] );
+		_norm.set( 0, 0, 1 ).transformDirection( this.transform );
+		this.planes[ 0 ].setFromNormalAndCoplanarPoint( _norm, _worldMin );
+		this.planes[ 1 ].setFromNormalAndCoplanarPoint( _norm, _worldMax ).negate();
 
-		// Left and right
-		this.planes[ 2 ].setFromNormalAndCoplanarPoint( normals[ 1 ], this.points[ 1 ] );
-		this.planes[ 3 ].setFromNormalAndCoplanarPoint( normals[ 1 ].negate(), this.points[ 3 ] );
+		_norm.set( 0, 1, 0 ).transformDirection( this.transform );
+		this.planes[ 2 ].setFromNormalAndCoplanarPoint( _norm, _worldMin );
+		this.planes[ 3 ].setFromNormalAndCoplanarPoint( _norm, _worldMax ).negate();
 
-		// Top and bottom
-		this.planes[ 4 ].setFromNormalAndCoplanarPoint( normals[ 2 ], this.points[ 3 ] );
-		this.planes[ 5 ].setFromNormalAndCoplanarPoint( normals[ 2 ].negate(), this.points[ 4 ] );
+		_norm.set( 1, 0, 0 ).transformDirection( this.transform );
+		this.planes[ 4 ].setFromNormalAndCoplanarPoint( _norm, _worldMin );
+		this.planes[ 5 ].setFromNormalAndCoplanarPoint( _norm, _worldMax ).negate();
 
 		this.planeNeedsUpdate = false;
 

--- a/src/three/math/OBB.js
+++ b/src/three/math/OBB.js
@@ -43,8 +43,8 @@ export class OBB {
 
 		const normals = [
 			_normal1.subVectors( this.points[ 1 ], this.points[ 0 ] ).cross( _vec3.subVectors( this.points[ 2 ], this.points[ 0 ] ) ).normalize(),
-			_normal2.subVectors( this.points[ 4 ], this.points[ 0 ] ).cross( _vec3.subVectors( this.points[ 1 ], this.points[ 0 ] ) ).normalize(),
-			_normal3.subVectors( this.points[ 2 ], this.points[ 0 ] ).cross( _vec3.subVectors( this.points[ 4 ], this.points[ 0 ] ) ).normalize()
+			_normal2.subVectors( this.points[ 0 ], this.points[ 3 ] ).cross( _vec3.subVectors( this.points[ 4 ], this.points[ 0 ] ) ).normalize(),
+			_normal3.subVectors( this.points[ 2 ], this.points[ 3 ] ).cross( _vec3.subVectors( this.points[ 6 ], this.points[ 2 ] ) ).normalize(),
 		];
 
 		// Front and back
@@ -52,12 +52,12 @@ export class OBB {
 		this.planes[ 1 ].setFromNormalAndCoplanarPoint( normals[ 0 ].negate(), this.points[ 6 ] );
 
 		// Left and right
-		this.planes[ 2 ].setFromNormalAndCoplanarPoint( normals[ 1 ], this.points[ 0 ] );
-		this.planes[ 3 ].setFromNormalAndCoplanarPoint( normals[ 1 ].negate(), this.points[ 2 ] );
+		this.planes[ 2 ].setFromNormalAndCoplanarPoint( normals[ 1 ], this.points[ 1 ] );
+		this.planes[ 3 ].setFromNormalAndCoplanarPoint( normals[ 1 ].negate(), this.points[ 3 ] );
 
 		// Top and bottom
-		this.planes[ 4 ].setFromNormalAndCoplanarPoint( normals[ 2 ], this.points[ 0 ] );
-		this.planes[ 5 ].setFromNormalAndCoplanarPoint( normals[ 2 ].negate(), this.points[ 1 ] );
+		this.planes[ 4 ].setFromNormalAndCoplanarPoint( normals[ 2 ], this.points[ 3 ] );
+		this.planes[ 5 ].setFromNormalAndCoplanarPoint( normals[ 2 ].negate(), this.points[ 4 ] );
 
 		this.planeNeedsUpdate = false;
 

--- a/src/three/math/OBB.js
+++ b/src/three/math/OBB.js
@@ -5,6 +5,7 @@ export class OBB {
 	constructor( box = new Box3(), transform = new Matrix4() ) {
 
 		this.box = box.clone();
+		this.orientedBox = box.clone();
 		this.transform = transform.clone();
 		this.inverseTransform = new Matrix4();
 		this.points = new Array( 8 ).fill().map( () => new Vector3() );
@@ -13,9 +14,10 @@ export class OBB {
 
 	update() {
 
-		const { points, inverseTransform, transform, box } = this;
+		const { points, inverseTransform, transform, box, orientedBox } = this;
 		inverseTransform.copy( transform ).invert();
 
+		orientedBox.copy( box ).applyMatrix4( transform );
 		const { min, max } = box;
 		let index = 0;
 		for ( let x = - 1; x <= 1; x += 2 ) {
@@ -61,6 +63,13 @@ export class OBB {
 				return false;
 
 			}
+
+		}
+
+		const boxInFrustum = frustum.boxInFrustum( this.orientedBox );
+		if ( ! boxInFrustum ) {
+
+			return false;
 
 		}
 

--- a/test/Ellipsoid.test.js
+++ b/test/Ellipsoid.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable jest/expect-expect */
 import * as Cesium from 'cesium';
-import { Vector3, MathUtils, Matrix4, Box3, Sphere } from 'three';
+import { Vector3, MathUtils, Matrix4, Box3, Sphere, Euler, Quaternion } from 'three';
 import { EllipsoidRegion } from '../src/three/math/EllipsoidRegion.js';
 import { Ellipsoid } from '../src/three/math/Ellipsoid.js';
 import { WGS84_HEIGHT, WGS84_RADIUS } from '../src/base/constants.js';
@@ -101,7 +101,7 @@ describe( 'Ellipsoid', () => {
 		const LOCAL_EPSILON = 1e-8;
 		for ( let i = 0; i < 100; i ++ ) {
 
-			v.random().normalize().multiplyScalar( WGS84_RADIUS * 2 );
+			v.random().normalize().multiplyScalar( WGS84_HEIGHT * 2 );
 			c.x = v.x;
 			c.y = v.y;
 			c.z = v.z;
@@ -180,31 +180,31 @@ describe( 'Ellipsoid', () => {
 
 	it( 'should match the expected elevation.', () => {
 
-		const northPos = new Vector3( 0, WGS84_HEIGHT, 0 );
+		//ellipsoid rotation
+		const northPos = new Vector3( 0, 0, WGS84_HEIGHT );
 		expect( wgsEllipse.getPositionElevation( northPos ) ).toBeCloseTo( 0, 1e-6 );
-		const southPos = new Vector3( 0, - WGS84_HEIGHT, 0 );
+		const southPos = new Vector3( 0, 0, - WGS84_HEIGHT );
 		expect( wgsEllipse.getPositionElevation( southPos ) ).toBeCloseTo( 0, 1e-6 );
 		const xPos = new Vector3( WGS84_RADIUS, 0, 0 );
 		expect( wgsEllipse.getPositionElevation( xPos ) ).toBeCloseTo( 0, 1e-6 );
 		const mxPos = new Vector3( - WGS84_RADIUS, 0, 0 );
 		expect( wgsEllipse.getPositionElevation( mxPos ) ).toBeCloseTo( 0, 1e-6 );
-		const zPos = new Vector3( 0, 0, WGS84_RADIUS );
+		const zPos = new Vector3( 0, WGS84_RADIUS, 0 );
 		expect( wgsEllipse.getPositionElevation( zPos ) ).toBeCloseTo( 0, 1e-6 );
-		const mzPos = new Vector3( 0, 0, - WGS84_RADIUS );
+		const mzPos = new Vector3( 0, - WGS84_RADIUS, 0 );
 		expect( wgsEllipse.getPositionElevation( mzPos ) ).toBeCloseTo( 0, 1e-6 );
 
-
-		const northPos100 = new Vector3( 0, WGS84_HEIGHT + 100, 0 );
+		const northPos100 = new Vector3( 0, 0, WGS84_HEIGHT + 100 );
 		expect( wgsEllipse.getPositionElevation( northPos100 ) ).toBeCloseTo( 100, 1e-6 );
-		const southPos100 = new Vector3( 0, - WGS84_HEIGHT + 100, 0 );
+		const southPos100 = new Vector3( 0, 0, - WGS84_HEIGHT + 100 );
 		expect( wgsEllipse.getPositionElevation( southPos100 ) ).toBeCloseTo( 100, 1e-6 );
 		const xPos100 = new Vector3( WGS84_RADIUS + 100, 0, 0 );
 		expect( wgsEllipse.getPositionElevation( xPos100 ) ).toBeCloseTo( 100, 1e-6 );
 		const mxPos100 = new Vector3( - WGS84_RADIUS + 100, 0, 0 );
 		expect( wgsEllipse.getPositionElevation( mxPos100 ) ).toBeCloseTo( 100, 1e-6 );
-		const zPos100 = new Vector3( 0, 0, WGS84_RADIUS + 100 );
+		const zPos100 = new Vector3( 0, WGS84_RADIUS + 100, 0 );
 		expect( wgsEllipse.getPositionElevation( zPos100 ) ).toBeCloseTo( 100, 1e-6 );
-		const mzPos100 = new Vector3( 0, 0, - WGS84_RADIUS + 100 );
+		const mzPos100 = new Vector3( 0, - WGS84_RADIUS + 100, 0 );
 		expect( wgsEllipse.getPositionElevation( mzPos100 ) ).toBeCloseTo( 100, 1e-6 );
 
 	} );

--- a/test/Ellipsoid.test.js
+++ b/test/Ellipsoid.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable jest/expect-expect */
 import * as Cesium from 'cesium';
-import { Vector3, MathUtils, Matrix4, Box3, Sphere, Euler, Quaternion } from 'three';
+import { Vector3, MathUtils, Matrix4, Box3, Sphere } from 'three';
 import { EllipsoidRegion } from '../src/three/math/EllipsoidRegion.js';
 import { Ellipsoid } from '../src/three/math/Ellipsoid.js';
 import { WGS84_HEIGHT, WGS84_RADIUS } from '../src/base/constants.js';
@@ -101,7 +101,7 @@ describe( 'Ellipsoid', () => {
 		const LOCAL_EPSILON = 1e-8;
 		for ( let i = 0; i < 100; i ++ ) {
 
-			v.random().normalize().multiplyScalar( WGS84_HEIGHT * 2 );
+			v.random().normalize().multiplyScalar( WGS84_RADIUS * 2 );
 			c.x = v.x;
 			c.y = v.y;
 			c.z = v.z;

--- a/test/Ellipsoid.test.js
+++ b/test/Ellipsoid.test.js
@@ -178,6 +178,37 @@ describe( 'Ellipsoid', () => {
 
 	} );
 
+	it( 'should match the expected elevation.', () => {
+
+		const northPos = new Vector3( 0, WGS84_HEIGHT, 0 );
+		expect( wgsEllipse.getPositionElevation( northPos ) ).toBeCloseTo( 0, 1e-6 );
+		const southPos = new Vector3( 0, - WGS84_HEIGHT, 0 );
+		expect( wgsEllipse.getPositionElevation( southPos ) ).toBeCloseTo( 0, 1e-6 );
+		const xPos = new Vector3( WGS84_RADIUS, 0, 0 );
+		expect( wgsEllipse.getPositionElevation( xPos ) ).toBeCloseTo( 0, 1e-6 );
+		const mxPos = new Vector3( - WGS84_RADIUS, 0, 0 );
+		expect( wgsEllipse.getPositionElevation( mxPos ) ).toBeCloseTo( 0, 1e-6 );
+		const zPos = new Vector3( 0, 0, WGS84_RADIUS );
+		expect( wgsEllipse.getPositionElevation( zPos ) ).toBeCloseTo( 0, 1e-6 );
+		const mzPos = new Vector3( 0, 0, - WGS84_RADIUS );
+		expect( wgsEllipse.getPositionElevation( mzPos ) ).toBeCloseTo( 0, 1e-6 );
+
+
+		const northPos100 = new Vector3( 0, WGS84_HEIGHT + 100, 0 );
+		expect( wgsEllipse.getPositionElevation( northPos100 ) ).toBeCloseTo( 100, 1e-6 );
+		const southPos100 = new Vector3( 0, - WGS84_HEIGHT + 100, 0 );
+		expect( wgsEllipse.getPositionElevation( southPos100 ) ).toBeCloseTo( 100, 1e-6 );
+		const xPos100 = new Vector3( WGS84_RADIUS + 100, 0, 0 );
+		expect( wgsEllipse.getPositionElevation( xPos100 ) ).toBeCloseTo( 100, 1e-6 );
+		const mxPos100 = new Vector3( - WGS84_RADIUS + 100, 0, 0 );
+		expect( wgsEllipse.getPositionElevation( mxPos100 ) ).toBeCloseTo( 100, 1e-6 );
+		const zPos100 = new Vector3( 0, 0, WGS84_RADIUS + 100 );
+		expect( wgsEllipse.getPositionElevation( zPos100 ) ).toBeCloseTo( 100, 1e-6 );
+		const mzPos100 = new Vector3( 0, 0, - WGS84_RADIUS + 100 );
+		expect( wgsEllipse.getPositionElevation( mzPos100 ) ).toBeCloseTo( 100, 1e-6 );
+
+	} );
+
 } );
 
 describe( 'EllipsoidRegion', () => {


### PR DESCRIPTION
Currently for simplicity GlobeControls camera far is far enough to include the entire earth resulting in unnecessary tiles being loaded.

With these changes we limit the frustum to the distance of the horizon based on our current latitude and elevation.

This seems to work well but some tiles are being loaded while they don't intersect the frustum.

I edited the googleMapsExample.js to visualize it.

I'm not sure where is the issue but I'm pretty sure it's either the frustum or the OOB.
This particular example might help identifying the issue, when the camera is zoomed in on the north pole we get false positive on the intersectsFrustum check. 
If we look at it from the side, it's considered like an intersection as it seems like the frustum far limit does intersect with the obbs.
![wrongFrustumCheck](https://github.com/NASA-AMMOS/3DTilesRendererJS/assets/7174039/f309ce0f-8af7-4d28-a49d-6a841c0d1f68)
But if we look at it from above, we can see that the frustum doesn't.
![wrongFrustumCheckFromAbove](https://github.com/NASA-AMMOS/3DTilesRendererJS/assets/7174039/c47d7258-eca8-430f-a307-cb8c7ec635a5)

Those false positive unload as soon as on the side view, the frustum move outside of those obb.