### PR TITLE
OBB: Encapsulate ray functions into OBB class

### DIFF
--- a/src/three/math/OBB.js
+++ b/src/three/math/OBB.js
@@ -1,8 +1,9 @@
-import { Matrix4, Box3, Vector3, Plane } from 'three';
+import { Matrix4, Box3, Vector3, Plane, Ray } from 'three';
 
 const _worldMin = new Vector3();
 const _worldMax = new Vector3();
 const _norm = new Vector3();
+const _ray = new Ray();
 
 export class OBB {
 
@@ -40,6 +41,23 @@ export class OBB {
 	distanceToPoint( point ) {
 
 		return this.clampPoint( point, _norm ).distanceTo( point );
+
+	}
+
+	// returns boolean indicating whether the ray intersected the box
+	intersectsRay( ray ) {
+
+		_ray.copy( ray ).applyMatrix4( this.inverseTransform );
+		return _ray.intersectsBox( this.box );
+
+	}
+
+	// Sets "target" equal to the intersection point.
+	// Returns "null" if no intersection found.
+	intersectRay( ray, target ) {
+
+		_ray.copy( ray ).applyMatrix4( this.inverseTransform );
+		return _ray.intersectBox( this.box, target );
 
 	}
 

--- a/src/three/math/OBB.js
+++ b/src/three/math/OBB.js
@@ -44,7 +44,7 @@ export class OBB {
 
 	}
 
-	// returns boolean indicating whether the ray intersected the box
+	// returns boolean indicating whether the ray has intersected the obb
 	intersectsRay( ray ) {
 
 		_ray.copy( ray ).applyMatrix4( this.inverseTransform );
@@ -57,7 +57,16 @@ export class OBB {
 	intersectRay( ray, target ) {
 
 		_ray.copy( ray ).applyMatrix4( this.inverseTransform );
-		return _ray.intersectBox( this.box, target );
+		if ( _ray.intersectBox( this.box, target ) ) {
+
+			target.applyMatrix4( this.transform );
+			return target;
+
+		} else {
+
+			return null;
+
+		}
 
 	}
 

--- a/src/three/math/TileBoundingVolume.js
+++ b/src/three/math/TileBoundingVolume.js
@@ -65,8 +65,7 @@ export class TileBoundingVolume {
 
 		if ( obb ) {
 
-			// the obb transform contains no scale
-			if ( obb.intersectsRay( ray, _obbVec ) ) {
+			if ( obb.intersectRay( ray, _obbVec ) ) {
 
 				obbDistSq = obb.box.containsPoint( ray.origin ) ? 0 : ray.origin.distanceToSquared( _obbVec );
 

--- a/src/three/math/TileBoundingVolume.js
+++ b/src/three/math/TileBoundingVolume.js
@@ -1,4 +1,4 @@
-import { Ray, Vector3, Sphere } from 'three';
+import { Vector3, Sphere } from 'three';
 import { WGS84_RADIUS, WGS84_HEIGHT } from '../../base/constants.js';
 import { OBB } from './OBB.js';
 import { EllipsoidRegion } from './EllipsoidRegion.js';
@@ -6,10 +6,8 @@ import { EllipsoidRegion } from './EllipsoidRegion.js';
 const _vecX = new Vector3();
 const _vecY = new Vector3();
 const _vecZ = new Vector3();
-const _vec = new Vector3();
 const _sphereVec = new Vector3();
 const _obbVec = new Vector3();
-const _ray = new Ray();
 
 // TODO: check region more precisely in all functions
 export class TileBoundingVolume {
@@ -37,14 +35,9 @@ export class TileBoundingVolume {
 		}
 
 		// Early out if we don't this this tile box
-		if ( obb ) {
+		if ( obb && ! obb.intersectRay( ray ) ) {
 
-			_ray.copy( ray ).applyMatrix4( obb.inverseTransform );
-			if ( ! _ray.intersectsBox( obb.box ) ) {
-
-				return false;
-
-			}
+			return false;
 
 		}
 
@@ -73,10 +66,9 @@ export class TileBoundingVolume {
 		if ( obb ) {
 
 			// the obb transform contains no scale
-			_ray.copy( ray ).applyMatrix4( obb.inverseTransform );
-			if ( _ray.intersectBox( obb.box, _obbVec ) ) {
+			if ( obb.intersectsRay( ray, _obbVec ) ) {
 
-				obbDistSq = obb.box.containsPoint( _ray.origin ) ? 0 : _ray.origin.distanceToSquared( _obbVec );
+				obbDistSq = obb.box.containsPoint( ray.origin ) ? 0 : ray.origin.distanceToSquared( _obbVec );
 
 			}
 


### PR DESCRIPTION
In the interest of encapsulating some of the bounding volume logic like #623 - I've moved the ray intersection functions over onto the OBB class.

cc @Desplandis