### PR TITLE
Fix the camera jumping

### DIFF
--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -215,9 +215,18 @@ export class EnvironmentControls extends EventDispatcher {
 			// the "pointer" for zooming and rotating should be based on the center point
 			pointerTracker.getCenterPoint( _pointer );
 			mouseToCoords( _pointer.x, _pointer.y, domElement, _pointer );
+			raycaster.setFromCamera( _pointer, camera );
+
+			// prevent the drag distance from getting too severe by limiting the drag point
+			// to a reasonable angle and reasonable distance with the drag plane
+			const dot = - raycaster.ray.direction.dot( up );
+			if ( dot < DRAG_PLANE_THRESHOLD || dot < DRAG_UP_THRESHOLD ) {
+
+				return;
+
+			}
 
 			// find the hit point
-			raycaster.setFromCamera( _pointer, camera );
 			const hit = this._raycast( raycaster );
 			if ( hit ) {
 


### PR DESCRIPTION
Fix #556 

Fix the camera jumping to a new position when clicking terrain that's too far away.

cc @AlaricBaraou 