### PR TITLE
Make pointer tracker handle different canvas positions and sizes

### DIFF
--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -83,7 +83,7 @@ export class EnvironmentControls extends EventDispatcher {
 		this.adjustHeight = true;
 
 		// internal state
-		this.pointerTracker = new PointerTracker();
+		this.pointerTracker = new PointerTracker( domElement );
 		this.needsUpdate = false;
 		this.actionHeightOffset = 0;
 
@@ -141,6 +141,7 @@ export class EnvironmentControls extends EventDispatcher {
 		// set the touch action to none so the browser does not
 		// drag the page to refresh or scroll
 		this.domElement = domElement;
+		this.pointerTracker.domElement = domElement;
 		domElement.style.touchAction = 'none';
 
 		let shiftClicked = false;

--- a/src/three/controls/PointerTracker.js
+++ b/src/three/controls/PointerTracker.js
@@ -2,8 +2,9 @@ import { Vector2 } from 'three';
 
 export class PointerTracker {
 
-	constructor() {
+	constructor( domElement ) {
 
+		this.domElement = domElement;
 		this.buttons = 0;
 		this.pointerType = null;
 		this.pointerOrder = [];
@@ -76,21 +77,21 @@ export class PointerTracker {
 	}
 
 	// get the pointer position in the coordinate system of the target element
-	getAdjustedPointer( e ) {
+	getAdjustedPointer( e, target ) {
 
-		const rect = e.target.getBoundingClientRect();
+		const domRef = this.domElement ? this.domElement : e.target;
+		const rect = domRef.getBoundingClientRect();
 		const x = e.clientX - rect.left;
 		const y = e.clientY - rect.top;
-		return { x, y };
+		target.set( x, y );
 
 	}
 
 	addPointer( e ) {
 
-		const { x, y } = this.getAdjustedPointer( e );
-
 		const id = e.pointerId;
-		const position = new Vector2( x, y );
+		const position = new Vector2();
+		this.getAdjustedPointer( e, position );
 		this.pointerOrder.push( id );
 		this.pointerPositions[ id ] = position;
 		this.previousPositions[ id ] = position.clone();
@@ -107,7 +108,6 @@ export class PointerTracker {
 
 	updatePointer( e ) {
 
-		const { x, y } = this.getAdjustedPointer( e );
 		const id = e.pointerId;
 		if ( ! ( id in this.pointerPositions ) ) {
 
@@ -115,7 +115,7 @@ export class PointerTracker {
 
 		}
 
-		this.pointerPositions[ id ].set( x, y );
+		this.getAdjustedPointer( e, this.pointerPositions[ id ] );
 		return true;
 
 	}

--- a/src/three/controls/PointerTracker.js
+++ b/src/three/controls/PointerTracker.js
@@ -75,10 +75,22 @@ export class PointerTracker {
 
 	}
 
+	// get the pointer position in the coordinate system of the target element
+	getAdjustedPointer( e ) {
+
+		const rect = e.target.getBoundingClientRect();
+		const x = e.clientX - rect.left;
+		const y = e.clientY - rect.top;
+		return { x, y };
+
+	}
+
 	addPointer( e ) {
 
+		const { x, y } = this.getAdjustedPointer( e );
+
 		const id = e.pointerId;
-		const position = new Vector2( e.clientX, e.clientY );
+		const position = new Vector2( x, y );
 		this.pointerOrder.push( id );
 		this.pointerPositions[ id ] = position;
 		this.previousPositions[ id ] = position.clone();
@@ -95,6 +107,7 @@ export class PointerTracker {
 
 	updatePointer( e ) {
 
+		const { x, y } = this.getAdjustedPointer( e );
 		const id = e.pointerId;
 		if ( ! ( id in this.pointerPositions ) ) {
 
@@ -102,7 +115,7 @@ export class PointerTracker {
 
 		}
 
-		this.pointerPositions[ id ].set( e.clientX, e.clientY );
+		this.pointerPositions[ id ].set( x, y );
 		return true;
 
 	}


### PR DESCRIPTION
In the case of a canvas non aligned on the top-left corner of the viewport the previous pointer tracker would end up with wrong positions.

This PR fix this.

There might be room for minor adjustments by trying to avoid calling getBoundingClientRect each time but optimising it by caching it might cause bugs in app with unusual canvas resize / reposition events. 