### PR TITLE
[Batch table] `getDataForId` and `3DTILES_batch_table_hierarchy` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,12 +286,8 @@ if ( intersects.length ) {
 		// Log the batch data
 		const batchTable = batchTableObject.batchTable;
 		const hoveredBatchid = batchidAttr.getX( face.a );
-		const batchData = batchTable.getData( 'BatchTableKey' );
-		if ( batchData ) {
-
-			console.log( batchData[ hoveredBatchid ] );
-
-		}
+		const batchData = batchTable.getDataFromId( hoveredBatchid );
+		console.log( batchData );
 
 	}
 

--- a/example/b3dmExample.js
+++ b/example/b3dmExample.js
@@ -186,12 +186,13 @@ function onMouseMove( e ) {
 			// Log the batch data
 			const batchTable = batchTableObject.batchTable;
 			hoveredBatchid = batchidAttr.getX( face.a );
+			const batchData = batchTable.getDataFromId( hoveredBatchid );
 
 			infoEl.innerText =
 				`_batchid   : ${ hoveredBatchid }\n` +
-				`Latitude   : ${ batchTable.getData( 'Latitude' )[ hoveredBatchid ].toFixed( 3 ) }\n` +
-				`Longitude  : ${ batchTable.getData( 'Longitude' )[ hoveredBatchid ].toFixed( 3 ) }\n` +
-				`Height     : ${ batchTable.getData( 'Height' )[ hoveredBatchid ].toFixed( 3 ) }\n`;
+				`Latitude   : ${ batchData[ 'Latitude' ].toFixed( 3 ) }\n` +
+				`Longitude  : ${ batchData[ 'Longitude' ].toFixed( 3 ) }\n` +
+				`Height     : ${ batchData[ 'Height' ].toFixed( 3 ) }\n`;
 
 		}
 

--- a/example/b3dmExample.js
+++ b/example/b3dmExample.js
@@ -119,7 +119,7 @@ function init() {
 	scene.add( offsetGroup );
 
 	new B3DMLoader()
-		.loadAsync( 'https://raw.githubusercontent.com/CesiumGS/3d-tiles-samples/main/1.0/TilesetWithRequestVolume/city/lr.b3dm' )
+		.loadAsync( 'https://raw.githubusercontent.com/CesiumGS/cesium/main/Apps/SampleData/Cesium3DTiles/Hierarchy/BatchTableHierarchy/tile.b3dm' )
 		.then( res => {
 
 			console.log( res );
@@ -189,10 +189,22 @@ function onMouseMove( e ) {
 			const batchData = batchTable.getDataFromId( hoveredBatchid );
 
 			infoEl.innerText =
-				`_batchid   : ${ hoveredBatchid }\n` +
-				`Latitude   : ${ batchData[ 'Latitude' ].toFixed( 3 ) }\n` +
-				`Longitude  : ${ batchData[ 'Longitude' ].toFixed( 3 ) }\n` +
-				`Height     : ${ batchData[ 'Height' ].toFixed( 3 ) }\n`;
+				`_batchid : ${ hoveredBatchid }\n` +
+				`Area     : ${ batchData[ 'height' ].toFixed( 3 ) }\n` +
+				`Height   : ${ batchData[ 'height' ].toFixed( 3 ) }\n`;
+
+			const hierarchyData = batchData[ '3DTILES_batch_table_hierarchy' ];
+			for ( const className in hierarchyData ) {
+
+
+				for ( const instance in hierarchyData[ className ] ) {
+
+					infoEl.innerText +=
+						`${ instance } : ${ hierarchyData[ className ][ instance ] }\n`;
+
+				}
+
+			}
 
 		}
 

--- a/src/base/loaders/B3DMLoaderBase.d.ts
+++ b/src/base/loaders/B3DMLoaderBase.d.ts
@@ -1,4 +1,5 @@
-import { FeatureTable, BatchTable } from '../../utilities/FeatureTable';
+import { BatchTable } from '../../utilities/BatchTable';
+import { FeatureTable } from '../../utilities/FeatureTable';
 
 export interface B3DMBaseResult {
 

--- a/src/base/loaders/B3DMLoaderBase.js
+++ b/src/base/loaders/B3DMLoaderBase.js
@@ -1,7 +1,8 @@
 // B3DM File Format
 // https://github.com/CesiumGS/3d-tiles/blob/master/specification/TileFormats/Batched3DModel/README.md
 
-import { FeatureTable, BatchTable } from '../../utilities/FeatureTable.js';
+import { BatchTable } from '../../utilities/BatchTable.js';
+import { FeatureTable } from '../../utilities/FeatureTable.js';
 import { LoaderBase } from './LoaderBase.js';
 import { readMagicBytes } from '../../utilities/readMagicBytes.js';
 

--- a/src/base/loaders/I3DMLoaderBase.d.ts
+++ b/src/base/loaders/I3DMLoaderBase.d.ts
@@ -1,4 +1,5 @@
-import { FeatureTable, BatchTable } from '../../utilities/FeatureTable';
+import { BatchTable } from '../../utilities/BatchTable';
+import { FeatureTable } from '../../utilities/FeatureTable';
 
 export interface I3DMBaseResult {
 

--- a/src/base/loaders/I3DMLoaderBase.js
+++ b/src/base/loaders/I3DMLoaderBase.js
@@ -1,7 +1,8 @@
 // I3DM File Format
 // https://github.com/CesiumGS/3d-tiles/blob/master/specification/TileFormats/Instanced3DModel/README.md
 
-import { FeatureTable, BatchTable } from '../../utilities/FeatureTable.js';
+import { BatchTable } from '../../utilities/BatchTable.js';
+import { FeatureTable } from '../../utilities/FeatureTable.js';
 import { arrayToString } from '../../utilities/arrayToString.js';
 import { LoaderBase } from './LoaderBase.js';
 import { readMagicBytes } from '../../utilities/readMagicBytes.js';

--- a/src/base/loaders/PNTSLoaderBase.d.ts
+++ b/src/base/loaders/PNTSLoaderBase.d.ts
@@ -1,4 +1,5 @@
-import { FeatureTable, BatchTable } from '../../utilities/FeatureTable';
+import { BatchTable } from '../../utilities/BatchTable';
+import { FeatureTable } from '../../utilities/FeatureTable';
 
 export interface PNTSBaseResult {
 

--- a/src/base/loaders/PNTSLoaderBase.js
+++ b/src/base/loaders/PNTSLoaderBase.js
@@ -1,7 +1,8 @@
 // PNTS File Format
 // https://github.com/CesiumGS/3d-tiles/blob/master/specification/TileFormats/PointCloud/README.md
 
-import { FeatureTable, BatchTable } from '../../utilities/FeatureTable.js';
+import { BatchTable } from '../../utilities/BatchTable.js';
+import { FeatureTable } from '../../utilities/FeatureTable.js';
 import { readMagicBytes } from '../../utilities/readMagicBytes.js';
 import { LoaderBase } from './LoaderBase.js';
 

--- a/src/three/loaders/B3DMLoader.d.ts
+++ b/src/three/loaders/B3DMLoader.d.ts
@@ -1,5 +1,6 @@
 import { B3DMBaseResult } from '../../base/loaders/B3DMLoaderBase';
-import { FeatureTable, BatchTable } from '../../utilities/FeatureTable';
+import { BatchTable } from '../../utilities/BatchTable';
+import { FeatureTable } from '../../utilities/FeatureTable';
 import { LoadingManager, Group } from 'three';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 

--- a/src/three/loaders/I3DMLoader.d.ts
+++ b/src/three/loaders/I3DMLoader.d.ts
@@ -1,5 +1,6 @@
 import { I3DMBaseResult } from '../../base/loaders/I3DMLoaderBase';
-import { FeatureTable, BatchTable } from '../../utilities/FeatureTable';
+import { BatchTable } from '../../utilities/BatchTable';
+import { FeatureTable } from '../../utilities/FeatureTable';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { Group, LoadingManager } from 'three';
 

--- a/src/utilities/BatchTable.d.ts
+++ b/src/utilities/BatchTable.d.ts
@@ -10,10 +10,9 @@ export class BatchTable {
 
 	getKeys() : Array< String >;
 
-	getData(
-		key : String,
-		componentType : String | null,
-		type : String | null
-	) : Number | String | ArrayBufferView;
+	getDataFromId(
+		id: Number,
+		target?: Object
+	) : Object;
 
 }

--- a/src/utilities/BatchTable.d.ts
+++ b/src/utilities/BatchTable.d.ts
@@ -1,0 +1,19 @@
+export class BatchTable {
+
+	constructor(
+		buffer : ArrayBuffer,
+		batchSize : Number,
+		start : Number,
+		headerLength : Number,
+		binLength : Number
+	);
+
+	getKeys() : Array< String >;
+
+	getData(
+		key : String,
+		componentType : String | null,
+		type : String | null
+	) : Number | String | ArrayBufferView;
+
+}

--- a/src/utilities/BatchTable.js
+++ b/src/utilities/BatchTable.js
@@ -11,7 +11,30 @@ export class BatchTable extends FeatureTable {
 
 	getData( key, componentType = null, type = null ) {
 
+		console.warn( 'BatchTable: BatchTable.getData is deprecated. Use BatchTable.getDataFromId instead.' );
 		return super.getData( key, this.batchSize, componentType, type );
+
+	}
+
+	getDataFromId( id, target = {} ) {
+
+		if ( id < 0 || id >= this.batchSize ) {
+
+			throw new Error( `BatchTable: id value "${ id }" out of bounds for "${ this.batchSize }" features number.` );
+
+		}
+
+		for ( const key of this.getKeys() ) {
+
+			if ( key !== 'extensions' ) {
+
+				target[ key ] = super.getData( key, this.batchSize )[ id ];
+
+			}
+
+		}
+
+		return target;
 
 	}
 

--- a/src/utilities/BatchTable.js
+++ b/src/utilities/BatchTable.js
@@ -1,0 +1,18 @@
+import { FeatureTable } from './FeatureTable.js';
+
+export class BatchTable extends FeatureTable {
+
+	constructor( buffer, batchSize, start, headerLength, binLength ) {
+
+		super( buffer, start, headerLength, binLength );
+		this.batchSize = batchSize;
+
+	}
+
+	getData( key, componentType = null, type = null ) {
+
+		return super.getData( key, this.batchSize, componentType, type );
+
+	}
+
+}

--- a/src/utilities/BatchTable.js
+++ b/src/utilities/BatchTable.js
@@ -1,3 +1,4 @@
+import { BatchTableHierarchyExtension } from './BatchTableHierarchyExtension.js';
 import { FeatureTable } from './FeatureTable.js';
 
 export class BatchTable extends FeatureTable {
@@ -6,6 +7,18 @@ export class BatchTable extends FeatureTable {
 
 		super( buffer, start, headerLength, binLength );
 		this.batchSize = batchSize;
+
+		this.extensions = {};
+		const extensions = this.header.extensions;
+		if ( extensions ) {
+
+			if ( extensions[ '3DTILES_batch_table_hierarchy' ] ) {
+
+				this.extensions[ '3DTILES_batch_table_hierarchy' ] = new BatchTableHierarchyExtension( this );
+
+			}
+
+		}
 
 	}
 
@@ -29,6 +42,19 @@ export class BatchTable extends FeatureTable {
 			if ( key !== 'extensions' ) {
 
 				target[ key ] = super.getData( key, this.batchSize )[ id ];
+
+			}
+
+		}
+
+		for ( const extensionName in this.extensions ) {
+
+			const extension = this.extensions[ extensionName ];
+
+			if ( extension.getDataFromId instanceof Function ) {
+
+				target[ extensionName ] = target[ extensionName ] || {};
+				extension.getDataFromId( id, target[ extensionName ] );
 
 			}
 

--- a/src/utilities/BatchTableHierarchyExtension.js
+++ b/src/utilities/BatchTableHierarchyExtension.js
@@ -1,0 +1,127 @@
+import { parseBinArray } from './FeatureTable.js';
+
+export class BatchTableHierarchyExtension {
+
+	constructor( batchTable ) {
+
+		this.batchTable = batchTable;
+
+		const extensionHeader = batchTable.header.extensions[ '3DTILES_batch_table_hierarchy' ];
+
+		this.classes = extensionHeader.classes;
+		for ( const classDef of this.classes ) {
+
+			const instances = classDef.instances;
+			for ( const property in instances ) {
+
+				classDef.instances[ property ] = this._parseProperty( instances[ property ], classDef.length, property );
+
+			}
+
+		}
+
+		this.instancesLength = extensionHeader.instancesLength;
+
+		this.classIds = this._parseProperty( extensionHeader.classIds, this.instancesLength, 'classIds' );
+
+		if ( extensionHeader.parentCounts ) {
+
+			this.parentCounts = this._parseProperty( extensionHeader.parentCounts, this.instancesLength, 'parentCounts' );
+
+		} else {
+
+			this.parentCounts = new Array( this.instancesLength ).fill( 1 );
+
+		}
+
+		if ( extensionHeader.parentIds ) {
+
+			const parentIdsLength = this.parentCounts.reduce( ( a, b ) => a + b, 0 );
+			this.parentIds = this._parseProperty( extensionHeader.parentIds, parentIdsLength, 'parentIds' );
+
+		} else {
+
+			this.parentIds = null;
+
+		}
+
+		this.instancesIds = [];
+		const classCounter = {};
+		for ( const classId of this.classIds ) {
+
+			classCounter[ classId ] = classCounter[ classId ] ?? 0;
+			this.instancesIds.push( classCounter[ classId ] );
+			classCounter[ classId ] ++;
+
+		}
+
+	}
+
+	_parseProperty( property, propertyLength, propertyName ) {
+
+		if ( Array.isArray( property ) ) {
+
+			return property;
+
+		} else {
+
+			const { buffer, binOffset } = this.batchTable;
+
+			const byteOffset = property.byteOffset;
+			const componentType = property.componentType || 'UNSIGNED_SHORT';
+
+			const arrayStart = binOffset + byteOffset;
+
+			return parseBinArray( buffer, arrayStart, propertyLength, 'SCALAR', componentType, propertyName );
+
+		}
+
+	}
+
+	getDataFromId( id, target = {} ) {
+
+		// Get properties inherited from parents
+
+		const parentCount = this.parentCounts[ id ];
+
+		if ( this.parentIds && parentCount > 0 ) {
+
+			let parentIdsOffset = 0;
+			for ( let i = 0; i < id; i ++ ) {
+
+				parentIdsOffset += this.parentCounts[ i ];
+
+			}
+
+			for ( let i = 0; i < parentCount; i ++ ) {
+
+				const parentId = this.parentIds[ parentIdsOffset + i ];
+				if ( parentId !== id ) {
+
+					this.getDataFromId( parentId, target );
+
+				}
+
+			}
+
+		}
+
+		// Get properties proper to this instance
+
+		const classId = this.classIds[ id ];
+		const instances = this.classes[ classId ].instances;
+		const className = this.classes[ classId ].name;
+		const instanceId = this.instancesIds[ id ];
+
+		for ( const key in instances ) {
+
+			target[ className ] = target[ className ] || {};
+			target[ className ][ key ] = instances[ key ][ instanceId ];
+
+		}
+
+		return target;
+
+	}
+
+}

--- a/src/utilities/FeatureTable.d.ts
+++ b/src/utilities/FeatureTable.d.ts
@@ -28,23 +28,3 @@ export class FeatureTable {
 	getBuffer( byteOffset : Number, byteLength : Number ) : ArrayBuffer;
 
 }
-
-export class BatchTable {
-
-	constructor(
-		buffer : ArrayBuffer,
-		batchSize : Number,
-		start : Number,
-		headerLength : Number,
-		binLength : Number
-	);
-
-	getKeys() : Array< String >;
-
-	getData(
-		key : String,
-		componentType : String | null,
-		type : String | null
-	) : Number | String | ArrayBufferView;
-
-}

--- a/src/utilities/FeatureTable.js
+++ b/src/utilities/FeatureTable.js
@@ -149,20 +149,3 @@ export class FeatureTable {
 	}
 
 }
-
-export class BatchTable extends FeatureTable {
-
-	constructor( buffer, batchSize, start, headerLength, binLength ) {
-
-		super( buffer, start, headerLength, binLength );
-		this.batchSize = batchSize;
-
-	}
-
-	getData( key, componentType = null, type = null ) {
-
-		return super.getData( key, this.batchSize, componentType, type );
-
-	}
-
-}

--- a/src/utilities/FeatureTable.js
+++ b/src/utilities/FeatureTable.js
@@ -1,5 +1,77 @@
 import { arrayToString } from './arrayToString.js';
 
+export function parseBinArray( buffer, arrayStart, count, type, componentType, propertyName ) {
+
+	let stride;
+	switch ( type ) {
+
+		case 'SCALAR':
+			stride = 1;
+			break;
+
+		case 'VEC2':
+			stride = 2;
+			break;
+
+		case 'VEC3':
+			stride = 3;
+			break;
+
+		case 'VEC4':
+			stride = 4;
+			break;
+
+		default:
+			throw new Error( `FeatureTable : Feature type not provided for "${ propertyName }".` );
+
+	}
+
+	let data;
+	const arrayLength = count * stride;
+
+	switch ( componentType ) {
+
+		case 'BYTE':
+			data = new Int8Array( buffer, arrayStart, arrayLength );
+			break;
+
+		case 'UNSIGNED_BYTE':
+			data = new Uint8Array( buffer, arrayStart, arrayLength );
+			break;
+
+		case 'SHORT':
+			data = new Int16Array( buffer, arrayStart, arrayLength );
+			break;
+
+		case 'UNSIGNED_SHORT':
+			data = new Uint16Array( buffer, arrayStart, arrayLength );
+			break;
+
+		case 'INT':
+			data = new Int32Array( buffer, arrayStart, arrayLength );
+			break;
+
+		case 'UNSIGNED_INT':
+			data = new Uint32Array( buffer, arrayStart, arrayLength );
+			break;
+
+		case 'FLOAT':
+			data = new Float32Array( buffer, arrayStart, arrayLength );
+			break;
+
+		case 'DOUBLE':
+			data = new Float64Array( buffer, arrayStart, arrayLength );
+			break;
+
+		default:
+			throw new Error( `FeatureTable : Feature component type not provided for "${ propertyName }".` );
+
+	}
+
+	return data;
+
+}
+
 export class FeatureTable {
 
 	constructor( buffer, start, headerLength, binLength ) {
@@ -61,74 +133,10 @@ export class FeatureTable {
 
 			}
 
-			let stride;
-			switch ( featureType ) {
-
-				case 'SCALAR':
-					stride = 1;
-					break;
-
-				case 'VEC2':
-					stride = 2;
-					break;
-
-				case 'VEC3':
-					stride = 3;
-					break;
-
-				case 'VEC4':
-					stride = 4;
-					break;
-
-				default:
-					throw new Error( `FeatureTable : Feature type not provided for "${ key }".` );
-
-			}
-
-			let data;
 			const arrayStart = binOffset + byteOffset;
-			const arrayLength = count * stride;
+			const data = parseBinArray( buffer, arrayStart, count, featureType, featureComponentType, key );
 
-			switch ( featureComponentType ) {
-
-				case 'BYTE':
-					data = new Int8Array( buffer, arrayStart, arrayLength );
-					break;
-
-				case 'UNSIGNED_BYTE':
-					data = new Uint8Array( buffer, arrayStart, arrayLength );
-					break;
-
-				case 'SHORT':
-					data = new Int16Array( buffer, arrayStart, arrayLength );
-					break;
-
-				case 'UNSIGNED_SHORT':
-					data = new Uint16Array( buffer, arrayStart, arrayLength );
-					break;
-
-				case 'INT':
-					data = new Int32Array( buffer, arrayStart, arrayLength );
-					break;
-
-				case 'UNSIGNED_INT':
-					data = new Uint32Array( buffer, arrayStart, arrayLength );
-					break;
-
-				case 'FLOAT':
-					data = new Float32Array( buffer, arrayStart, arrayLength );
-					break;
-
-				case 'DOUBLE':
-					data = new Float64Array( buffer, arrayStart, arrayLength );
-					break;
-
-				default:
-					throw new Error( `FeatureTable : Feature component type not provided for "${ key }".` );
-
-			}
-
-			const dataEnd = arrayStart + arrayLength * data.BYTES_PER_ELEMENT;
+			const dataEnd = arrayStart + data.byteLength;
 			if ( dataEnd > binOffset + binLength ) {
 
 				throw new Error( 'FeatureTable: Feature data read outside binary body length.' );


### PR DESCRIPTION
This PR adds : 

- A `BatchTable.getDataForId` method which returns all data in a batch table for a given batch `ID`.
- The support for the [`3DTILES_batch_table_hierarchy`](https://github.com/CesiumGS/3d-tiles/blob/main/extensions/3DTILES_batch_table_hierarchy/README.md) extension to enrich `BatchTable.getDataForId` with data eventually stored using this extension.

This PR should close #595.

**Here is an explanation on a few things I did :**

I added a [`BatchTableHierarchyExtension`](https://github.com/mgermerie/3DTilesRendererJS/blob/5660f778cafe7cf2fb14373f0371698f2c0ed960/src/utilities/BatchTableHierarchyExtension.js) class that allows parsing batch table data formatted using [`3DTILES_batch_table_hierarchy`](https://github.com/CesiumGS/3d-tiles/blob/main/extensions/3DTILES_batch_table_hierarchy/README.md) extension.

I defined a `parseBinArray` function in [`FeatureTable.js`](https://github.com/mgermerie/3DTilesRendererJS/blob/5660f778cafe7cf2fb14373f0371698f2c0ed960/src/utilities/FeatureTable.js#L3) file. It is simply a factorization of already existing code that allows parsing data from a binary batch table in [`BatchTableHierarchyExtension`](https://github.com/mgermerie/3DTilesRendererJS/blob/5660f778cafe7cf2fb14373f0371698f2c0ed960/src/utilities/BatchTableHierarchyExtension.js) without needing to rewrite this function.

I defined `BatchTable` in its own [`BatchTable.js`](https://github.com/mgermerie/3DTilesRendererJS/blob/5660f778cafe7cf2fb14373f0371698f2c0ed960/src/utilities/BatchTable.js) file, outside of [`FeatureTable.js`](https://github.com/mgermerie/3DTilesRendererJS/blob/5660f778cafe7cf2fb14373f0371698f2c0ed960/src/utilities/FeatureTable.js) file. This is just to prevent circular dependency. 
Otherwise, we would have the following :
```js
// In BatchTableHierarchyExtension.js file :
import { parseBinArray } from './FeatureTable.js';
```
```js
// In FeatureTable.js file :
import { BatchTableHierarchyExtension } from './BatchTableHierarchyExtension.js';
```

**Notes and questions :**

- I never wrote type definition files before so don't hesitate to mention if I'm missing some points in those I edited.
- If I understood well, everything that is defined within a type definition file describes what is in the public API (plus the exports in `index.js`). Should I add a `BatchTableHierarchyExtension.d.ts` file or would you rather have it not exposed ?
- I chose to register the `BatchTableHierarchyExtension` within `BatchTable` constructor, but wonder of different ways to do it : would it be better to register it within [`B3DMLoaderBase`](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/ac83abe6f82974ae2f2d4d146a99f33b406bd414/src/base/loaders/B3DMLoaderBase.js#L70), [`I3DMLoaderBase`](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/ac83abe6f82974ae2f2d4d146a99f33b406bd414/src/base/loaders/I3DMLoaderBase.js#L73) and [`PNTSLoaderBase`](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/ac83abe6f82974ae2f2d4d146a99f33b406bd414/src/base/loaders/PNTSLoaderBase.js#L69) (a bit like `3DTILES_draco_point_compression` extension is registered in [`PNTSLoader`](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/ac83abe6f82974ae2f2d4d146a99f33b406bd414/src/three/loaders/PNTSLoader.js#L39)) ?


Don't hesitate if you need more info on the PR !