### PR TITLE
fix: const reassignment error in resolveDefault function

### DIFF
--- a/src/three/gltf/classes/PropertySetAccessor.js
+++ b/src/three/gltf/classes/PropertySetAccessor.js
@@ -191,7 +191,7 @@ export function resolveDefault( value, type, target = null ) {
 		if ( isMatrixType( type ) ) {
 
 			const elements = target.elements;
-			for ( const i = 0, l = elements.length; i < l; i ++ ) {
+			for ( let i = 0, l = elements.length; i < l; i ++ ) {
 
 				elements[ i ] = value[ i ];
 


### PR DESCRIPTION
## Description

In the file [src/three/gltf/classes/PropertySetAccessor.js](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/453db64ee26da92481ea90373204273c915aed64/src/three/gltf/classes/PropertySetAccessor.js), at line 194, in the `resolveDefault` function, the `for` loop variable `i` is incorrectly declared as `const`.

As it is currently written, it is not possible to reassign the `const` variable `i`, resulting in an error. Since `i` is incremented within the loop, it should be declared as `let` instead of `const`.