### PR TITLE
Fix memory leak when loading texture with ImageBitmap

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -765,6 +765,13 @@ export class TilesRenderer extends TilesRendererBase {
 			for ( let i = 0, l = textures.length; i < l; i ++ ) {
 
 				const texture = textures[ i ];
+
+				if ( texture.image instanceof ImageBitmap ) {
+
+					texture.image.close();
+
+				}
+
 				texture.dispose();
 
 			}


### PR DESCRIPTION
During rendering large-scale 3DTiles with high resolution textures, we identified a memory leak problem. When continuously loading new tiles, memory usage would constantly increase without being released. And the browser will crash after console reported the error `Couldn't load texture blob: http://xxx`
<img width="345" alt="image" src="https://github.com/NASA-AMMOS/3DTilesRendererJS/assets/19679189/16ce8777-bc65-4f64-ae49-260c5a6813e9">


I found that it cause by GLTFLoader loaded textures with ImageBitmap and did not close or dispose it when tiles be disposed. https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/GLTFLoader.js#L2547


After this fix, I have tested that the memory won't increase endlessly. It will reach the top when geometry and textures in scene maintain in a reasonable value.


related issue: https://github.com/mrdoob/three.js/issues/23953