### PR TITLE
Adjust traversal behavior to handle empty root tiles more gracefully

### DIFF
--- a/src/base/TileInternal.d.ts
+++ b/src/base/TileInternal.d.ts
@@ -8,6 +8,9 @@ export interface TileInternal extends Tile {
 
 	// tile description
 	__isLeaf: boolean;
+	__hasContent: boolean;
+	__hasRenderableContent: boolean;
+	__hasUnrenderableContent: boolean;
 
 	// resource tracking
 	__usedLastFrame: boolean;

--- a/src/base/TileInternal.d.ts
+++ b/src/base/TileInternal.d.ts
@@ -7,8 +7,6 @@ import { Tile } from './Tile';
 export interface TileInternal extends Tile {
 
 	// tile description
-	__externalTileSet: boolean;
-	__contentEmpty: boolean;
 	__isLeaf: boolean;
 
 	// resource tracking

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -339,7 +339,6 @@ export class TilesRendererBase {
 			tile.__hasUnrenderableContent = Boolean( extension && /json$/.test( extension ) );
 			tile.__hasRenderableContent = ! tile.__hasUnrenderableContent;
 
-
 		} else {
 
 			tile.__hasContent = false;

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -57,10 +57,10 @@ const lruPriorityCallback = ( a, b ) => {
 		// dispose of least recent tiles first
 		return a.__lastFrameVisited > b.__lastFrameVisited ? - 1 : 1;
 
-	} else if ( a.__externalTileSet !== b.__externalTileSet ) {
+	} else if ( a.__hasUnrenderableContent !== b.__hasUnrenderableContent ) {
 
 		// dispose of external tile sets last
-		return a.__externalTileSet ? - 1 : 1;
+		return a.__hasUnrenderableContent ? - 1 : 1;
 
 	}
 
@@ -335,7 +335,6 @@ export class TilesRendererBase {
 			// "content" should only indicate loadable meshes, not external tile sets
 			const extension = getUrlExtension( tile.content.uri );
 			const isExternalTileSet = Boolean( extension && extension.toLowerCase() === 'json' );
-			tile.__externalTileSet = isExternalTileSet;
 			tile.__contentEmpty = isExternalTileSet;
 
 			tile.__hasContent = true;
@@ -345,7 +344,6 @@ export class TilesRendererBase {
 
 		} else {
 
-			tile.__externalTileSet = false;
 			tile.__contentEmpty = true;
 
 			tile.__hasContent = false;
@@ -533,7 +531,7 @@ export class TilesRendererBase {
 		const lruCache = this.lruCache;
 		const downloadQueue = this.downloadQueue;
 		const parseQueue = this.parseQueue;
-		const isExternalTileSet = tile.__externalTileSet;
+		const isExternalTileSet = tile.__hasUnrenderableContent;
 		const addedSuccessfully = lruCache.add( tile, t => {
 
 			// Stop the load if it's started

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -1,7 +1,7 @@
 import { getUrlExtension } from '../utilities/urlExtension.js';
 import { LRUCache } from '../utilities/LRUCache.js';
 import { PriorityQueue } from '../utilities/PriorityQueue.js';
-import { determineFrustumSet, toggleTiles, skipTraversal, markUsedSetLeaves, traverseSet } from './traverseFunctions.js';
+import { markUsedTiles, toggleTiles, markVisibleTiles, markUsedSetLeaves, traverseSet } from './traverseFunctions.js';
 import { UNLOADED, LOADING, PARSING, LOADED, FAILED } from './constants.js';
 
 const PLUGIN_REGISTERED = Symbol( 'PLUGIN_REGISTERED' );
@@ -208,9 +208,9 @@ export class TilesRendererBase {
 		stats.visible = 0,
 		this.frameCount ++;
 
-		determineFrustumSet( root, this );
+		markUsedTiles( root, this );
 		markUsedSetLeaves( root, this );
-		skipTraversal( root, this );
+		markVisibleTiles( root, this );
 		toggleTiles( root, this );
 
 		lruCache.scheduleUnload();
@@ -338,10 +338,19 @@ export class TilesRendererBase {
 			tile.__externalTileSet = isExternalTileSet;
 			tile.__contentEmpty = isExternalTileSet;
 
+			tile.__hasContent = true;
+			tile.__hasRenderableContent = Boolean( extension && /json$/.test( extension ) );
+			tile.__hasUnrenderableContent = ! tile.__hasRenderableContent;
+
+
 		} else {
 
 			tile.__externalTileSet = false;
 			tile.__contentEmpty = true;
+
+			tile.__hasContent = false;
+			tile.__hasRenderableContent = false;
+			tile.__hasUnrenderableContent = false;
 
 		}
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -334,8 +334,6 @@ export class TilesRendererBase {
 
 			// "content" should only indicate loadable meshes, not external tile sets
 			const extension = getUrlExtension( tile.content.uri );
-			const isExternalTileSet = Boolean( extension && extension.toLowerCase() === 'json' );
-			tile.__contentEmpty = isExternalTileSet;
 
 			tile.__hasContent = true;
 			tile.__hasUnrenderableContent = Boolean( extension && /json$/.test( extension ) );
@@ -343,8 +341,6 @@ export class TilesRendererBase {
 
 
 		} else {
-
-			tile.__contentEmpty = true;
 
 			tile.__hasContent = false;
 			tile.__hasUnrenderableContent = false;
@@ -385,7 +381,7 @@ export class TilesRendererBase {
 
 			// increment the "depth from parent" when we encounter a new tile with content
 			tile.__depth = parentTile.__depth + 1;
-			tile.__depthFromRenderedParent = parentTile.__depthFromRenderedParent + ( tile.__contentEmpty ? 0 : 1 );
+			tile.__depthFromRenderedParent = parentTile.__depthFromRenderedParent + ( tile.__hasRenderableContent ? 1 : 0 );
 
 			tile.refine = tile.refine || parentTile.refine;
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -339,8 +339,8 @@ export class TilesRendererBase {
 			tile.__contentEmpty = isExternalTileSet;
 
 			tile.__hasContent = true;
-			tile.__hasRenderableContent = Boolean( extension && /json$/.test( extension ) );
-			tile.__hasUnrenderableContent = ! tile.__hasRenderableContent;
+			tile.__hasUnrenderableContent = Boolean( extension && /json$/.test( extension ) );
+			tile.__hasRenderableContent = ! tile.__hasUnrenderableContent;
 
 
 		} else {
@@ -349,8 +349,8 @@ export class TilesRendererBase {
 			tile.__contentEmpty = true;
 
 			tile.__hasContent = false;
-			tile.__hasRenderableContent = false;
 			tile.__hasUnrenderableContent = false;
+			tile.__hasRenderableContent = false;
 
 		}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -266,7 +266,7 @@ export function markUsedSetLeaves( tile, renderer ) {
 				const childLoaded =
 					c.__allChildrenLoaded ||
 					( c.__hasRenderableContent && isDownloadFinished( c.__loadingState ) ) ||
-					( ! c.__hasUnrenderableContent && ! c.__hasRenderableContent && c.children.length === 0 ) ||
+					( ! c.__hasContent && c.children.length === 0 ) ||
 					( c.__hasUnrenderableContent && c.__loadingState === FAILED );
 				allChildrenLoaded = allChildrenLoaded && childLoaded;
 
@@ -308,7 +308,7 @@ export function markVisibleTiles( tile, renderer ) {
 			tile.__active = true;
 			stats.active ++;
 
-		} else if ( ! lruCache.isFull() && ( tile.__hasRenderableContent || tile.__hasUnrenderableContent ) ) {
+		} else if ( ! lruCache.isFull() && tile.__hasContent ) {
 
 			renderer.requestTileContents( tile );
 
@@ -321,8 +321,7 @@ export function markVisibleTiles( tile, renderer ) {
 	const errorRequirement = ( renderer.errorTarget + 1 ) * renderer.errorThreshold;
 	const meetsSSE = tile.__error <= errorRequirement;
 	const includeTile = meetsSSE || tile.refine === 'ADD';
-	const hasModel = tile.__hasRenderableContent;
-	const hasContent = hasModel || tile.__hasUnrenderableContent;
+	const hasContent = tile.__hasContent;
 	const loadedContent = isDownloadFinished( tile.__loadingState ) && hasContent;
 	const childrenWereVisible = tile.__childrenWereVisible;
 	const children = tile.children;

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -67,7 +67,7 @@ function recursivelyLoadTiles( tile, renderer ) {
 	// Try to load any external tile set children if the external tile set has loaded.
 	const doTraverse =
 		! tile.__hasRenderableContent && (
-			! tile.__externalTileSet ||
+			! tile.__hasUnrenderableContent ||
 			isDownloadFinished( tile.__loadingState )
 		);
 	if ( doTraverse ) {
@@ -266,8 +266,8 @@ export function markUsedSetLeaves( tile, renderer ) {
 				const childLoaded =
 					c.__allChildrenLoaded ||
 					( c.__hasRenderableContent && isDownloadFinished( c.__loadingState ) ) ||
-					( ! c.__externalTileSet && ! c.__hasRenderableContent && c.children.length === 0 ) ||
-					( c.__externalTileSet && c.__loadingState === FAILED );
+					( ! c.__hasUnrenderableContent && ! c.__hasRenderableContent && c.children.length === 0 ) ||
+					( c.__hasUnrenderableContent && c.__loadingState === FAILED );
 				allChildrenLoaded = allChildrenLoaded && childLoaded;
 
 			}
@@ -308,7 +308,7 @@ export function markVisibleTiles( tile, renderer ) {
 			tile.__active = true;
 			stats.active ++;
 
-		} else if ( ! lruCache.isFull() && ( tile.__hasRenderableContent || tile.__externalTileSet ) ) {
+		} else if ( ! lruCache.isFull() && ( tile.__hasRenderableContent || tile.__hasUnrenderableContent ) ) {
 
 			renderer.requestTileContents( tile );
 
@@ -322,7 +322,7 @@ export function markVisibleTiles( tile, renderer ) {
 	const meetsSSE = tile.__error <= errorRequirement;
 	const includeTile = meetsSSE || tile.refine === 'ADD';
 	const hasModel = tile.__hasRenderableContent;
-	const hasContent = hasModel || tile.__externalTileSet;
+	const hasContent = hasModel || tile.__hasUnrenderableContent;
 	const loadedContent = isDownloadFinished( tile.__loadingState ) && hasContent;
 	const childrenWereVisible = tile.__childrenWereVisible;
 	const children = tile.children;

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -126,7 +126,7 @@ function canTraverse( tile, renderer ) {
 	}
 
 	// If the tile isn't used don't traverse further
-	if ( ! tile.__used ) {
+	if ( ! isUsedThisFrame( tile, renderer.frameCount ) ) {
 
 		return false;
 
@@ -198,7 +198,7 @@ export function markUsedTiles( tile, renderer ) {
 
 		const c = children[ i ];
 		markUsedTiles( c, renderer );
-		anyChildrenUsed = anyChildrenUsed || c.__used;
+		anyChildrenUsed = anyChildrenUsed || isUsedThisFrame( c, renderer.frameCount );
 
 	}
 
@@ -394,8 +394,7 @@ export function markVisibleTiles( tile, renderer ) {
 // Final traverse to toggle tile visibility.
 export function toggleTiles( tile, renderer ) {
 
-	const frameCount = renderer.frameCount;
-	const isUsed = isUsedThisFrame( tile, frameCount );
+	const isUsed = isUsedThisFrame( tile, renderer.frameCount );
 	if ( isUsed || tile.__usedLastFrame ) {
 
 		let setActive = false;

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -238,12 +238,8 @@ export function markUsedSetLeaves( tile, renderer ) {
 
 	}
 
-
 	if ( ! anyChildrenUsed ) {
 
-		// TODO: This isn't necessarily right because it's possible that a parent tile is considered in the
-		// frustum while the child tiles are not, making them unused. If all children have loaded and were properly
-		// considered to be in the used set then we shouldn't set ourselves to a leaf here.
 		tile.__isLeaf = true;
 
 	} else {
@@ -263,7 +259,7 @@ export function markUsedSetLeaves( tile, renderer ) {
 				// - the children's children have been loaded
 				// - the tile content has loaded
 				// - the tile is completely empty - ie has no children and no content
-				// - the child tileset has tried to load but failed
+				// - the child tile set has tried to load but failed
 				const childLoaded =
 					c.__allChildrenLoaded ||
 					( c.__hasRenderableContent && isDownloadFinished( c.__loadingState ) ) ||

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -167,7 +167,7 @@ export function traverseSet( tile, beforeCb = null, afterCb = null, parent = nul
 }
 
 // Determine which tiles are used by the renderer given the current camera configuration
-export function determineFrustumSet( tile, renderer ) {
+export function markUsedTiles( tile, renderer ) {
 
 	// determine frustum set is run first so we can ensure the preprocessing of all the necessary
 	// child tiles has happened here.
@@ -196,7 +196,7 @@ export function determineFrustumSet( tile, renderer ) {
 	for ( let i = 0, l = children.length; i < l; i ++ ) {
 
 		const c = children[ i ];
-		determineFrustumSet( c, renderer );
+		markUsedTiles( c, renderer );
 		anyChildrenUsed = anyChildrenUsed || c.__used;
 
 	}
@@ -283,7 +283,7 @@ export function markUsedSetLeaves( tile, renderer ) {
 
 // TODO: revisit implementation
 // Skip past tiles we consider unrenderable because they are outside the error threshold.
-export function skipTraversal( tile, renderer ) {
+export function markVisibleTiles( tile, renderer ) {
 
 	const stats = renderer.stats;
 	const frameCount = renderer.frameCount;
@@ -381,7 +381,7 @@ export function skipTraversal( tile, renderer ) {
 			const c = children[ i ];
 			if ( isUsedThisFrame( c, frameCount ) ) {
 
-				skipTraversal( c, renderer );
+				markVisibleTiles( c, renderer );
 
 			}
 


### PR DESCRIPTION
Related to #669
Related to #662  
Fix #663 

- Adjusts some Tile flags to have more clear naming (`__contentEmpty`, `__externalTileSet` changed to `__hasContent`, `__hasRenderableContent`, `__hasUnrenderableContent`).
- Adjusts behavior to not force all children to load if a tile is an empty root fixing the itowns issue:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/a10a19fd-cc4a-484e-9a32-184c00340b21">
