### PR TITLE
Remove support for loadSiblings, stopAtEmptyTiles options

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,14 +352,6 @@ maxDepth = Infinity : Number
 
 The max depth to which tiles will be loaded and rendered. Setting it to `1` will only render the root tile. If the tile at depth `maxDepth` is an empty tile then the next set of visible children will be rendered.
 
-### .loadSiblings
-
-```js
-loadSiblings = true : Boolean
-```
-
-If true then all sibling tiles will be loaded, as well, to ensure coherence when moving the camera. If false then only currently viewed tiles will be loaded.
-
 ### .displayActiveTiles
 
 ```js

--- a/TESTCASES.md
+++ b/TESTCASES.md
@@ -260,52 +260,6 @@ Verify no errors are logged.
 
 Verify that the stats display 125 geometries, 126 textures, and 1 programs.
 
-## Verify stopAtEmptyTiles works
-
-#### steps
-
-1. Open the kitchen sink example by navigating [here](https://nasa-ammos.github.io/3DTilesRendererJS/example/bundle/).
-1. Set `maxDepth` to 1.
-1. Verify that only 1 tile is visible.
-1. Open the kitchen sink example with the no root content tileset by navigating [here](https://nasa-ammos.github.io/3DTilesRendererJS/example/bundle/#../data/tileset-no-root-content.json).
-1. Set `maxDepth` to 1.
-1. Verify that all tiles disappear.
-
-#### expected
-
-No tiles are visible when the active leafs have no content.
-
-## Verify maxDepth limit does not stop at empty tiles when stopAtEmptyTiles = false
-
-1. Open the kitchen sink example by navigating [here](https://nasa-ammos.github.io/3DTilesRendererJS/example/bundle/).
-1. Set `maxDepth` to 1.
-1. Verify that only 1 tile is visible.
-1. Open the kitchen sink example with the no root content tileset by navigating [here](https://nasa-ammos.github.io/3DTilesRendererJS/example/bundle/#../data/tileset-no-root-content.json).
-1. Disable `stopAtEmptyTiles`.
-1. Set `maxDepth` to 1.
-1. Verify that 4 tiles are visible.
-
-#### expected
-
-The next shallowest tiles are visible past the `maxDepth` cutoff.
-
-## Verify tileset with missing mid tile content loads and renders correctly
-
-#### steps
-
-1. Open the kitchen sink example with the no root content tileset by navigating [here](https://nasa-ammos.github.io/3DTilesRendererJS/example/bundle/#../data/tileset-no-midtile-content.json).
-1. Zoom in slowly and verify the tiles load correctly and completely.
-1. Set `errorTarget` to 0.
-1. Set `maxDepth` to 3.
-1. Set `colorMode` to `RANDOM_COLOR`.
-1. Verify that one tile is missing.
-1. Disable `stopAtEmptyTiles`.
-1. Verify that there are four smaller tiles compared to the rest of the tileset where the missing midtile with content is.
-
-#### expected
-
-The tileset renders and loads correctly.
-
 ## Verify tileset with additive tiles renders correctly
 
 #### steps

--- a/TESTCASES.md
+++ b/TESTCASES.md
@@ -2,12 +2,11 @@
 
 Series of manually performed test cases for scenarios that are difficult / not feasible to test in an automated fashion.
 
-## Verify all sibling tiles load when loadSiblings = true
+## Verify all sibling tiles load
 
 #### steps
 
 1. Open the kitchen sink example.
-1. Ensure `loadSiblings` is enabled.
 1. Ensure `displayActiveTiles` is enabled.
 1. Zoom in as much as possible so much of the tileset is not visible.
 1. Wait until all tiles have loaded.
@@ -18,18 +17,6 @@ Series of manually performed test cases for scenarios that are difficult / not f
 
 Tiles are displayed all the way out to the edge of the tileset.
 
-## Verify sibling tiles do _not_ load when loadSiblings = false
-
-#### steps
-
-1. Open the kitchen sink example.
-1. Ensure `loadSiblings` is disabled.
-1. Ensure `displayActiveTiles` is enabled.
-1. Zoom in as much as possible so much of the tileset is not visible.
-1. Wait until all tiles have loaded.
-1. Disable the `enableUpdate` option.
-1. Zoom out to view the whole tileset.
-
 #### expected
 
 Only tiles that were visible when zoomed in are displayed.
@@ -39,7 +26,6 @@ Only tiles that were visible when zoomed in are displayed.
 #### steps
 
 1. Open the kitchen sink example.
-1. Ensure `loadSiblings` is enabled.
 1. Ensure `displayActiveTiles` is enabled.
 1. Zoom in as much as possible so much of the tileset is not visible.
 1. Wait until all tiles have loaded.

--- a/example/index.js
+++ b/example/index.js
@@ -65,7 +65,6 @@ const params = {
 	errorTarget: 6,
 	errorThreshold: 60,
 	maxDepth: 15,
-	loadSiblings: true,
 	stopAtEmptyTiles: true,
 	displayActiveTiles: false,
 	resolutionScale: 1.0,
@@ -263,7 +262,6 @@ function init() {
 	gui.width = 300;
 
 	const tileOptions = gui.addFolder( 'Tiles Options' );
-	tileOptions.add( params, 'loadSiblings' );
 	tileOptions.add( params, 'stopAtEmptyTiles' );
 	tileOptions.add( params, 'displayActiveTiles' );
 	tileOptions.add( params, 'errorTarget' ).min( 0 ).max( 50 );
@@ -481,7 +479,6 @@ function animate() {
 	// update options
 	tiles.errorTarget = params.errorTarget;
 	tiles.errorThreshold = params.errorThreshold;
-	tiles.loadSiblings = params.loadSiblings;
 	tiles.optimizeRaycast = params.optimizeRaycast;
 	tiles.stopAtEmptyTiles = params.stopAtEmptyTiles;
 	tiles.displayActiveTiles = params.displayActiveTiles;

--- a/example/index.js
+++ b/example/index.js
@@ -65,7 +65,6 @@ const params = {
 	errorTarget: 6,
 	errorThreshold: 60,
 	maxDepth: 15,
-	stopAtEmptyTiles: true,
 	displayActiveTiles: false,
 	resolutionScale: 1.0,
 

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -8,7 +8,6 @@ export class TilesRendererBase {
 
 	errorTarget : Number;
 	errorThreshold : Number;
-	loadSiblings : Boolean;
 	displayActiveTiles : Boolean;
 	maxDepth : Number;
 	stopAtEmptyTiles : Boolean;

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -10,7 +10,6 @@ export class TilesRendererBase {
 	errorThreshold : Number;
 	displayActiveTiles : Boolean;
 	maxDepth : Number;
-	stopAtEmptyTiles : Boolean;
 
 	fetchOptions : RequestInit;
 	/** function to preprocess the url for each individual tile */

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -98,6 +98,12 @@ export class TilesRendererBase {
 
 	}
 
+	set stopAtEmptyTiles( v ) {
+
+		console.warn( 'TilesRenderer: "stopAtEmptyTiles" option has been removed.' );
+
+	}
+
 	constructor( url = null ) {
 
 		// state
@@ -138,7 +144,6 @@ export class TilesRendererBase {
 		this.errorThreshold = Infinity;
 		this.displayActiveTiles = false;
 		this.maxDepth = Infinity;
-		this.stopAtEmptyTiles = true;
 
 	}
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -92,6 +92,12 @@ export class TilesRendererBase {
 
 	}
 
+	set loadSiblings( v ) {
+
+		console.warn( 'TilesRenderer: "loadSiblings" option has been removed.' );
+
+	}
+
 	constructor( url = null ) {
 
 		// state
@@ -130,7 +136,6 @@ export class TilesRendererBase {
 		// options
 		this.errorTarget = 6.0;
 		this.errorThreshold = Infinity;
-		this.loadSiblings = true;
 		this.displayActiveTiles = false;
 		this.maxDepth = Infinity;
 		this.stopAtEmptyTiles = true;

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -137,7 +137,7 @@ export function determineFrustumSet( tile, renderer ) {
 	const inFrustum = renderer.tileInView( tile );
 	if ( inFrustum === false ) {
 
-		return false;
+		return;
 
 	}
 
@@ -159,14 +159,14 @@ export function determineFrustumSet( tile, renderer ) {
 		const error = tile.__error;
 		if ( error <= errorTarget ) {
 
-			return true;
+			return;
 
 		}
 
 		// Early out if we've reached the maximum allowed depth.
 		if ( renderer.maxDepth > 0 && tile.__depth + 1 >= maxDepth ) {
 
-			return true;
+			return;
 
 		}
 
@@ -178,8 +178,8 @@ export function determineFrustumSet( tile, renderer ) {
 	for ( let i = 0, l = children.length; i < l; i ++ ) {
 
 		const c = children[ i ];
-		const r = determineFrustumSet( c, renderer );
-		anyChildrenUsed = anyChildrenUsed || r;
+		determineFrustumSet( c, renderer );
+		anyChildrenUsed = anyChildrenUsed || c.__used;
 
 	}
 
@@ -196,7 +196,7 @@ export function determineFrustumSet( tile, renderer ) {
 
 	}
 
-	return true;
+	return;
 
 }
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -131,7 +131,6 @@ export function determineFrustumSet( tile, renderer ) {
 	const errorTarget = renderer.errorTarget;
 	const maxDepth = renderer.maxDepth;
 	const lruCache = renderer.lruCache;
-	const stopAtEmptyTiles = renderer.stopAtEmptyTiles;
 	resetFrameState( tile, frameCount );
 
 	// Early out if this tile is not within view.
@@ -150,9 +149,11 @@ export function determineFrustumSet( tile, renderer ) {
 
 	// Early out if this tile has less error than we're targeting but don't stop
 	// at an external tile set.
-	if ( ( stopAtEmptyTiles || ! tile.__contentEmpty ) && ! tile.__externalTileSet ) {
+	// TODO: it's possible we should remove this external tile set check, too. The tile set
+	// should embed the necessary logic internally to stop or continue traversal.
+	if ( ! tile.__externalTileSet ) {
 
-		// compute the _error and __distanceFromCamera fields
+		// compute the __error and __distanceFromCamera fields
 		renderer.calculateError( tile );
 
 		const error = tile.__error;

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -130,7 +130,6 @@ export function determineFrustumSet( tile, renderer ) {
 	const frameCount = renderer.frameCount;
 	const errorTarget = renderer.errorTarget;
 	const maxDepth = renderer.maxDepth;
-	const loadSiblings = renderer.loadSiblings;
 	const lruCache = renderer.lruCache;
 	const stopAtEmptyTiles = renderer.stopAtEmptyTiles;
 	resetFrameState( tile, frameCount );
@@ -185,7 +184,7 @@ export function determineFrustumSet( tile, renderer ) {
 
 	// If there are children within view and we are loading siblings then mark
 	// all sibling tiles as used, as well.
-	if ( anyChildrenUsed && loadSiblings ) {
+	if ( anyChildrenUsed && tile.refine !== 'ADD' ) {
 
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 


### PR DESCRIPTION
Related to #142
Related to #662 
Related to #663 

This support removes the "loadSiblings" flag and adopts the "true" behavior for "REPLACE" refine and the "false" behavior for "ADD". Now "ADD" will no longer force sibling geometry to load while "REPLACE" will.

The general goal is to ensure that when refine === "REPLACE" that we always have coherent sibling tiles loaded such that there is no "pop" when turning the camera and other tiles haven't been loaded. This is done by ensuring that any children are marked as "used" down to the next tile with content so we can be resilient to content "gaps" in the tile set from parent tiles with no geometry.

This enables the OSM tile set from #662 to load a lot faster but doesn't address the France tile set from https://github.com/iTowns/itowns/issues/2335. It's likely that the sibling behavior isn't correct - ie we could be considering tiles with no geometry as a "valid" sibling rather than traversing to children the next content-ful child (assuming the empty parent isn't an external tile set json). This would render the "loadSiblings" options and refinement difference irrelevant, I think.

OSM buildings marked in red:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e9eca737-e892-408e-9fc7-76c2b86f49f3">

cc @jailln 

_edit The Google globe tile set includes some intermediate "empty" tiles that are not external tile sets but they all use a geometric error of 1e+100 which may provide some hint as to how this should be handled._

<details>
<summary>Needed Traversal Improvements</summary>

- "REPLACE" parent tiles should only trigger loads for immediate children - or at least only up to calculated error requirements - rather than [loading up to the next set of visible children](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/master/src/base/traverseFunctions.js#L58), which may be incredibly broad and deep.
- If an in-frustum REPLACE parent tile has no children in the frustum, then the parent tile should not be considered in the frustum.
- When triggering all "REPLACE" parent children to load we can calculate the SSE even though they may be out of the frustum (see [executeTraversal](https://github.com/CesiumGS/cesium/blob/0a69f67b393ba194eefb7254600811c4b712ddc0/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js#L212-L214) > [updateAndPushChildren](https://github.com/CesiumGS/cesium/blob/0a69f67b393ba194eefb7254600811c4b712ddc0/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js#L99-L101) > [updateTile](https://github.com/CesiumGS/cesium/blob/0a69f67b393ba194eefb7254600811c4b712ddc0/packages/engine/Source/Scene/Cesium3DTilesetTraversal.js#L193) > [updateTileVisibility](https://github.com/CesiumGS/cesium/blob/0a69f67b393ba194eefb7254600811c4b712ddc0/packages/engine/Source/Scene/Cesium3DTilesetTraversal.js#L211) > [Tile.updateVisibility](https://github.com/CesiumGS/cesium/blob/0a69f67b393ba194eefb7254600811c4b712ddc0/packages/engine/Source/Scene/Cesium3DTile.js#L1041)). This information is then used in [executeEmptyTraversal](https://github.com/CesiumGS/cesium/blob/0a69f67b393ba194eefb7254600811c4b712ddc0/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js#L141) to load tiles up to the next valid [error value](https://github.com/CesiumGS/cesium/blob/0a69f67b393ba194eefb7254600811c4b712ddc0/packages/engine/Source/Scene/Cesium3DTilesetBaseTraversal.js#L273).
- Remove check for in-frustum in error calculation

</details>