### PR TITLE
GlobeControls: Apply a minimum elevation

### DIFF
--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -25,6 +25,7 @@ const _pointer = new Vector2();
 const _prevPointer = new Vector2();
 const _deltaPointer = new Vector2();
 
+const MIN_ELEVATION = 10;
 const MAX_GLOBE_DISTANCE = 2 * 1e7;
 const GLOBE_TRANSITION_THRESHOLD = 0.75 * 1e7;
 export class GlobeControls extends EnvironmentControls {
@@ -164,12 +165,10 @@ export class GlobeControls extends EnvironmentControls {
 		const invMatrix = _invMatrix.copy( tilesGroup.matrixWorld ).invert();
 		_pos.copy( camera.position ).applyMatrix4( invMatrix );
 		ellipsoid.getPositionToCartographic( _pos, _latLon );
-		const elevation = ellipsoid.getPositionElevation( _pos );
 
-		// due to the level of precision of the tiles / sphere
-		// we can get an elevation that will be higher than the actual elevation.
-		// when we end up below the surface of the ellipsoid the elevation is returned as positive instead of negative
-		// resulting in a horizon distance that is too large.
+		// use a minimum elevation for computing the horizon distance to avoid the far clip
+		// plane approaching zero as the camera goes to or below sea level.
+		const elevation = Math.max( ellipsoid.getPositionElevation( _pos ), MIN_ELEVATION );
 		const horizonDistance = ellipsoid.calculateHorizonDistance( _latLon.lat, elevation );
 		camera.far = horizonDistance + 0.1;
 

--- a/src/three/math/Ellipsoid.js
+++ b/src/three/math/Ellipsoid.js
@@ -227,11 +227,10 @@ export class Ellipsoid {
 
 	getPositionElevation( pos ) {
 
-		this.getPositionToSurfacePoint( pos, _vec3 );
+		this.getPositionToSurfacePoint( pos, _vec );
 
-		const elevation = _vec3.distanceTo( pos );
-
-		return elevation;
+		const heightDelta = _vec2.subVectors( pos, _vec );
+		return Math.sign( heightDelta.dot( pos ) ) * heightDelta.length();
 
 	}
 

--- a/src/three/math/Ellipsoid.js
+++ b/src/three/math/Ellipsoid.js
@@ -227,6 +227,7 @@ export class Ellipsoid {
 
 	getPositionElevation( pos ) {
 
+		// logic from "getPositionToCartographic"
 		this.getPositionToSurfacePoint( pos, _vec );
 
 		const heightDelta = _vec2.subVectors( pos, _vec );

--- a/test/Ellipsoid.test.js
+++ b/test/Ellipsoid.test.js
@@ -196,15 +196,15 @@ describe( 'Ellipsoid', () => {
 
 		const northPos100 = new Vector3( 0, 0, WGS84_HEIGHT + 100 );
 		expect( wgsEllipse.getPositionElevation( northPos100 ) ).toBeCloseTo( 100, 1e-6 );
-		const southPos100 = new Vector3( 0, 0, - WGS84_HEIGHT + 100 );
+		const southPos100 = new Vector3( 0, 0, - WGS84_HEIGHT - 100 );
 		expect( wgsEllipse.getPositionElevation( southPos100 ) ).toBeCloseTo( 100, 1e-6 );
 		const xPos100 = new Vector3( WGS84_RADIUS + 100, 0, 0 );
 		expect( wgsEllipse.getPositionElevation( xPos100 ) ).toBeCloseTo( 100, 1e-6 );
-		const mxPos100 = new Vector3( - WGS84_RADIUS + 100, 0, 0 );
+		const mxPos100 = new Vector3( - WGS84_RADIUS - 100, 0, 0 );
 		expect( wgsEllipse.getPositionElevation( mxPos100 ) ).toBeCloseTo( 100, 1e-6 );
 		const zPos100 = new Vector3( 0, WGS84_RADIUS + 100, 0 );
 		expect( wgsEllipse.getPositionElevation( zPos100 ) ).toBeCloseTo( 100, 1e-6 );
-		const mzPos100 = new Vector3( 0, - WGS84_RADIUS + 100, 0 );
+		const mzPos100 = new Vector3( 0, - WGS84_RADIUS - 100, 0 );
 		expect( wgsEllipse.getPositionElevation( mzPos100 ) ).toBeCloseTo( 100, 1e-6 );
 
 	} );


### PR DESCRIPTION
Fix #486 
Fix #507

- Use a minimum elevation in GlobeControls to compute far clip plane.
- Enable `getPositionElevation` to return a negative value.

cc @AlaricBaraou 