### PR TITLE
Verify GLTFMeshFeaturesExtension is used before processing it

### DIFF
--- a/src/three/loaders/gltf/GLTFMeshFeaturesExtension.js
+++ b/src/three/loaders/gltf/GLTFMeshFeaturesExtension.js
@@ -37,6 +37,14 @@ export class GLTFMeshFeaturesExtension {
 
 	async afterRoot( { scene, parser } ) {
 
+		const extensions = parser.json.extensions;
+		const rootExtension = extensions && extensions[ EXT_NAME ];
+		if ( ! rootExtension ) {
+
+			return;
+
+		}
+
 		// get fetch the relevant textures are loaded
 		const textureCount = parser.json.textures?.length || 0;
 		const promises = new Array( textureCount ).fill( null );


### PR DESCRIPTION
Verify `GLTFMeshFeaturesExtension` is defined in the tileset extensions before trying to parse if (same check than in `GLTFStructuralMetadataExtension`).

Without this check, an error is raised if we register this extension on the `GLTFLoader` and load a tileset that doesn't have this extension:

```
TypeError: Cannot read properties of undefined (reading 'undefined')
    at GLTFMeshFeaturesExtension.js:15:1
    at Object3D.traverse (three.module.js:7682:1)
    at Group.traverse (three.module.js:7688:1)
    at forEachPrimitiveExtension (GLTFMeshFeaturesExtension.js:9:1)
    at GLTFMeshFeaturesExtension.afterRoot (GLTFMeshFeaturesExtension.js:43:1)
    at GLTFLoader.js:1591:1
    at GLTFParser._invokeAll (GLTFLoader.js:1686:1)
    at GLTFLoader.js:1590:1
```