### PR TITLE
Minor optimizations (TextDecoder, queueMicrotask)

### DIFF
--- a/src/three/DebugTilesRenderer.js
+++ b/src/three/DebugTilesRenderer.js
@@ -95,7 +95,7 @@ export class DebugTilesRenderer extends TilesRenderer {
 			.then( () => {
 
 				// defer to after the loaded tileset has been initialized
-				Promise.resolve().then( () => {
+				queueMicrotask( () => {
 
 					this.initExtremes();
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -336,7 +336,7 @@ export class TilesRenderer extends TilesRendererBase {
 			// Push this onto the end of the event stack to ensure this runs
 			// after the base renderer has placed the provided json where it
 			// needs to be placed and is ready for an update.
-			Promise.resolve().then( () => {
+			queueMicrotask( () => {
 
 				this.dispatchEvent( {
 					type: 'load-tile-set',

--- a/src/three/gltf/MeshFeatures.js
+++ b/src/three/gltf/MeshFeatures.js
@@ -137,7 +137,7 @@ export class MeshFeatures {
 
 		} else {
 
-			return Promise.resolve().then( () => {
+			return queueMicrotask( () => {
 
 				return this.getFeatures( ...args );
 

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -1,10 +1,3 @@
-// Fires at the end of the frame and before the next one
-function enqueueMicrotask( callback ) {
-
-	Promise.resolve().then( callback );
-
-}
-
 class LRUCache {
 
 	constructor() {
@@ -174,7 +167,7 @@ class LRUCache {
 		if ( ! this.scheduled ) {
 
 			this.scheduled = true;
-			enqueueMicrotask( () => {
+			queueMicrotask( () => {
 
 				this.scheduled = false;
 				this.unloadUnusedContent();

--- a/src/utilities/arrayToString.js
+++ b/src/utilities/arrayToString.js
@@ -1,6 +1,7 @@
+const utf8decoder = new TextDecoder();
+
 export function arrayToString( array ) {
 
-	const utf8decoder = new TextDecoder();
 	return utf8decoder.decode( array );
 
 }


### PR DESCRIPTION
1) Replace `Promise.resolve().then(...)` with `queueMicrotask()`. 
(The queueMicrotask API has been implemented in all major browsers for 5-6 years now).
2) While profiling, I noticed a slight overhead when creating a new instance of `TextDecoder` for every tile while parsing the FeatureTable. Moving it out of the function scope completely eliminates its execution time when profiling.