### PR TITLE
GoogleCloudAuthPlugin

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -449,8 +449,11 @@ export class TilesRendererBase {
 		const tileSets = this.tileSets;
 		if ( ! ( url in tileSets ) ) {
 
+			let processedUrl = url;
+			this.invokeAllPlugins( plugin => processedUrl = plugin.preprocessURL ? plugin.preprocessURL( processedUrl ) : processedUrl );
+
 			const pr = this
-				.fetchTileSet( this.preprocessURL ? this.preprocessURL( url ) : url, this.fetchOptions )
+				.fetchTileSet( processedUrl, this.fetchOptions )
 				.then( json => {
 
 					tileSets[ url ] = json;
@@ -599,8 +602,10 @@ export class TilesRendererBase {
 
 				}
 
-				const uri = this.preprocessURL ? this.preprocessURL( tileCb.content.uri ) : tileCb.content.uri;
-				return this.fetchTileSet( uri, Object.assign( { signal }, this.fetchOptions ), tileCb );
+				let processedUrl = tileCb.content.uri;
+				this.invokeAllPlugins( plugin => processedUrl = plugin.preprocessURL ? plugin.preprocessURL( processedUrl ) : processedUrl );
+
+				return this.fetchTileSet( processedUrl, Object.assign( { signal }, this.fetchOptions ), tileCb );
 
 			} )
 				.then( json => {
@@ -631,8 +636,10 @@ export class TilesRendererBase {
 
 				}
 
-				const uri = this.preprocessURL ? this.preprocessURL( downloadTile.content.uri ) : downloadTile.content.uri;
-				return fetch( uri, Object.assign( { signal }, this.fetchOptions ) );
+				let processedUrl = downloadTile.content.uri;
+				this.invokeAllPlugins( plugin => processedUrl = plugin.preprocessURL ? plugin.preprocessURL( processedUrl ) : processedUrl );
+
+				return fetch( processedUrl, Object.assign( { signal }, this.fetchOptions ) );
 
 			} )
 				.then( res => {
@@ -718,7 +725,7 @@ export class TilesRendererBase {
 
 	invokeOnePlugin( func ) {
 
-		const plugins = this.plugins;
+		const plugins = [ ...this.plugins, this ];
 		for ( let i = 0; i < plugins.length; i ++ ) {
 
 			const result = func( plugins[ i ] );
@@ -736,7 +743,7 @@ export class TilesRendererBase {
 
 	invokeAllPlugins( func ) {
 
-		const plugins = this.plugins;
+		const plugins = [ ...this.plugins, this ];
 		const pending = [];
 		for ( let i = 0; i < plugins.length; i ++ ) {
 

--- a/src/three/plugins/GoogleCloudAuthPlugin.js
+++ b/src/three/plugins/GoogleCloudAuthPlugin.js
@@ -40,22 +40,18 @@ export class GoogleCloudAuthPlugin {
 
 	preprocessURL( uri ) {
 
-		if ( this.sessionToken !== null ) {
+		uri = new URL( uri );
+		if ( /^http/.test( uri.protocol ) ) {
 
-			uri = new URL( uri );
-			if ( /^http/.test( uri.protocol ) ) {
+			uri.searchParams.append( 'key', this.apiToken );
+			if ( this.sessionToken !== null ) {
 
 				uri.searchParams.append( 'session', this.sessionToken );
-				uri.searchParams.append( 'key', this.apiToken );
 
 			}
-			return uri.toString();
-
-		} else {
-
-			return uri;
 
 		}
+		return uri.toString();
 
 	}
 

--- a/src/three/plugins/GoogleCloudAuthPlugin.js
+++ b/src/three/plugins/GoogleCloudAuthPlugin.js
@@ -1,0 +1,62 @@
+export class GoogleCloudAuthPlugin {
+
+	constructor( { apiToken } ) {
+
+		this.name = 'GOOGLE_CLOUD_AUTH_PLUGIN';
+		this.apiToken = apiToken;
+		this.sessionToken = null;
+
+		this._onLoadCallback = null;
+		this._visibilityChangeCallback = null;
+
+	}
+
+	init( tiles ) {
+
+		this._onLoadCallback = () => {
+
+			// find the session id in the first sub tile set
+			tiles.traverse( tile => {
+
+				if ( tile.content && tile.content.uri ) {
+
+					this.sessionToken = new URL( tile.content.uri ).searchParams.get( 'session' );
+					return true;
+
+				}
+
+				return false;
+
+			} );
+
+			// clear the callback once the root is loaded
+			tiles.removeEventListener( 'load-tile-set', this._onLoadCallback );
+
+		};
+
+		tiles.addEventListener( 'load-tile-set', this._onLoadCallback );
+
+	}
+
+	preprocessURL( uri ) {
+
+		if ( this.sessionToken !== null ) {
+
+			uri = new URL( uri );
+			if ( /^http/.test( uri.protocol ) ) {
+
+				uri.searchParams.append( 'session', this.sessionToken );
+				uri.searchParams.append( 'key', this.apiToken );
+
+			}
+			return uri.toString();
+
+		} else {
+
+			return uri;
+
+		}
+
+	}
+
+}

--- a/src/three/renderers/GoogleTilesRenderer.js
+++ b/src/three/renderers/GoogleTilesRenderer.js
@@ -18,9 +18,9 @@ const GoogleTilesRendererMixin = base => class extends base {
 
 	}
 
-	constructor( apiToken, baseUrl = TILE_URL ) {
+	constructor( apiToken, url = TILE_URL ) {
 
-		super( new URL( `${ baseUrl }?key=${ apiToken }` ).toString() );
+		super( url );
 
 		this._credits = new GoogleMapsTilesCredits();
 

--- a/src/three/renderers/GoogleTilesRenderer.js
+++ b/src/three/renderers/GoogleTilesRenderer.js
@@ -8,6 +8,71 @@ const API_ORIGIN = 'https://tile.googleapis.com';
 const TILE_URL = `${ API_ORIGIN }/v1/3dtiles/root.json`;
 const _mat = new Matrix4();
 const _euler = new Euler();
+
+class GoogleCloudAuthPlugin {
+
+	constructor( { apiToken } ) {
+
+		this.name = 'GOOGLE_CLOUD_AUTH_PLUGIN';
+		this.apiToken = apiToken;
+		this.sessionToken = null;
+
+		this._onLoadCallback = null;
+		this._visibilityChangeCallback = null;
+
+	}
+
+	init( tiles ) {
+
+		this._onLoadCallback = () => {
+
+			// find the session id in the first sub tile set
+			tiles.traverse( tile => {
+
+				if ( tile.content && tile.content.uri ) {
+
+					this.sessionToken = new URL( tile.content.uri ).searchParams.get( 'session' );
+					return true;
+
+				}
+
+				return false;
+
+			} );
+
+			// clear the callback once the root is loaded
+			tiles.removeEventListener( 'load-tile-set', this._onLoadCallback );
+
+		};
+
+		tiles.addEventListener( 'load-tile-set', this._onLoadCallback );
+
+	}
+
+	preprocessURL( uri ) {
+
+		if ( this.sessionToken !== null ) {
+
+			uri = new URL( uri );
+			if ( /^http/.test( uri.protocol ) ) {
+
+				uri.searchParams.append( 'session', this.sessionToken );
+				uri.searchParams.append( 'key', this.apiToken );
+
+			}
+			return uri.toString();
+
+		} else {
+
+			return uri;
+
+		}
+
+	}
+
+}
+
+
 const GoogleTilesRendererMixin = base => class extends base {
 
 	get ellipsoid() {
@@ -16,9 +81,9 @@ const GoogleTilesRendererMixin = base => class extends base {
 
 	}
 
-	constructor( apiKey, baseUrl = TILE_URL ) {
+	constructor( apiToken, baseUrl = TILE_URL ) {
 
-		super( new URL( `${ baseUrl }?key=${ apiKey }` ).toString() );
+		super( new URL( `${ baseUrl }?key=${ apiToken }` ).toString() );
 
 		this._credits = new GoogleMapsTilesCredits();
 
@@ -28,44 +93,6 @@ const GoogleTilesRendererMixin = base => class extends base {
 		this.lruCache.minSize = 3000;
 		this.lruCache.maxSize = 5000;
 		this.errorTarget = 40;
-
-		const onLoadCallback = () => {
-
-			// find the session id in the first sub tile set
-			let session;
-			this.traverse( tile => {
-
-				if ( tile.content && tile.content.uri ) {
-
-					session = new URL( tile.content.uri ).searchParams.get( 'session' );
-					return true;
-
-				}
-
-				return false;
-
-			} );
-
-			// adjust the url preprocessor to include the api key, session
-			this.preprocessURL = uri => {
-
-				uri = new URL( uri );
-				if ( /^http/.test( uri.protocol ) ) {
-
-					uri.searchParams.append( 'session', session );
-					uri.searchParams.append( 'key', apiKey );
-
-				}
-				return uri.toString();
-
-			};
-
-			// clear the callback once the root is loaded
-			this.removeEventListener( 'load-tile-set', onLoadCallback );
-
-		};
-
-		this.addEventListener( 'load-tile-set', onLoadCallback );
 
 		this.addEventListener( 'tile-visibility-change', e => {
 
@@ -82,6 +109,8 @@ const GoogleTilesRendererMixin = base => class extends base {
 			}
 
 		} );
+
+		this.registerPlugin( new GoogleCloudAuthPlugin( { apiToken } ) );
 
 	}
 

--- a/src/three/renderers/GoogleTilesRenderer.js
+++ b/src/three/renderers/GoogleTilesRenderer.js
@@ -3,75 +3,12 @@ import { TilesRenderer } from '../TilesRenderer.js';
 import { DebugTilesRenderer } from '../DebugTilesRenderer.js';
 import { WGS84_ELLIPSOID } from '../math/GeoConstants.js';
 import { GoogleMapsTilesCredits } from './GoogleMapsTilesCredits.js';
+import { GoogleCloudAuthPlugin } from '../plugins/GoogleCloudAuthPlugin.js';
 
 const API_ORIGIN = 'https://tile.googleapis.com';
 const TILE_URL = `${ API_ORIGIN }/v1/3dtiles/root.json`;
 const _mat = new Matrix4();
 const _euler = new Euler();
-
-class GoogleCloudAuthPlugin {
-
-	constructor( { apiToken } ) {
-
-		this.name = 'GOOGLE_CLOUD_AUTH_PLUGIN';
-		this.apiToken = apiToken;
-		this.sessionToken = null;
-
-		this._onLoadCallback = null;
-		this._visibilityChangeCallback = null;
-
-	}
-
-	init( tiles ) {
-
-		this._onLoadCallback = () => {
-
-			// find the session id in the first sub tile set
-			tiles.traverse( tile => {
-
-				if ( tile.content && tile.content.uri ) {
-
-					this.sessionToken = new URL( tile.content.uri ).searchParams.get( 'session' );
-					return true;
-
-				}
-
-				return false;
-
-			} );
-
-			// clear the callback once the root is loaded
-			tiles.removeEventListener( 'load-tile-set', this._onLoadCallback );
-
-		};
-
-		tiles.addEventListener( 'load-tile-set', this._onLoadCallback );
-
-	}
-
-	preprocessURL( uri ) {
-
-		if ( this.sessionToken !== null ) {
-
-			uri = new URL( uri );
-			if ( /^http/.test( uri.protocol ) ) {
-
-				uri.searchParams.append( 'session', this.sessionToken );
-				uri.searchParams.append( 'key', this.apiToken );
-
-			}
-			return uri.toString();
-
-		} else {
-
-			return uri;
-
-		}
-
-	}
-
-}
-
 
 const GoogleTilesRendererMixin = base => class extends base {
 


### PR DESCRIPTION
Related to #629

Separates the GoogleTilesRenderer from the auth plugin. Plugins now have "preprocessUrl" function access. Plugin invocation now implicitly tries to call the function on "this".

**Next**
- Cesium Plugin, test with GoogleTiles renderer
- Deprecate GoogleTilesRenderer
- Deprecate "preprocessUrl" function