### PR TITLE
Load cesium ion tileset right when available

### DIFF
--- a/src/three/renderers/CesiumIonTilesRenderer.js
+++ b/src/three/renderers/CesiumIonTilesRenderer.js
@@ -60,6 +60,8 @@ const CesiumIonTilesRendererMixin = base => class extends base {
 				this.rootURL = url;
 				this.fetchOptions.headers = this.fetchOptions.headers || {};
 				this.fetchOptions.headers.Authorization = `Bearer ${ json.accessToken }`;
+				// Actually load the tileset now that we got its url from the cesium ion server
+				super.update();
 
 			} ).catch( () => {
 


### PR DESCRIPTION
Load cesium ion tilesets directly after getting the url from the api instead of waiting for the next animation frame.

This is particularly useful in cases where render is triggered asynchronously (and not at each frame) in which case we ask for `TilesRenderer` `update` at init and then when `load-tile-set` and `load-model` are triggered.