### PR TITLE
ImplicitTilesPlugin: Remove three.js dependency, simplify box bounds update

### DIFF
--- a/src/three/plugins/SUBTREELoader.js
+++ b/src/three/plugins/SUBTREELoader.js
@@ -703,22 +703,25 @@ export class SUBTREELoader extends LoaderBase {
 			const cellSteps = 2 ** tile.__level - 1;
 			const scale = Math.pow( 2, - tile.__level );
 
-			// iterate over the three obb axes
-			for ( let i = 0; i < 3; i ++ ) {
+			// Iterate over the three obb axes. Skip the z axis since octree
+			// implicit bounds are not supported.
+			for ( let i = 0; i < 2; i ++ ) {
 
-				// multiply x and y axes by the scale
-				// don't scale z because octree mode isn't supported, yet
+				// scale the bounds axes
 				box[ 3 + i * 3 + 0 ] *= scale;
 				box[ 3 + i * 3 + 1 ] *= scale;
-				// box[ 3 + i * 3 + 2 ] *= scale;
+				box[ 3 + i * 3 + 2 ] *= scale;
 
-				// adjust the center value by offsetting based on the cell identifier
-				// and start points
+				// axis vector
 				const x = box[ 3 + i * 3 + 0 ];
 				const y = box[ 3 + i * 3 + 1 ];
-				box[ 0 ] += 2 * x * ( - 0.5 * cellSteps + tile.__x );
-				box[ 1 ] += 2 * y * ( - 0.5 * cellSteps + tile.__y );
-				// box[ 2 ] += 2 * y * ( - 0.5 * cellSteps + tile.__z );
+				const z = box[ 3 + i * 3 + 2 ];
+
+				// adjust the center by the x and y axes
+				const axisOffset = i === 0 ? tile.__x : tile.__y;
+				box[ 0 ] += 2 * x * ( - 0.5 * cellSteps + axisOffset );
+				box[ 1 ] += 2 * y * ( - 0.5 * cellSteps + axisOffset );
+				box[ 2 ] += 2 * z * ( - 0.5 * cellSteps + axisOffset );
 
 			}
 

--- a/src/three/plugins/SUBTREELoader.js
+++ b/src/three/plugins/SUBTREELoader.js
@@ -702,6 +702,8 @@ export class SUBTREELoader extends LoaderBase {
 			const box = [ ...this.rootTile.boundingVolume.box ];
 			const cellSteps = 2 ** tile.__level - 1;
 			const scale = Math.pow( 2, - tile.__level );
+
+			// iterate over the three obb axes
 			for ( let i = 0; i < 3; i ++ ) {
 
 				// multiply x and y axes by the scale

--- a/src/three/plugins/SUBTREELoader.js
+++ b/src/three/plugins/SUBTREELoader.js
@@ -708,15 +708,15 @@ export class SUBTREELoader extends LoaderBase {
 				// don't scale z because octree mode isn't supported, yet
 				box[ 3 + i * 3 + 0 ] *= scale;
 				box[ 3 + i * 3 + 1 ] *= scale;
-				box[ 3 + i * 3 + 2 ] *= 1;
+				// box[ 3 + i * 3 + 2 ] *= scale;
 
-				// adjust the center value by offsetting based ons the cell identifier
+				// adjust the center value by offsetting based on the cell identifier
 				// and start points
 				const x = box[ 3 + i * 3 + 0 ];
 				const y = box[ 3 + i * 3 + 1 ];
 				box[ 0 ] += 2 * x * ( - 0.5 * cellSteps + tile.__x );
 				box[ 1 ] += 2 * y * ( - 0.5 * cellSteps + tile.__y );
-				box[ 2 ] += 0;
+				// box[ 2 ] += 2 * y * ( - 0.5 * cellSteps + tile.__z );
 
 			}
 

--- a/src/three/plugins/SUBTREELoader.js
+++ b/src/three/plugins/SUBTREELoader.js
@@ -666,8 +666,8 @@ export class SUBTREELoader extends LoaderBase {
 			const maxX = region[ 2 ];
 			const minY = region[ 1 ];
 			const maxY = region[ 3 ];
-			const sizeX = ( maxX - minX ) / ( Math.pow( 2, tile.__level ) );
-			const sizeY = ( maxY - minY ) / ( Math.pow( 2, tile.__level ) );
+			const sizeX = ( maxX - minX ) / Math.pow( 2, tile.__level );
+			const sizeY = ( maxY - minY ) / Math.pow( 2, tile.__level );
 			region[ 0 ] = minX + sizeX * tile.__x;	//west
 			region[ 2 ] = minX + sizeX * ( tile.__x + 1 );	//east
 			region[ 1 ] = minY + sizeY * tile.__y;	//south
@@ -676,7 +676,15 @@ export class SUBTREELoader extends LoaderBase {
 			for ( let k = 0; k < 4; k ++ ) {
 
 				const coord = region[ k ];
-				if ( coord < - Math.PI ) region[ k ] += 2 * Math.PI; else if ( coord > Math.PI ) region[ k ] -= 2 * Math.PI;
+				if ( coord < - Math.PI ) {
+
+					region[ k ] += 2 * Math.PI;
+
+				} else if ( coord > Math.PI ) {
+
+					region[ k ] -= 2 * Math.PI;
+
+				}
 
 			}
 


### PR DESCRIPTION
Related to #608 

Removes the dependency on three.js by computing the box bounds without matrix transformations. Also updates the `getTileBoundingVolume` logic to support output multiple bounds types of present.

At some point we can probably move this to the "base" folder since three.js is no longer required.

cc @AnthonyGlt 