### PR TITLE
Fix illegal re-assign of `const`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
 		"no-throw-literal": [
 			"error"
 		],
+		"no-const-assign": "error",
 		"prefer-const": [
 			"error",
 			{

--- a/src/three/loaders/gltf/metadata/utilities/ClassPropertyHelpers.js
+++ b/src/three/loaders/gltf/metadata/utilities/ClassPropertyHelpers.js
@@ -204,7 +204,7 @@ export function resolveDefaultElement( property, target = null ) {
 		if ( isMatrixType( type ) ) {
 
 			const elements = target.elements;
-			for ( const i = 0, l = elements.length; i < l; i ++ ) {
+			for ( let i = 0, l = elements.length; i < l; i ++ ) {
 
 				elements[ i ] = defaultValue[ i ];
 


### PR DESCRIPTION
Building `0.3.34` with ESBuild triggers some build failures:

```
> node_modules/3d-tiles-renderer/src/three/loaders/gltf/metadata/utilities/ClassPropertyHelpers.js:207:50: error: Cannot assign to "i" because it is a constant
```