### PR TITLE
adjust attributions in GoogleMapsTilesCredits

### DIFF
--- a/src/three/renderers/GoogleMapsTilesCredits.js
+++ b/src/three/renderers/GoogleMapsTilesCredits.js
@@ -53,6 +53,7 @@ export class GoogleMapsTilesCredits {
 
 		} );
 
+		// attribution guidelines: https://developers.google.com/maps/documentation/tile/create-renderer#display-attributions
 		return sortedByCount.map( pair => pair[ 0 ] ).join( '; ' );
 
 	}

--- a/src/three/renderers/GoogleMapsTilesCredits.js
+++ b/src/three/renderers/GoogleMapsTilesCredits.js
@@ -45,6 +45,8 @@ export class GoogleMapsTilesCredits {
 
 	toString() {
 
+		// attribution guidelines: https://developers.google.com/maps/documentation/tile/create-renderer#display-attributions
+		
 		const sortedByCount = Object.entries( this.creditsCount ).sort( ( a, b ) => {
 
 			const countA = a[ 1 ];
@@ -53,7 +55,6 @@ export class GoogleMapsTilesCredits {
 
 		} );
 
-		// attribution guidelines: https://developers.google.com/maps/documentation/tile/create-renderer#display-attributions
 		return sortedByCount.map( pair => pair[ 0 ] ).join( '; ' );
 
 	}

--- a/src/three/renderers/GoogleMapsTilesCredits.js
+++ b/src/three/renderers/GoogleMapsTilesCredits.js
@@ -46,8 +46,8 @@ export class GoogleMapsTilesCredits {
 	toString() {
 
 		const sortedByCount = Object.entries( this.creditsCount ).sort( ( a, b ) => {
-			const countA = a[1];
-			const countB = b[1];
+			const countA = a[ 1 ];
+			const countB = b[ 1 ];
 			return countB - countA; // Descending order
 		} );
 

--- a/src/three/renderers/GoogleMapsTilesCredits.js
+++ b/src/three/renderers/GoogleMapsTilesCredits.js
@@ -46,7 +46,7 @@ export class GoogleMapsTilesCredits {
 	toString() {
 
 		// attribution guidelines: https://developers.google.com/maps/documentation/tile/create-renderer#display-attributions
-		
+
 		const sortedByCount = Object.entries( this.creditsCount ).sort( ( a, b ) => {
 
 			const countA = a[ 1 ];

--- a/src/three/renderers/GoogleMapsTilesCredits.js
+++ b/src/three/renderers/GoogleMapsTilesCredits.js
@@ -46,11 +46,11 @@ export class GoogleMapsTilesCredits {
 	toString() {
 
 		const sortedByCount = Object.entries( this.creditsCount ).sort( ( a, b ) => {
-			
+
 			const countA = a[ 1 ];
 			const countB = b[ 1 ];
 			return countB - countA; // Descending order
-		
+
 		} );
 
 		return sortedByCount.map( pair => pair[ 0 ] ).join( '; ' );

--- a/src/three/renderers/GoogleMapsTilesCredits.js
+++ b/src/three/renderers/GoogleMapsTilesCredits.js
@@ -45,13 +45,13 @@ export class GoogleMapsTilesCredits {
 
 	toString() {
 
-		const sortedByCount = Object.entries(this.creditsCount).sort((a, b) => {
+		const sortedByCount = Object.entries( this.creditsCount ).sort( ( a, b ) => {
 			const countA = a[1];
 			const countB = b[1];
 			return countB - countA; // Descending order
-		});
+		} );
 
-		return sortedByCount.map(pair => pair[0]).join('; ');
+		return sortedByCount.map( pair => pair[0] ).join( '; ' );
 
 	}
 

--- a/src/three/renderers/GoogleMapsTilesCredits.js
+++ b/src/three/renderers/GoogleMapsTilesCredits.js
@@ -45,8 +45,13 @@ export class GoogleMapsTilesCredits {
 
 	toString() {
 
-		const tokens = Object.keys( this.creditsCount ).sort();
-		return tokens.join( ', ' );
+		const sortedByCount = Object.entries(this.creditsCount).sort((a, b) => {
+			const countA = a[1];
+			const countB = b[1];
+			return countB - countA; // Descending order
+		});
+
+		return sortedByCount.map(pair => pair[0]).join('; ');
 
 	}
 

--- a/src/three/renderers/GoogleMapsTilesCredits.js
+++ b/src/three/renderers/GoogleMapsTilesCredits.js
@@ -46,12 +46,14 @@ export class GoogleMapsTilesCredits {
 	toString() {
 
 		const sortedByCount = Object.entries( this.creditsCount ).sort( ( a, b ) => {
+			
 			const countA = a[ 1 ];
 			const countB = b[ 1 ];
 			return countB - countA; // Descending order
+		
 		} );
 
-		return sortedByCount.map( pair => pair[0] ).join( '; ' );
+		return sortedByCount.map( pair => pair[ 0 ] ).join( '; ' );
 
 	}
 


### PR DESCRIPTION
https://developers.google.com/maps/documentation/tile/create-renderer#display-attributions

As it seems it is required to display the attributions sorted by the number of occurences. Additionally multiple attributions should be seperated by semicolon