### PR TITLE
TilesRenderer: Handle ending raycast traversal early

### DIFF
--- a/src/three/TilesGroup.js
+++ b/src/three/TilesGroup.js
@@ -16,7 +16,7 @@ export class TilesGroup extends Group {
 
 	raycast( raycaster, intersects ) {
 
-		// returning "true" ends raycasting traversal
+		// returning "true" ends raycast traversal
 		if ( this.tilesRenderer.optimizeRaycast ) {
 
 			this.tilesRenderer.raycast( raycaster, intersects );

--- a/src/three/TilesGroup.js
+++ b/src/three/TilesGroup.js
@@ -16,11 +16,15 @@ export class TilesGroup extends Group {
 
 	raycast( raycaster, intersects ) {
 
+		// returning "true" ends raycasting traversal
 		if ( this.tilesRenderer.optimizeRaycast ) {
 
 			this.tilesRenderer.raycast( raycaster, intersects );
+			return true;
 
 		}
+
+		return false;
 
 	}
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -694,21 +694,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 				} );
 
-			} else {
-
-				// We handle raycasting in a custom way so remove it from here
-				scene.traverse( c => {
-
-					const ogRaycast = c.raycast
-					c.raycast = ( ...args ) => {
-
-						ogRaycast.call( c, ...args );
-						// console.log('CUSTOM!');
-
-					};
-
-				} );
-
 			}
 
 			const materials = [];

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -11,6 +11,7 @@ import {
 	Vector2,
 	LoadingManager,
 	EventDispatcher,
+	REVISION,
 } from 'three';
 import { raycastTraverse, raycastTraverseFirstHit } from './raycastTraverse.js';
 import { readMagicBytes } from '../utilities/readMagicBytes.js';
@@ -92,18 +93,23 @@ export class TilesRenderer extends TilesRendererBase {
 		} );
 		this.manager = manager;
 
-		// Setting up the override raycasting function to be used by
-		// 3D objects created by this renderer
-		const tilesRenderer = this;
-		this._overridenRaycast = function ( raycaster, intersects ) {
+		// In three.js r165 and higher raycast traversal can be ended early
+		if ( REVISION < 165 ) {
 
-			if ( ! tilesRenderer.optimizeRaycast ) {
+			// Setting up the override raycasting function to be used by
+			// 3D objects created by this renderer
+			const tilesRenderer = this;
+			this._overridenRaycast = function ( raycaster, intersects ) {
 
-				Object.getPrototypeOf( this ).raycast.call( this, raycaster, intersects );
+				if ( ! tilesRenderer.optimizeRaycast ) {
 
-			}
+					Object.getPrototypeOf( this ).raycast.call( this, raycaster, intersects );
 
-		};
+				}
+
+			};
+
+		}
 
 	}
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -19,7 +19,7 @@ import { TileBoundingVolume } from './math/TileBoundingVolume.js';
 import { ExtendedFrustum } from './math/ExtendedFrustum.js';
 
 // In three.js r165 and higher raycast traversal can be ended early
-const OVERRIDE_RAYCAST = parseInt( REVISION ) < 165;
+const REVISION_165 = parseInt( REVISION ) < 165;
 const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
 const tempMat2 = new Matrix4();
@@ -95,7 +95,7 @@ export class TilesRenderer extends TilesRendererBase {
 		} );
 		this.manager = manager;
 
-		if ( OVERRIDE_RAYCAST ) {
+		if ( REVISION_165 ) {
 
 			// Setting up the override raycasting function to be used by
 			// 3D objects created by this renderer
@@ -685,7 +685,7 @@ export class TilesRenderer extends TilesRendererBase {
 			} );
 			updateFrustumCulled( scene, ! this.autoDisableRendererCulling );
 
-			if ( OVERRIDE_RAYCAST ) {
+			if ( REVISION_165 ) {
 
 				// We handle raycasting in a custom way so remove it from here
 				scene.traverse( c => {

--- a/src/three/gltf/MeshFeatures.js
+++ b/src/three/gltf/MeshFeatures.js
@@ -1,6 +1,8 @@
 import { ShaderMaterial, Vector2, Vector4, WebGLRenderTarget, WebGLRenderer, REVISION, Box2 } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 
+const REVISION_165 = parseInt( REVISION ) >= 165;
+
 // renderer and quad for rendering a single pixel
 const _renderer = new WebGLRenderer();
 const _quad = new FullScreenQuad( new ShaderMaterial( {
@@ -58,7 +60,7 @@ function getTextureCoordAttribute( geometry, index ) {
 // render target
 function renderPixelToTarget( texture, pixel, dstPixel, target ) {
 
-	if ( REVISION >= 165 ) {
+	if ( REVISION_165 ) {
 
 		_box.min.copy( pixel );
 		_box.max.copy( pixel );
@@ -134,7 +136,7 @@ export class MeshFeatures {
 	// performs texture data read back asynchronously
 	getFeaturesAsync( ...args ) {
 
-		if ( REVISION >= 165 ) {
+		if ( REVISION_165 ) {
 
 			this._asyncRead = true;
 			const result = this.getFeatures( ...args );

--- a/src/three/raycastTraverse.js
+++ b/src/three/raycastTraverse.js
@@ -1,7 +1,7 @@
 import { Matrix4, Ray, Vector3, REVISION } from 'three';
 
 // In three.js r165 and higher raycast traversal can be ended early
-const OVERRIDE_RAYCAST = parseInt( REVISION ) < 165;
+const REVISION_165 = parseInt( REVISION ) < 165;
 const _mat = new Matrix4();
 const _localRay = new Ray();
 const _vec = new Vector3();
@@ -15,7 +15,7 @@ function distanceSort( a, b ) {
 
 function intersectTileScene( scene, raycaster, intersects ) {
 
-	if ( OVERRIDE_RAYCAST ) {
+	if ( REVISION_165 ) {
 
 		// Don't intersect the box3 helpers because those are used for debugging
 		scene.traverse( c => {

--- a/src/three/raycastTraverse.js
+++ b/src/three/raycastTraverse.js
@@ -1,5 +1,7 @@
-import { Matrix4, Ray, Vector3 } from 'three';
+import { Matrix4, Ray, Vector3, REVISION } from 'three';
 
+// In three.js r165 and higher raycast traversal can be ended early
+const OVERRIDE_RAYCAST = parseInt( REVISION ) < 165;
 const _mat = new Matrix4();
 const _localRay = new Ray();
 const _vec = new Vector3();
@@ -13,20 +15,28 @@ function distanceSort( a, b ) {
 
 function intersectTileScene( scene, raycaster, intersects ) {
 
-	// Don't intersect the box3 helpers because those are used for debugging
-	scene.traverse( c => {
+	if ( OVERRIDE_RAYCAST ) {
 
-		// We set the default raycast function to empty so three.js doesn't automatically cast against it
-		Object.getPrototypeOf( c ).raycast.call( c, raycaster, intersects );
+		// Don't intersect the box3 helpers because those are used for debugging
+		scene.traverse( c => {
 
-	} );
+			// We set the default raycast function to empty so three.js doesn't automatically cast against it
+			Object.getPrototypeOf( c ).raycast.call( c, raycaster, intersects );
+
+		} );
+		_hitArray.sort( distanceSort );
+
+	} else {
+
+		raycaster.intersectObject( scene, true, intersects );
+
+	}
 
 }
 
 function intersectTileSceneFirstHist( scene, raycaster ) {
 
 	intersectTileScene( scene, raycaster, _hitArray );
-	_hitArray.sort( distanceSort );
 
 	const hit = _hitArray[ 0 ] || null;
 	_hitArray.length = 0;


### PR DESCRIPTION
Fix #416 
Related to https://github.com/mrdoob/three.js/pull/27709

If a three.js version greater than r165 then we can use the new ability to exit raycast traversal early (https://github.com/mrdoob/three.js/pull/27709) which will improve performance and allow for custom raycast functions.

Raycasting in an extreme case (close mesh, error target of 10) results in improvements from ~1.8-2.1ms to ~0.2ms for a raycast.

**TODO**
- Add a function for retrieving whether r165 has been used.

cc @AlaricBaraou 