### PR TITLE
TilesRenderer: Queue loads for all visible tiles

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -495,7 +495,7 @@ export class TilesRendererBase {
 		const downloadQueue = this.downloadQueue;
 		const parseQueue = this.parseQueue;
 		const isExternalTileSet = tile.__externalTileSet;
-		lruCache.add( tile, t => {
+		const addedSuccessfully = lruCache.add( tile, t => {
 
 			// Stop the load if it's started
 			if ( t.__loadingState === LOADING ) {
@@ -531,6 +531,13 @@ export class TilesRendererBase {
 			downloadQueue.remove( t );
 
 		} );
+
+		// if we couldn't add the tile to the lru cache because it's full then skip
+		if ( ! addedSuccessfully ) {
+
+			return;
+
+		}
 
 		// Track a new load index so we avoid the condition where this load is stopped and
 		// another begins soon after so we don't parse twice.

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -87,40 +87,6 @@ function recursivelyLoadTiles( tile, depthFromRenderedParent, renderer, frameCou
 
 }
 
-function recursivelyLoadTiles_old( tile, depthFromRenderedParent, renderer ) {
-
-	renderer.ensureChildrenArePreprocessed( tile );
-
-	// TODO: is this triggering loads for children
-
-	// Try to load any external tile set children if the external tile set has loaded.
-	const doTraverse =
-		tile.__contentEmpty && (
-			! tile.__externalTileSet ||
-			isDownloadFinished( tile.__loadingState )
-		);
-	if ( doTraverse ) {
-
-		const children = tile.children;
-		for ( let i = 0, l = children.length; i < l; i ++ ) {
-
-			// don't increment depth to rendered parent here because we should treat
-			// the next layer of rendered children as just a single depth away for the
-			// sake of sorting.
-			const child = children[ i ];
-			child.__depthFromRenderedParent = depthFromRenderedParent;
-			recursivelyLoadTiles( child, depthFromRenderedParent, renderer );
-
-		}
-
-	} else {
-
-		renderer.requestTileContents( tile );
-
-	}
-
-}
-
 // Helper function for recursively traversing a tile set. If `beforeCb` returns `true` then the
 // traversal will end early.
 export function traverseSet( tile, beforeCb = null, afterCb = null, parent = null, depth = 0 ) {
@@ -398,18 +364,7 @@ export function skipTraversal( tile, renderer ) {
 		// layer when the data has loaded.
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
-			// TODO: we should perform this recursion down to all the leaves of tiles that need to be
-			// be loaded rather than just the next layer of visible children
-			const c = children[ i ];
-			recursivelyLoadTiles( c, tile.__depthFromRenderedParent + 1, renderer, frameCount );
-
-			// if ( isUsedThisFrame( c, frameCount ) && ! lruCache.isFull() ) {
-
-			// 	c.__depthFromRenderedParent = tile.__depthFromRenderedParent + 1;
-			// 	recursivelyLoadTiles( c, c.__depthFromRenderedParent, renderer );
-
-			// }
-
+			recursivelyLoadTiles( children[ i ], tile.__depthFromRenderedParent + 1, renderer, frameCount );
 
 		}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -55,35 +55,7 @@ function recursivelyMarkUsed( tile, frameCount, lruCache, renderer ) {
 
 }
 
-
-// function recursivelyLoadTiles2( tile, depthFromRenderedParent, renderer, frameCount ) {
-
-// 	renderer.ensureChildrenArePreprocessed( tile );
-
-// 	const lruCache = renderer.lruCache;
-// 	if ( isUsedThisFrame( tile, frameCount ) && ! lruCache.isFull() ) {
-
-// 		if ( ( ! tile.__contentEmpty || tile.__externalTileSet ) && ! isDownloadFinished( tile.__loadingState ) ) {
-
-// 			renderer.requestTileContents( tile );
-
-// 		}
-
-// 		tile.__depthFromRenderedParent = depthFromRenderedParent;
-
-// 		const children = tile.children;
-// 		for ( let i = 0, l = children.length; i < l; i ++ ) {
-
-// 			const child = children[ i ];
-// 			recursivelyLoadTiles2( child, tile.__contentEmpty ? depthFromRenderedParent : depthFromRenderedParent + 1, renderer );
-
-// 		}
-
-// 	}
-
-// }
-
-function recursivelyLoadTiles2( tile, depthFromRenderedParent, renderer, frameCount ) {
+function recursivelyLoadTiles( tile, depthFromRenderedParent, renderer, frameCount ) {
 
 	renderer.ensureChildrenArePreprocessed( tile );
 
@@ -107,7 +79,7 @@ function recursivelyLoadTiles2( tile, depthFromRenderedParent, renderer, frameCo
 			// the next layer of rendered children as just a single depth away for the
 			// sake of sorting.
 			const child = children[ i ];
-			recursivelyLoadTiles2( child, ! tile.__contentEmpty ? depthFromRenderedParent : depthFromRenderedParent + 1, renderer, frameCount );
+			recursivelyLoadTiles( child, ! tile.__contentEmpty ? depthFromRenderedParent : depthFromRenderedParent + 1, renderer, frameCount );
 
 		}
 
@@ -115,8 +87,7 @@ function recursivelyLoadTiles2( tile, depthFromRenderedParent, renderer, frameCo
 
 }
 
-
-function recursivelyLoadTiles( tile, depthFromRenderedParent, renderer ) {
+function recursivelyLoadTiles_old( tile, depthFromRenderedParent, renderer ) {
 
 	renderer.ensureChildrenArePreprocessed( tile );
 
@@ -430,7 +401,7 @@ export function skipTraversal( tile, renderer ) {
 			// TODO: we should perform this recursion down to all the leaves of tiles that need to be
 			// be loaded rather than just the next layer of visible children
 			const c = children[ i ];
-			recursivelyLoadTiles2( c, tile.__depthFromRenderedParent + 1, renderer, frameCount );
+			recursivelyLoadTiles( c, tile.__depthFromRenderedParent + 1, renderer, frameCount );
 
 			// if ( isUsedThisFrame( c, frameCount ) && ! lruCache.isFull() ) {
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -87,27 +87,18 @@ function recursivelyLoadTiles2( tile, depthFromRenderedParent, renderer, frameCo
 
 	renderer.ensureChildrenArePreprocessed( tile );
 
-
 	const lruCache = renderer.lruCache;
 	if ( isUsedThisFrame( tile, frameCount ) && ! lruCache.isFull() ) {
 
-		tile.__depthFromRenderedParent = depthFromRenderedParent;
-
-
-
-
-
-
-
-
-		const doLoad =
-			( ! tile.__contentEmpty || tile.__externalTileSet ) && ! isDownloadFinished( tile.__loadingState );
+		const doLoad = ( ! tile.__contentEmpty || tile.__externalTileSet ) && ! isDownloadFinished( tile.__loadingState );
 
 		if ( doLoad ) {
 
 			renderer.requestTileContents( tile );
 
 		}
+
+		tile.__depthFromRenderedParent = depthFromRenderedParent;
 
 		const children = tile.children;
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
@@ -116,11 +107,9 @@ function recursivelyLoadTiles2( tile, depthFromRenderedParent, renderer, frameCo
 			// the next layer of rendered children as just a single depth away for the
 			// sake of sorting.
 			const child = children[ i ];
-			child.__depthFromRenderedParent = depthFromRenderedParent;
-			recursivelyLoadTiles( child, ! doLoad ? depthFromRenderedParent : depthFromRenderedParent + 1, renderer );
+			recursivelyLoadTiles2( child, ! tile.__contentEmpty ? depthFromRenderedParent : depthFromRenderedParent + 1, renderer, frameCount );
 
 		}
-
 
 	}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -370,7 +370,6 @@ export function skipTraversal( tile, renderer ) {
 
 	} else {
 
-
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
 			const c = children[ i ];

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -40,6 +40,11 @@ class LRUCache {
 
 		if ( this.isFull() ) {
 
+			// TODO: can we check if the tile being added is a better tile to include and remove
+			// other tiles to make space. Ideally this would use the other priority sort function as
+			// the other callback functions.
+			// But how can we efficiently find the less viable tile? Sort every time on add when full?
+			// Binary sort insert? It will be slow when reaching the limits
 			return false;
 
 		}


### PR DESCRIPTION
Related to #632 

In progress PR for queuing up all tiles needed for rendering so we can make sure the jobs are saturated as consistently as possible. Currently tiles can seem slower but it's possible this is because the queue sort is prioritizing tiles that were not previously added to the queue, preventing some parents from loading sooner.

**TODO**
- Check if raising the queue size on tiles has a significant improvement before / after
- Measure time to load completion
- Ideate on queue sort improvements