### PR TITLE
Traversal: Lazily compute error

### DIFF
--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -16,9 +16,8 @@ function isUsedThisFrame( tile, frameCount ) {
 // Lazily get error
 function getError( tile, renderer ) {
 
-	if ( tile.__errorGeneratedFrame !== renderer.frameCount ) {
+	if ( tile.__error === Infinity ) {
 
-		tile.__errorGeneratedFrame = renderer.frameCount;
 		renderer.calculateError( tile );
 
 	}
@@ -45,7 +44,6 @@ function resetFrameState( tile, renderer ) {
 
 		// update tile frustum and error state
 		tile.__inFrustum = renderer.tileInView( tile );
-		renderer.calculateError( tile );
 
 	}
 
@@ -100,6 +98,7 @@ function recursivelyLoadNextRenderableTiles( tile, renderer ) {
 
 	} else {
 
+		getError( tile, renderer );
 		renderer.requestTileContents( tile );
 
 	}
@@ -321,6 +320,7 @@ export function markVisibleTiles( tile, renderer ) {
 
 		} else if ( ! lruCache.isFull() && tile.__hasContent ) {
 
+			getError( tile, renderer );
 			renderer.requestTileContents( tile );
 
 		}
@@ -344,6 +344,7 @@ export function markVisibleTiles( tile, renderer ) {
 	const includeTile = meetsSSE || tile.refine === 'ADD';
 	if ( includeTile && ! loadedContent && ! lruCache.isFull() && hasContent ) {
 
+		getError( tile, renderer );
 		renderer.requestTileContents( tile );
 
 	}

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -13,6 +13,20 @@ function isUsedThisFrame( tile, frameCount ) {
 
 }
 
+// Lazily get error
+function getError( tile, renderer ) {
+
+	if ( tile.__errorGeneratedFrame !== renderer.frameCount ) {
+
+		tile.__errorGeneratedFrame = renderer.frameCount;
+		renderer.calculateError( tile );
+
+	}
+
+	return tile.__error;
+
+}
+
 // Resets the frame frame information for the given tile
 function resetFrameState( tile, renderer ) {
 
@@ -111,7 +125,7 @@ function markUsed( tile, renderer ) {
 function canTraverse( tile, renderer ) {
 
 	// If we've met the error requirements then don't load further
-	if ( tile.__error <= renderer.errorTarget ) {
+	if ( getError( tile, renderer ) <= renderer.errorTarget ) {
 
 		return false;
 
@@ -319,7 +333,7 @@ export function markVisibleTiles( tile, renderer ) {
 	const hasContent = tile.__hasContent;
 	const loadedContent = isDownloadFinished( tile.__loadingState ) && hasContent;
 	const errorRequirement = ( renderer.errorTarget + 1 ) * renderer.errorThreshold;
-	const meetsSSE = tile.__error <= errorRequirement;
+	const meetsSSE = getError( tile, renderer ) <= errorRequirement;
 	const childrenWereVisible = tile.__childrenWereVisible;
 
 	// we don't wait for all children tiles to load if this tile set has empty tiles at the root


### PR DESCRIPTION
Related to #678

**TODO**
- Compare timing
- Check if we need to compute the error before every request tile
- Consider a function that triggers error calculation rather than a getter function