### PR TITLE
Added `loaderMap` property on `TilesRenderer` class to enable using custom loaders for tile formats

### DIFF
--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -3,6 +3,7 @@ import { Tile } from '../base/Tile';
 import { Tileset } from '../base/Tileset';
 import { TilesRendererBase } from '../base/TilesRendererBase';
 import { TilesGroup } from './TilesGroup';
+import { LoaderBase } from '../base/LoaderBase';
 
 export class TilesRenderer extends TilesRendererBase {
 
@@ -10,6 +11,8 @@ export class TilesRenderer extends TilesRendererBase {
 	optimizeRaycast : Boolean;
 
 	manager : LoadingManager;
+
+	loaderMap: Map<string, LoaderBase>; 
 
 	group : TilesGroup;
 


### PR DESCRIPTION
#508 

I didn't go the `LoadingManager.getHandler` solution, since `B3DMLoader` and other tile format loaders aren't inherited from three.js' `Loader` class. It would at least cause ts errors for the library users.

Instead, a property called `loaderMap` is added to the `TilesRenderer` class to define which loader should be used for each format.

```js
const tilesRenderer = new TilesRenderer( './path/to/tileset.json' );
tilesRenderer.loaderMap.set('b3dm', new YourCustomB3DMLoader(tilesRenderer.manager));
tilesRenderer.setCamera( camera );
tilesRenderer.setResolutionFromRenderer( camera, renderer );
scene.add( tilesRenderer.group );
```
@gkjohnson how do you like it?