### PR TITLE
Add missing extension in import path

### DIFF
--- a/src/three/gltf/classes/StructualMetadata.js
+++ b/src/three/gltf/classes/StructualMetadata.js
@@ -1,7 +1,7 @@
 // TODO: there are cases where we create a Matrix or Vector, for example, and immediately
 // discard it due to how "noData" is handled
 
-import { PropertyAttributeAccessor } from './PropertyAttributeAccessor';
+import { PropertyAttributeAccessor } from './PropertyAttributeAccessor.js';
 import { PropertyTableAccessor } from './PropertyTableAccessor.js';
 import { PropertyTextureAccessor } from './PropertyTextureAccessor.js';
 


### PR DESCRIPTION
Add missing js extension in import path causing the following issue when using `3d-tiles-renderer` `0.3.33` in an external project:
```
ERROR in ./node_modules/3d-tiles-renderer/src/three/gltf/classes/StructualMetadata.js 4:0-72
Module not found: Error: Can't resolve './PropertyAttributeAccessor' in '/home/jailln/Documents/dev/itowns/node_modules/3d-tiles-renderer/src/three/gltf/classes'
Did you mean 'PropertyAttributeAccessor.js'?
BREAKING CHANGE: The request './PropertyAttributeAccessor' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
[...]
```

PS: Thanks for this great lib :slightly_smiling_face:  