### PR TITLE
EnvironmentControls updates

### DIFF
--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -378,6 +378,14 @@ export class EnvironmentControls extends EventDispatcher {
 
 			e.preventDefault();
 
+			const { pointerTracker } = this;
+			pointerTracker.setHoverEvent( e );
+			if ( ! pointerTracker.updatePointer( e ) ) {
+
+				return;
+
+			}
+
 			this.dispatchEvent( _startEvent );
 
 			let delta;

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -104,7 +104,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 		this.zoomDirectionSet = false;
 		this.zoomPointSet = false;
-		this.zoomDirection = this.pivotDirection;
+		this.zoomDirection = new Vector3();
 		this.zoomPoint = this.pivotPoint;
 		this.zoomDelta = 0;
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -949,6 +949,19 @@ export class EnvironmentControls extends EventDispatcher {
 
 	}
 
+	_raycastAtMousePosition( coords, raycaster ) {
+
+		const camera = this.camera;
+		const ray = raycaster.ray;
+		ray.origin.setFromMatrixPosition( camera.matrixWorld );
+		ray.origin.set( coords.x, coords.y, - 1 ).unproject( camera );
+		ray.direction.set( coords.x, coords.y, 0.5 ).unproject( camera ).sub( ray.origin ).normalize();
+		raycaster.camera = camera;
+
+		return this._raycast( raycaster );
+
+	}
+
 	_raycast( raycaster ) {
 
 		const { scene, useFallbackPlane, fallbackPlane } = this;

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -222,8 +222,7 @@ export class EnvironmentControls extends EventDispatcher {
 			mouseToCoords( _pointer.x, _pointer.y, domElement, _pointer );
 
 			// find the hit point
-			raycaster.setFromCamera( _pointer, camera );
-			const hit = this._raycast( raycaster );
+			const hit = this._raycastAtMousePosition( _pointer, raycaster );
 			if ( hit ) {
 
 				// if two fingers, right click, or shift click are being used then we trigger
@@ -951,6 +950,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 	_raycastAtMousePosition( coords, raycaster ) {
 
+		// position the ray for the raycaster at the near clip plane
 		const camera = this.camera;
 		const ray = raycaster.ray;
 		ray.origin.setFromMatrixPosition( camera.matrixWorld );

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -93,16 +93,19 @@ export class EnvironmentControls extends EventDispatcher {
 		this.needsUpdate = false;
 		this.actionHeightOffset = 0;
 
+		this.pivotPoint = new Vector3();
+		this.pivotDirection = new Vector3();
+
 		this.dragPointSet = false;
-		this.dragPoint = new Vector3();
+		this.dragPoint = this.pivotPoint;
 
 		this.rotationPointSet = false;
-		this.rotationPoint = new Vector3();
+		this.rotationPoint = this.pivotPoint;
 
 		this.zoomDirectionSet = false;
 		this.zoomPointSet = false;
-		this.zoomDirection = new Vector3();
-		this.zoomPoint = new Vector3();
+		this.zoomDirection = this.pivotDirection;
+		this.zoomPoint = this.pivotPoint;
 		this.zoomDelta = 0;
 
 		this.pivotMesh = new PivotPointMesh();

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -100,7 +100,7 @@ export class EnvironmentControls extends EventDispatcher {
 		this.zoomDirectionSet = false;
 		this.zoomPointSet = false;
 		this.zoomDirection = new Vector3();
-		this.zoomPoint = this.pivotPoint;
+		this.zoomPoint = new Vector3();
 		this.zoomDelta = 0;
 
 		this.pivotMesh = new PivotPointMesh();
@@ -377,11 +377,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 			const { pointerTracker } = this;
 			pointerTracker.setHoverEvent( e );
-			if ( ! pointerTracker.updatePointer( e ) ) {
-
-				return;
-
-			}
+			pointerTracker.updatePointer( e );
 
 			this.dispatchEvent( _startEvent );
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -94,7 +94,6 @@ export class EnvironmentControls extends EventDispatcher {
 		this.actionHeightOffset = 0;
 
 		// pivot point for drag and rotation
-		this.pivotPointSet = false;
 		this.pivotPoint = new Vector3();
 
 		this.zoomDirectionSet = false;
@@ -184,7 +183,6 @@ export class EnvironmentControls extends EventDispatcher {
 			e.preventDefault();
 
 			const {
-				camera,
 				raycaster,
 				domElement,
 				up,
@@ -233,7 +231,6 @@ export class EnvironmentControls extends EventDispatcher {
 
 					this.setState( ROTATE );
 					this.pivotPoint.copy( hit.point );
-					this.pivotPointSet = true;
 
 					this.pivotMesh.position.copy( hit.point );
 					this.pivotMesh.updateMatrixWorld();
@@ -246,7 +243,6 @@ export class EnvironmentControls extends EventDispatcher {
 
 						this.setState( DRAG );
 						this.pivotPoint.copy( hit.point );
-						this.pivotPointSet = true;
 
 						this.pivotMesh.position.copy( hit.point );
 						this.pivotMesh.updateMatrixWorld();
@@ -484,8 +480,6 @@ export class EnvironmentControls extends EventDispatcher {
 
 		this.state = NONE;
 		this.pinchState = NONE;
-		this.pivotPointSet = false;
-		this.pivotPointSet = false;
 		this.scene.remove( this.pivotMesh );
 		this.pivotMesh.visible = true;
 		this.actionHeightOffset = 0;

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -455,6 +455,15 @@ export class EnvironmentControls extends EventDispatcher {
 
 	}
 
+	getLastInteractionPoint( target ) {
+
+		// TODO: Ensure are handling the last zoom point if possible
+		// TODO: Return null (or get center point?) if it can't be provided
+
+		return target.copy( this.pivotPoint );
+
+	}
+
 	detach() {
 
 		this.domElement = null;

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -318,9 +318,15 @@ export class GlobeControls extends EnvironmentControls {
 			// zoom the camera
 			const normalizedDelta = Math.pow( 0.95, Math.abs( zoomDelta * 0.05 ) );
 			const scaleFactor = zoomDelta > 0 ? 1 / Math.abs( normalizedDelta ) : normalizedDelta;
+			const maxDiameter = 2.0 * Math.max( ...this.ellipsoid.radius );
+			const minZoom = Math.min( camera.right - camera.left, camera.top - camera.bottom ) / maxDiameter;
 
-			camera.zoom = camera.zoom * scaleFactor * zoomSpeed;
+			camera.zoom = Math.max( 0.75 * minZoom, camera.zoom * scaleFactor * zoomSpeed );
 			camera.updateProjectionMatrix();
+
+			const alpha = MathUtils.mapLinear( camera.zoom, minZoom, minZoom * 0.75, 0, 1 );
+			this._tiltTowardsCenter( MathUtils.lerp( 1, 0.8, alpha ) );
+			this._alignCameraUpToNorth( MathUtils.lerp( 1, 0.9, alpha ) );
 
 			this.zoomDelta = 0;
 
@@ -399,15 +405,13 @@ export class GlobeControls extends EnvironmentControls {
 	_isDistantControls() {
 
 		const { camera, ellipsoid } = this;
-		const maxRadius = Math.max( ...ellipsoid.radius );
+		const maxDiameter = 2.0 * Math.max( ...ellipsoid.radius );
 
 		let isFullyInView = false;
 		if ( camera.isOrthographicCamera ) {
 
 			const maxView = Math.min( camera.right - camera.left, camera.top - camera.bottom ) / camera.zoom;
-			isFullyInView = maxRadius > maxView;
-
-			console.log( maxRadius, maxView );
+			isFullyInView = maxDiameter > maxView;
 
 		} else {
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -256,7 +256,7 @@ export class GlobeControls extends EnvironmentControls {
 			pointerTracker.getPreviousCenterPoint( _prevPointer );
 			_deltaPointer
 				.subVectors( _pointer, _prevPointer )
-				.multiplyScalar( camera.position.distanceTo( pivotPoint ) * 1e-9 / devicePixelRatio );
+				.multiplyScalar( camera.position.distanceTo( pivotPoint ) * 5 * 1e-10 / devicePixelRatio );
 
 			const azimuth = - _deltaPointer.x * rotationSpeed;
 			const altitude = - _deltaPointer.y * rotationSpeed;

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -222,7 +222,7 @@ export class GlobeControls extends EnvironmentControls {
 				rotationSpeed,
 				camera,
 				pivotMesh,
-				dragPoint,
+				pivotPoint,
 				tilesGroup,
 			} = this;
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -202,6 +202,19 @@ export class GlobeControls extends EnvironmentControls {
 		const horizonDistance = ellipsoid.calculateHorizonDistance( _latLon.lat, elevation );
 		camera.far = horizonDistance + 0.1;
 
+
+
+		if ( camera.isOrthographicCamera ) {
+
+			_invMatrix.copy( camera.matrixWorld ).invert();
+
+			const v = new Vector3().setFromMatrixPosition( this.tilesGroup.matrixWorld ).applyMatrix4( _invMatrix );
+
+			camera.near = - Math.max( ...this.ellipsoid.radius );
+			camera.far = - v.z;
+
+		}
+
 		camera.updateProjectionMatrix();
 
 	}
@@ -327,9 +340,13 @@ export class GlobeControls extends EnvironmentControls {
 				camera.updateProjectionMatrix();
 
 				let alpha = MathUtils.mapLinear( camera.zoom, minZoom * 1.25, minZoom * 0.75, 0, 1 );
-				alpha = MathUtils.clamp( alpha, 0, 1 );
-				this._tiltTowardsCenter( MathUtils.lerp( 1, 0.8, alpha ) );
-				this._alignCameraUpToNorth( MathUtils.lerp( 1, 0.9, alpha ) );
+				if ( alpha > 0 ) {
+
+					alpha = MathUtils.clamp( alpha, 0, 1 );
+					this._tiltTowardsCenter( MathUtils.lerp( 1, 0.8, alpha ) );
+					this._alignCameraUpToNorth( MathUtils.lerp( 1, 0.9, alpha ) );
+
+				}
 
 				// this.zoomDelta = 0;
 
@@ -415,7 +432,7 @@ export class GlobeControls extends EnvironmentControls {
 		const maxDiameter = 2.0 * Math.max( ...ellipsoid.radius );
 
 		let isFullyInView = false;
-		if ( camera.isOrthographicCamera && false ) {
+		if ( camera.isOrthographicCamera ) {
 
 			const maxView = Math.min( camera.right - camera.left, camera.top - camera.bottom ) / camera.zoom;
 			isFullyInView = 0.5 * maxDiameter > maxView;


### PR DESCRIPTION
Related to #438 
Fix #530 

- Fix zoomed out rotation action scale
- Fix GlobeControls: Zooming out past threshold increases zoom speed

**TODO**
- Separate PR for simplification & polish, first
  - Simplify logic
  - Simplify use of zoom point where possible
  - Ensure actions scale based on pixel density
- Add function for retrieving the last interacted point
- The logic of the controls relies on positioning - see if we can fix that? Perhaps set the camera distance at a certain position based on zoom?