### PR TITLE
Add missing super deleteCamera on FadeTilesRenderer

### DIFF
--- a/example/src/FadeTilesRenderer.js
+++ b/example/src/FadeTilesRenderer.js
@@ -219,6 +219,7 @@ export const FadeTilesRendererMixin = base => class extends base {
 
 	deleteCamera( camera ) {
 
+		super.deleteCamera( camera );
 		this.prevCameraTransforms.delete( camera );
 
 	}


### PR DESCRIPTION
 FadeTilesRendererMixin was overriding deleteCamera from the base Class without calling the original method.