### PR TITLE
FadeTilesRenderer: Fix fade events not firing correctly

### DIFF
--- a/example/fadingTiles.js
+++ b/example/fadingTiles.js
@@ -141,6 +141,6 @@ function render() {
 
 	renderer.render( scene, camera );
 
-	params.fadingGroundTiles = groundTiles._fadeGroup.children.length + ' tiles';
+	params.fadingGroundTiles = groundTiles.fadingTiles + ' tiles';
 
 }

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -345,8 +345,12 @@ export class FadeManager {
 
 			} );
 
+			// Check if the fade in and fade out animations are complete
 			const fadeOutComplete = fadeOut === 1 || fadeOut === 0;
 			const fadeInComplete = fadeIn === 1 || fadeIn === 0;
+
+			// If they are or the fade out animation is further along than the
+			// fade in animation then mark the fade as completed for this tile
 			if ( ( fadeOutComplete && fadeInComplete ) || fadeOut >= fadeIn ) {
 
 				this.completeFade( object );

--- a/example/src/FadeManager.js
+++ b/example/src/FadeManager.js
@@ -345,7 +345,9 @@ export class FadeManager {
 
 			} );
 
-			if ( fadeOut === 1.0 || fadeOut >= fadeIn ) {
+			const fadeOutComplete = fadeOut === 1 || fadeOut === 0;
+			const fadeInComplete = fadeIn === 1 || fadeIn === 0;
+			if ( ( fadeOutComplete && fadeInComplete ) || fadeOut >= fadeIn ) {
 
 				this.completeFade( object );
 

--- a/example/src/FadeTilesRenderer.js
+++ b/example/src/FadeTilesRenderer.js
@@ -104,6 +104,12 @@ export const FadeTilesRendererMixin = base => class extends base {
 
 	}
 
+	get fadingTiles() {
+
+		return this._fadeManager.fadeCount;
+
+	}
+
 	constructor( ...args ) {
 
 		super( ...args );


### PR DESCRIPTION
Change the FadeTilesRenderer to remove fading tiles if they have completed both fade in and fade out animations (set to 0 or 1).

cc @AlaricBaraou 