### PR TITLE
Remove Matrix4.identity(), fix typo

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -484,10 +484,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 			}
 
-		} else {
-
-			transform.identity();
-
 		}
 
 		if ( parentTile ) {
@@ -529,7 +525,8 @@ export class TilesRenderer extends TilesRendererBase {
 
 			scene: null,
 			geometry: null,
-			material: null,
+			materials: null,
+			textures: null,
 
 		};
 
@@ -566,7 +563,6 @@ export class TilesRenderer extends TilesRendererBase {
 				break;
 
 			case 'z':
-				upAdjustment.identity();
 				break;
 
 		}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -562,9 +562,6 @@ export class TilesRenderer extends TilesRendererBase {
 				upAdjustment.makeRotationAxis( X_AXIS, Math.PI / 2 );
 				break;
 
-			case 'z':
-				break;
-
 		}
 
 		const fileType = ( readMagicBytes( buffer ) || extension ).toLowerCase();


### PR DESCRIPTION
1. Remove the call that resets the matrix to the identity matrix `Matrix4.identity()`, as the constructor initializes it by default.
2. Fix typo: `material` -> `materials`