### PR TITLE
Implict Tiling: Remove unneeded tile members

### DIFF
--- a/src/three/plugins/ImplicitTilingPlugin.js
+++ b/src/three/plugins/ImplicitTilingPlugin.js
@@ -21,10 +21,6 @@ export class ImplicitTilingPlugin {
 			tile.__hasUnrenderableContent = true;
 			tile.__hasRenderableContent = false;
 
-			// Store the infos from the tileset
-			tile.__subtreeDivider = tile.implicitTiling.subdivisionScheme === 'QUADTREE' ? 4 : 8;
-			tile.__subtreeUri = tile.implicitTiling.subtrees.uri;
-
 			// Keep the original content uri
 			tile.__contentUri = uri ?? tile.content?.uri;
 
@@ -39,19 +35,19 @@ export class ImplicitTilingPlugin {
 			tile.__level = 0;
 
 			// Replace the original content uri to the subtree uri
-			let implicitUri = tile.__subtreeUri.replace( '{level}', tile.__level );
-			implicitUri = implicitUri.replace( '{x}', tile.__x );
-			implicitUri = implicitUri.replace( '{y}', tile.__y );
-			implicitUri = implicitUri.replace( '{z}', tile.__z );
-			tile.content.uri = new URL( implicitUri, tile.__basePath + '/' ).toString();
+			const implicitUri = tile.implicitTiling.subtrees.uri
+				.replace( '{level}', tile.__level )
+				.replace( '{x}', tile.__x )
+				.replace( '{y}', tile.__y )
+				.replace( '{z}', tile.__z );
 
-			// Handling content uri pointing to a subtree file
+			tile.content.uri = new URL( implicitUri, tile.__basePath + '/' ).toString();
 
 		} else if ( /.subtree$/i.test( tile.content?.uri ) ) {
 
+			// Handling content uri pointing to a subtree file
 			tile.__hasUnrenderableContent = true;
 			tile.__hasRenderableContent = false;
-			tile.__implicitRoot = parentTile?.__implicitRoot;	// Idx of the tile in its subtree
 
 		}
 

--- a/src/three/plugins/SUBTREELoader.js
+++ b/src/three/plugins/SUBTREELoader.js
@@ -8,6 +8,12 @@ import { LoaderBase } from '../../base/loaders/LoaderBase.js';
 import { readMagicBytes } from '../../utilities/readMagicBytes.js';
 import { arrayToString } from '../../utilities/arrayToString.js';
 
+function getBoundsDivider( tile ) {
+
+	return tile.implicitTiling.subdivisionScheme === 'QUADTREE' ? 4 : 8;
+
+}
+
 export class SUBTREELoader extends LoaderBase {
 
 	constructor( tile ) {
@@ -374,7 +380,7 @@ export class SUBTREELoader extends LoaderBase {
 		bufferViewsU8
 	) {
 
-		const branchingFactor = this.rootTile.__subtreeDivider;
+		const branchingFactor = getBoundsDivider( this.rootTile );
 		const subtreeLevels = this.rootTile.implicitTiling.subtreeLevels;
 		const tileAvailabilityBits =
 			( Math.pow( branchingFactor, subtreeLevels ) - 1 ) / ( branchingFactor - 1 );
@@ -513,7 +519,7 @@ export class SUBTREELoader extends LoaderBase {
 				subtreeLocator.childMortonIndex
 			);
 			// Assign subtree uri as content
-			subtreeTile.content = { uri: this.parseImplicitURI( subtreeTile, this.rootTile.__subtreeUri ) };
+			subtreeTile.content = { uri: this.parseImplicitURI( subtreeTile, this.rootTile.implicitTiling.subtrees.uri ) };
 			leafTile.children.push( subtreeTile );
 
 		}
@@ -540,9 +546,9 @@ export class SUBTREELoader extends LoaderBase {
 
 		for ( let level = 1; level < this.rootTile.implicitTiling.subtreeLevels; level ++ ) {
 
-			const branchingFactor = this.rootTile.__subtreeDivider;
+			const branchingFactor = getBoundsDivider( this.rootTile );
 			const levelOffset = ( Math.pow( branchingFactor, level ) - 1 ) / ( branchingFactor - 1 );
-			const numberOfChildren = this.rootTile.__subtreeDivider * parentRow.length;
+			const numberOfChildren = branchingFactor * parentRow.length;
 			for (
 				let childMortonIndex = 0;
 				childMortonIndex < numberOfChildren;
@@ -765,7 +771,7 @@ export class SUBTREELoader extends LoaderBase {
 	listChildSubtrees( subtree, bottomRow ) {
 
 		const results = [];
-		const branchingFactor = this.rootTile.__subtreeDivider;
+		const branchingFactor = getBoundsDivider( this.rootTile );
 		for ( let i = 0; i < bottomRow.length; i ++ ) {
 
 			const leafTile = bottomRow[ i ];


### PR DESCRIPTION
Related to #608 

- Removes the need for `__subtreeDivider` by calculating it as-needed.
- Removes `__subtreeUri` since it's already present on the object.
- Remove unnecessary assignment of `__implicitRoot`.

cc @AnthonyGlt 