### PR TITLE
WIP: Add support for custom fetch functions

### DIFF
--- a/src/base/I3DMLoaderBase.js
+++ b/src/base/I3DMLoaderBase.js
@@ -84,7 +84,7 @@ export class I3DMLoaderBase extends LoaderBase {
 		} else {
 
 			const externalUri = this.resolveExternalURL( arrayToString( bodyBytes ) );
-			promise = fetch( externalUri, this.fetchOptions )
+			promise = this.fetcher( externalUri, this.fetchOptions )
 				.then( res => {
 
 					if ( ! res.ok ) {

--- a/src/base/LoaderBase.d.ts
+++ b/src/base/LoaderBase.d.ts
@@ -6,5 +6,9 @@ export class LoaderBase {
 	resolveExternalURL( url: string ): string;
 	workingPathForURL( url: string ): string
 	parse( buffer: ArrayBuffer ): Promise< any >;
+	fetcher( 
+		input: string | URL,
+		init?: RequestInit
+	): Promise<Response>;
 
 }

--- a/src/base/LoaderBase.js
+++ b/src/base/LoaderBase.js
@@ -3,13 +3,14 @@ export class LoaderBase {
 	constructor() {
 
 		this.fetchOptions = {};
+		this.fetcher = ( url, options ) => fetch( url, options );
 		this.workingPath = '';
 
 	}
 
 	load( url ) {
 
-		return fetch( url, this.fetchOptions )
+		return this.fetcher( url, this.fetchOptions )
 			.then( res => {
 
 				if ( ! res.ok ) {

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -14,6 +14,10 @@ export class TilesRendererBase {
 	stopAtEmptyTiles : Boolean;
 
 	fetchOptions : RequestInit;
+	fetcher( 
+		input: string | URL,
+		init?: RequestInit
+	): Promise<Response>;
 	/** function to preprocess the url for each individual tile */
 	preprocessURL : ((uri: string | URL) => string) | null;
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -82,6 +82,7 @@ export class TilesRendererBase {
 		this.tileSets = {};
 		this.rootURL = url;
 		this.fetchOptions = {};
+		this.fetcher = ( url, options ) => fetch( url, options );
 
 		this.preprocessURL = null;
 
@@ -340,7 +341,7 @@ export class TilesRendererBase {
 	// Private Functions
 	fetchTileSet( url, fetchOptions, parent = null ) {
 
-		return fetch( url, fetchOptions )
+		return this.fetcher( url, fetchOptions )
 			.then( res => {
 
 				if ( res.ok ) {
@@ -561,7 +562,7 @@ export class TilesRendererBase {
 				}
 
 				const uri = this.preprocessURL ? this.preprocessURL( downloadTile.content.uri ) : downloadTile.content.uri;
-				return fetch( uri, Object.assign( { signal }, this.fetchOptions ) );
+				return this.fetcher( uri, Object.assign( { signal }, this.fetchOptions ) );
 
 			} )
 				.then( res => {

--- a/src/three/CMPTLoader.js
+++ b/src/three/CMPTLoader.js
@@ -32,6 +32,7 @@ export class CMPTLoader extends CMPTLoaderBase {
 					const loader = new B3DMLoader( manager );
 					loader.workingPath = this.workingPath;
 					loader.fetchOptions = this.fetchOptions;
+					loader.fetcher = this.fetcher;
 
 					loader.adjustmentTransform.copy( adjustmentTransform );
 
@@ -47,6 +48,7 @@ export class CMPTLoader extends CMPTLoaderBase {
 					const loader = new PNTSLoader( manager );
 					loader.workingPath = this.workingPath;
 					loader.fetchOptions = this.fetchOptions;
+					loader.fetcher = this.fetcher;
 					const promise = loader.parse( slicedBuffer.buffer );
 					promises.push( promise );
 					break;
@@ -59,6 +61,7 @@ export class CMPTLoader extends CMPTLoaderBase {
 					const loader = new I3DMLoader( manager );
 					loader.workingPath = this.workingPath;
 					loader.fetchOptions = this.fetchOptions;
+					loader.fetcher = this.fetcher;
 
 					loader.adjustmentTransform.copy( adjustmentTransform );
 

--- a/src/three/renderers/CesiumIonTilesRenderer.js
+++ b/src/three/renderers/CesiumIonTilesRenderer.js
@@ -38,7 +38,7 @@ const CesiumIonTilesRendererMixin = base => class extends base {
 			const url = new URL( `https://api.cesium.com/v1/assets/${ this._ionAssetId }/endpoint` );
 			url.searchParams.append( 'access_token', this._ionAccessToken );
 
-			fetch( url, { mode: 'cors' } ).then( res => {
+			this.fetcher( url, { mode: 'cors' } ).then( res => {
 
 				if ( res.ok ) {
 


### PR DESCRIPTION
This PR adds support for replacing the current `fetch()` calls with a custom fetch function. This support is realized via a new `fetcher` property in the `LoaderBase` and `TilesRendererBase` classes. The ability to use a custom fetch function is useful in projects that already use e.g. Angular's `HttpClient` with `HttpInterceptors` for fetching resources.