### PR TITLE
LRUCache: Add support for memory-based cache limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ Utility class for the TilesRenderer to keep track of currently used items so ren
 maxSize = 800 : number
 ```
 
-The maximum cached size. If that current amount of cached items is equal to this value then no more items can be cached.
+The maximum cached size in number of items. If that current amount of cached items is equal to this value then no more items can be cached.
 
 ### .minSize
 
@@ -631,7 +631,23 @@ The maximum cached size. If that current amount of cached items is equal to this
 minSize = 600 : number
 ```
 
-The minimum cache size. Above this cached data will be unloaded if it's unused.
+The minimum cache size in number of items. Above this cached data will be unloaded if it's unused.
+
+### .maxByteSize
+
+```js
+maxByteSize = 0.3 * 2**30 : Number
+```
+
+The maximum cached size in bytes. If that current amount of cached bytes is equal to this value then no more items can be cached.
+
+### .minByteSize
+
+```js
+minByteSize = 0.2 * 2**30 : Number
+```
+
+The minimum cache size in number of bytes. Above this cached data will be unloaded if it's unused.
 
 ### .unloadPercent
 

--- a/example/src/plugins/UpdateOnChangePlugin.js
+++ b/example/src/plugins/UpdateOnChangePlugin.js
@@ -34,6 +34,9 @@ export class UpdateOnChangePlugin {
 
 		};
 
+		// dispose tile is included here because the LRUCache can evict tiles that are actively used if they're
+		// above the byte cap causing tile gaps
+		tiles.addEventListener( 'dispose-model', this._needsUpdateCallback );
 		tiles.addEventListener( 'camera-resolution-change', this._needsUpdateCallback );
 		tiles.addEventListener( 'load-content', this._needsUpdateCallback );
 		tiles.addEventListener( 'add-camera', this._onCameraAdd );
@@ -69,6 +72,7 @@ export class UpdateOnChangePlugin {
 	dispose() {
 
 		const tiles = this.tiles;
+		tiles.removeEventListener( 'dispose-model', this._needsUpdateCallback );
 		tiles.removeEventListener( 'camera-resolution-change', this._needsUpdateCallback );
 		tiles.removeEventListener( 'content-load', this._needsUpdateCallback );
 		tiles.removeEventListener( 'camera-add', this._onCameraAdd );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.21.8",
         "@babel/preset-env": "^7.21.5",
         "@types/eslint": "^7.28.1",
-        "@types/three": "^0.167.0",
+        "@types/three": "^0.166.0",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
         "babel-jest": "^29.5.0",
@@ -22,7 +22,7 @@
         "eslint-plugin-jest": "^28.6.0",
         "jest": "^27.1.1",
         "jest-cli": "^27.1.1",
-        "three": "^0.167.0",
+        "three": "^0.166.0",
         "typescript": "^5.1.3",
         "vite": "^5.3.1"
       },
@@ -4282,9 +4282,9 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.167.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.167.1.tgz",
-      "integrity": "sha512-OCd2Uv/8/4TbmSaIRFawrCOnDMLdpaa+QGJdhlUBmdfbHjLY8k6uFc0tde2/UvcaHQ6NtLl28onj/vJfofV+Tg==",
+      "version": "0.166.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.166.0.tgz",
+      "integrity": "sha512-FHMnpcdhdbdOOIYbfkTkUVpYMW53odxbTRwd0/xJpYnTzEsjnVnondGAvHZb4z06UW0vo6WPVuvH0/9qrxKx7g==",
       "dev": true,
       "dependencies": {
         "@tweenjs/tween.js": "~23.1.2",
@@ -11274,9 +11274,9 @@
       "peer": true
     },
     "node_modules/three": {
-      "version": "0.167.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.167.1.tgz",
-      "integrity": "sha512-gYTLJA/UQip6J/tJvl91YYqlZF47+D/kxiWrbTon35ZHlXEN0VOo+Qke2walF1/x92v55H6enomymg4Dak52kw==",
+      "version": "0.166.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.166.1.tgz",
+      "integrity": "sha512-LtuafkKHHzm61AQA1be2MAYIw1IjmhOUxhBa0prrLpEMWbV7ijvxCRHjSgHPGp2493wLBzwKV46tA9nivLEgKg==",
       "dev": true
     },
     "node_modules/throat": {
@@ -14949,9 +14949,9 @@
       "dev": true
     },
     "@types/three": {
-      "version": "0.167.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.167.1.tgz",
-      "integrity": "sha512-OCd2Uv/8/4TbmSaIRFawrCOnDMLdpaa+QGJdhlUBmdfbHjLY8k6uFc0tde2/UvcaHQ6NtLl28onj/vJfofV+Tg==",
+      "version": "0.166.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.166.0.tgz",
+      "integrity": "sha512-FHMnpcdhdbdOOIYbfkTkUVpYMW53odxbTRwd0/xJpYnTzEsjnVnondGAvHZb4z06UW0vo6WPVuvH0/9qrxKx7g==",
       "dev": true,
       "requires": {
         "@tweenjs/tween.js": "~23.1.2",
@@ -20251,9 +20251,9 @@
       "peer": true
     },
     "three": {
-      "version": "0.167.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.167.1.tgz",
-      "integrity": "sha512-gYTLJA/UQip6J/tJvl91YYqlZF47+D/kxiWrbTon35ZHlXEN0VOo+Qke2walF1/x92v55H6enomymg4Dak52kw==",
+      "version": "0.166.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.166.1.tgz",
+      "integrity": "sha512-LtuafkKHHzm61AQA1be2MAYIw1IjmhOUxhBa0prrLpEMWbV7ijvxCRHjSgHPGp2493wLBzwKV46tA9nivLEgKg==",
       "dev": true
     },
     "throat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.21.8",
         "@babel/preset-env": "^7.21.5",
         "@types/eslint": "^7.28.1",
-        "@types/three": "^0.165.0",
+        "@types/three": "^0.167.0",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
         "babel-jest": "^29.5.0",
@@ -22,7 +22,7 @@
         "eslint-plugin-jest": "^28.6.0",
         "jest": "^27.1.1",
         "jest-cli": "^27.1.1",
-        "three": "^0.165.0",
+        "three": "^0.167.0",
         "typescript": "^5.1.3",
         "vite": "^5.3.1"
       },
@@ -4282,12 +4282,12 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.165.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.165.0.tgz",
-      "integrity": "sha512-AJK8JZAFNBF0kBXiAIl5pggYlzAGGA8geVYQXAcPCEDRbyA+oEjkpUBcJJrtNz6IiALwzGexFJGZG2yV3WsYBw==",
+      "version": "0.167.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.167.1.tgz",
+      "integrity": "sha512-OCd2Uv/8/4TbmSaIRFawrCOnDMLdpaa+QGJdhlUBmdfbHjLY8k6uFc0tde2/UvcaHQ6NtLl28onj/vJfofV+Tg==",
       "dev": true,
       "dependencies": {
-        "@tweenjs/tween.js": "~23.1.1",
+        "@tweenjs/tween.js": "~23.1.2",
         "@types/stats.js": "*",
         "@types/webxr": "*",
         "fflate": "~0.8.2",
@@ -11274,9 +11274,9 @@
       "peer": true
     },
     "node_modules/three": {
-      "version": "0.165.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
-      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
+      "version": "0.167.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.167.1.tgz",
+      "integrity": "sha512-gYTLJA/UQip6J/tJvl91YYqlZF47+D/kxiWrbTon35ZHlXEN0VOo+Qke2walF1/x92v55H6enomymg4Dak52kw==",
       "dev": true
     },
     "node_modules/throat": {
@@ -14949,12 +14949,12 @@
       "dev": true
     },
     "@types/three": {
-      "version": "0.165.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.165.0.tgz",
-      "integrity": "sha512-AJK8JZAFNBF0kBXiAIl5pggYlzAGGA8geVYQXAcPCEDRbyA+oEjkpUBcJJrtNz6IiALwzGexFJGZG2yV3WsYBw==",
+      "version": "0.167.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.167.1.tgz",
+      "integrity": "sha512-OCd2Uv/8/4TbmSaIRFawrCOnDMLdpaa+QGJdhlUBmdfbHjLY8k6uFc0tde2/UvcaHQ6NtLl28onj/vJfofV+Tg==",
       "dev": true,
       "requires": {
-        "@tweenjs/tween.js": "~23.1.1",
+        "@tweenjs/tween.js": "~23.1.2",
         "@types/stats.js": "*",
         "@types/webxr": "*",
         "fflate": "~0.8.2",
@@ -20251,9 +20251,9 @@
       "peer": true
     },
     "three": {
-      "version": "0.165.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
-      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
+      "version": "0.167.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.167.1.tgz",
+      "integrity": "sha512-gYTLJA/UQip6J/tJvl91YYqlZF47+D/kxiWrbTon35ZHlXEN0VOo+Qke2walF1/x92v55H6enomymg4Dak52kw==",
       "dev": true
     },
     "throat": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.8",
     "@babel/preset-env": "^7.21.5",
-    "@types/three": "^0.165.0",
+    "@types/three": "^0.167.0",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
     "babel-jest": "^29.5.0",
@@ -51,7 +51,7 @@
     "eslint-plugin-jest": "^28.6.0",
     "jest": "^27.1.1",
     "jest-cli": "^27.1.1",
-    "three": "^0.165.0",
+    "three": "^0.167.0",
     "typescript": "^5.1.3",
     "vite": "^5.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.8",
     "@babel/preset-env": "^7.21.5",
-    "@types/three": "^0.167.0",
+    "@types/three": "^0.166.0",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
     "babel-jest": "^29.5.0",
@@ -51,7 +51,7 @@
     "eslint-plugin-jest": "^28.6.0",
     "jest": "^27.1.1",
     "jest-cli": "^27.1.1",
-    "three": "^0.167.0",
+    "three": "^0.166.0",
     "typescript": "^5.1.3",
     "vite": "^5.3.1"
   },

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -706,7 +706,7 @@ export class TilesRendererBase {
 
 				stats.parsing --;
 				tile.__loadingState = LOADED;
-				lruCache.updateMemoryUsed( tile );
+				lruCache.updateMemoryUsage( tile );
 
 				if ( tile.__wasSetVisible ) {
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -662,6 +662,7 @@ export class TilesRendererBase {
 					stats.downloading --;
 					tile.__loadAbort = null;
 					tile.__loadingState = LOADED;
+					lruCache.updateMemoryUsed( tile );
 
 					tile.children.push( json.root );
 
@@ -745,6 +746,7 @@ export class TilesRendererBase {
 
 					stats.parsing --;
 					tile.__loadingState = LOADED;
+					lruCache.updateMemoryUsed( tile );
 
 					if ( tile.__wasSetVisible ) {
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -157,7 +157,11 @@ export class TilesRendererBase {
 
 		this.plugins.push( plugin );
 		plugin[ PLUGIN_REGISTERED ] = true;
-		plugin.init( this );
+		if ( plugin.init ) {
+
+			plugin.init( this );
+
+		}
 
 	}
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -287,6 +287,20 @@ export class TilesRendererBase {
 
 	disposeTile( tile ) {
 
+		if ( tile.__visible ) {
+
+			this.setTileVisible( tile, false );
+			tile.__visible = false;
+
+		}
+
+		if ( tile.__active ) {
+
+			this.setTileActive( tile, false );
+			tile.__active = false;
+
+		}
+
 	}
 
 	preprocessNode( tile, tileSetDir, parentTile = null ) {

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -17,6 +17,7 @@ import { raycastTraverse, raycastTraverseFirstHit } from './raycastTraverse.js';
 import { readMagicBytes } from '../utilities/readMagicBytes.js';
 import { TileBoundingVolume } from './math/TileBoundingVolume.js';
 import { ExtendedFrustum } from './math/ExtendedFrustum.js';
+import { estimateBytesUsed } from './utilities.js';
 
 // In three.js r165 and higher raycast traversal can be ended early
 const REVISION_165 = parseInt( REVISION ) < 165;
@@ -73,6 +74,8 @@ export class TilesRenderer extends TilesRendererBase {
 		this.optimizeRaycast = true;
 		this._eventDispatcher = new EventDispatcher();
 		this._upRotationMatrix = new Matrix4();
+
+		this.lruCache.getMemoryUsageCallback = tile => tile.cached.bytesUsed || 0;
 
 		// flag indicating whether frustum culling should be disabled
 		this._autoDisableRendererCulling = true;
@@ -764,6 +767,7 @@ export class TilesRenderer extends TilesRendererBase {
 		cached.textures = textures;
 		cached.scene = scene;
 		cached.metadata = metadata;
+		cached.bytesUsed = estimateBytesUsed( scene );
 
 		// dispatch an event indicating that this model has completed
 		this.dispatchEvent( {

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -803,6 +803,8 @@ export class TilesRenderer extends TilesRendererBase {
 
 	disposeTile( tile ) {
 
+		super.disposeTile( tile );
+
 		// This could get called before the tile has finished downloading
 		const cached = tile.cached;
 		if ( cached.scene ) {
@@ -875,8 +877,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 		}
 
-		this.activeTiles.delete( tile );
-		this.visibleTiles.delete( tile );
 		cached._loadIndex ++;
 
 	}

--- a/src/three/utilities.js
+++ b/src/three/utilities.js
@@ -1,29 +1,45 @@
 import { estimateBytesUsed as _estimateBytesUsed } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import { TextureUtils } from 'three';
+import * as THREE from 'three';
 
-export function estimateBytesUsed( scene ) {
+// Returns the estimated number of bytes used by the object
+export function estimateBytesUsed( object ) {
+
+	// NOTE: This is for backwards compatibility and should be removed later
+	const { TextureUtils } = THREE;
+	if ( ! TextureUtils ) {
+
+		return 0;
+
+	}
+
+	const dedupeSet = new Set();
 
 	let totalBytes = 0;
-	scene.traverse( c => {
+	object.traverse( c => {
 
-		if ( c.geometry ) {
+		// get geometry bytes
+		if ( c.geometry && ! dedupeSet.has( c.geometry ) ) {
 
 			totalBytes += _estimateBytesUsed( c.geometry );
+			dedupeSet.add( c.geometry );
 
 		}
 
+		// get material bytes
 		if ( c.material ) {
 
 			const material = c.material;
 			for ( const key in material ) {
 
 				const value = material[ key ];
-				if ( value && value.isTexture ) {
+				if ( value && value.isTexture && ! dedupeSet.has( value ) ) {
 
 					const { format, type, image } = value;
 					const { width, height } = image;
 					const bytes = TextureUtils.getByteLength( width, height, format, type );
 					totalBytes += value.generateMipmaps ? bytes * 4 / 3 : bytes;
+
+					dedupeSet.add( value );
 
 				}
 

--- a/src/three/utilities.js
+++ b/src/three/utilities.js
@@ -1,0 +1,38 @@
+import { estimateBytesUsed as _estimateBytesUsed } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { TextureUtils } from 'three';
+
+export function estimateBytesUsed( scene ) {
+
+	let totalBytes = 0;
+	scene.traverse( c => {
+
+		if ( c.geometry ) {
+
+			totalBytes += _estimateBytesUsed( c.geometry );
+
+		}
+
+		if ( c.material ) {
+
+			const material = c.material;
+			for ( const key in material ) {
+
+				const value = material[ key ];
+				if ( value && value.isTexture ) {
+
+					const { format, type, image } = value;
+					const { width, height } = image;
+					const bytes = TextureUtils.getByteLength( width, height, format, type );
+					totalBytes += value.generateMipmaps ? bytes * 4 / 3 : bytes;
+
+				}
+
+			}
+
+		}
+
+	} );
+
+	return totalBytes;
+
+}

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -203,8 +203,8 @@ class LRUCache {
 		} = this;
 
 		const unused = itemList.length - usedSet.size;
-		const excessNodes = Math.min( itemList.length - minSize, unused );
-		const excessBytes = this.cachedBytes - this.minBytesSize;
+		const excessNodes = Math.max( Math.min( itemList.length - minSize, unused ), 0 );
+		const excessBytes = this.cachedBytes - minBytesSize;
 		const unloadPriorityCallback = this.unloadPriorityCallback || this.defaultPriorityCallback;
 		let remaining = excessNodes;
 
@@ -240,8 +240,9 @@ class LRUCache {
 			// address corner cases where the minSize might be zero or smaller than maxSize - minSize,
 			// which would result in a very small or no items being unloaded.
 			const maxUnload = Math.max( minSize * unloadPercent, excessNodes * unloadPercent );
-			const nodesToUnload = Math.ceil( Math.min( maxUnload, unused ) );
-			const bytesToUnload = Math.max( unloadPercent * excessBytes, unloadPercent * minBytesSize );
+			const nodesToUnload = Math.ceil( Math.min( maxUnload, unused, excessNodes ) );
+			const maxBytesUnload = Math.max( unloadPercent * excessBytes, unloadPercent * minBytesSize );
+			const bytesToUnload = Math.min( maxBytesUnload, excessBytes );
 
 			let removedNodes = 0;
 			let removedBytes = 0;

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -1,4 +1,4 @@
-const GB_BYTES = 2 ** 30;
+const GIGABYTE_BYTES = 2 ** 30;
 
 class LRUCache {
 
@@ -37,8 +37,8 @@ class LRUCache {
 		// options
 		this.maxSize = 800;
 		this.minSize = 600;
-		this.minBytesSize = 0.2 * GB_BYTES;
-		this.maxBytesSize = 0.3 * GB_BYTES;
+		this.minBytesSize = 0.2 * GIGABYTE_BYTES;
+		this.maxBytesSize = 0.3 * GIGABYTE_BYTES;
 		this.unloadPercent = 0.05;
 
 		// "itemSet" doubles as both the list of the full set of items currently
@@ -50,7 +50,7 @@ class LRUCache {
 		this.callbacks = new Map();
 		this.markUnusedQueued = false;
 		this.unloadingHandle = - 1;
-		this.currBytes = 0;
+		this.cachedBytes = 0;
 		this.bytesMap = new Map();
 
 		this._unloadPriorityCallback = null;
@@ -64,7 +64,7 @@ class LRUCache {
 	// Returns whether or not the cache has reached the maximum size
 	isFull() {
 
-		return this.itemSet.size >= this.maxSize || this.currBytes >= this.maxBytesSize;
+		return this.itemSet.size >= this.maxSize || this.cachedBytes >= this.maxBytesSize;
 
 	}
 
@@ -99,7 +99,7 @@ class LRUCache {
 		callbacks.set( item, removeCb );
 
 		const bytes = this.getMemoryUsageCallback( item );
-		this.currBytes += bytes;
+		this.cachedBytes += bytes;
 		bytesMap.set( item, bytes );
 
 		return true;
@@ -116,7 +116,7 @@ class LRUCache {
 
 		if ( itemSet.has( item ) ) {
 
-			this.currBytes -= bytesMap.get( item );
+			this.cachedBytes -= bytesMap.get( item );
 			bytesMap.delete( item );
 
 			callbacks.get( item )( item );
@@ -145,11 +145,11 @@ class LRUCache {
 
 		}
 
-		this.currBytes -= bytesMap.get( item );
+		this.cachedBytes -= bytesMap.get( item );
 
 		const bytes = this.getMemoryUsageCallback( item );
 		bytesMap.set( item, bytes );
-		this.currBytes += bytes;
+		this.cachedBytes += bytes;
 
 	}
 
@@ -202,12 +202,12 @@ class LRUCache {
 
 		const unused = itemList.length - usedSet.size;
 		const excessNodes = Math.min( itemList.length - minSize, unused );
-		const excessBytes = this.currBytes - this.minBytesSize;
+		const excessBytes = this.cachedBytes - this.minBytesSize;
 		const unloadPriorityCallback = this.unloadPriorityCallback || this.defaultPriorityCallback;
 		let remaining = excessNodes;
 
 		const hasNodesToUnload = excessNodes > 0 && unused > 0;
-		const hasBytesToUnload = unused && this.currBytes > this.minBytesSize || this.currBytes > this.maxBytesSize;
+		const hasBytesToUnload = unused && this.cachedBytes > this.minBytesSize || this.cachedBytes > this.maxBytesSize;
 		if ( hasBytesToUnload || hasNodesToUnload ) {
 
 			// used items should be at the end of the array
@@ -265,7 +265,7 @@ class LRUCache {
 			}
 
 			itemList.splice( 0, nodesToUnload );
-			this.currBytes -= removedBytes;
+			this.cachedBytes -= removedBytes;
 
 			remaining = nodesToUnload < excessNodes || bytesToUnload < excessBytes;
 

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -37,8 +37,8 @@ class LRUCache {
 		// options
 		this.maxSize = 800;
 		this.minSize = 600;
-		this.minBytesSize = 0.2 * GIGABYTE_BYTES;
-		this.maxBytesSize = 0.3 * GIGABYTE_BYTES;
+		this.minBytesSize = 0.3 * GIGABYTE_BYTES;
+		this.maxBytesSize = 0.4 * GIGABYTE_BYTES;
 		this.unloadPercent = 0.05;
 
 		// "itemSet" doubles as both the list of the full set of items currently

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -1,3 +1,5 @@
+const GB_BYTES = 2 ** 30;
+
 class LRUCache {
 
 	get unloadPriorityCallback() {
@@ -35,8 +37,8 @@ class LRUCache {
 		// options
 		this.maxSize = 800;
 		this.minSize = 600;
-		this.minBytesSize = 1000;
-		this.maxBytesSize = 5000;
+		this.minBytesSize = 0.2 * GB_BYTES;
+		this.maxBytesSize = 0.3 * GB_BYTES;
 		this.unloadPercent = 0.05;
 
 		// "itemSet" doubles as both the list of the full set of items currently

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -135,7 +135,7 @@ class LRUCache {
 
 	}
 
-	updateMemoryUsed( item ) {
+	updateMemoryUsage( item ) {
 
 		const itemSet = this.itemSet;
 		const bytesMap = this.bytesMap;
@@ -279,7 +279,9 @@ class LRUCache {
 			itemList.splice( 0, removedNodes );
 			this.cachedBytes -= removedBytes;
 
-			remaining = removedNodes < excessNodes || removedBytes < excessBytes;
+			// if we didn't remove enough nodes or we still have excess bytes and there are nodes to removed
+			// then we want to fire another round of unloading
+			remaining = removedNodes < excessNodes || removedBytes < excessBytes && removedNodes < unused;
 
 		}
 

--- a/test/LRUCache.test.js
+++ b/test/LRUCache.test.js
@@ -133,8 +133,8 @@ describe( 'LRUCache', () => {
 
 		}
 
-		expect( cache.itemList.length ).toEqual( 6 );
-		expect( cache.cachedBytes ).toEqual( 24 );
+		expect( cache.itemList.length ).toEqual( 7 );
+		expect( cache.cachedBytes ).toEqual( 28 );
 
 		cache.markAllUnused();
 		cache.unloadUnusedContent();
@@ -176,8 +176,8 @@ describe( 'LRUCache', () => {
 		expect( cache.itemList.length ).toEqual( 10 );
 
 		cache.unloadUnusedContent();
-		expect( cache.cachedBytes ).toEqual( 24 );
-		expect( cache.itemList.length ).toEqual( 6 );
+		expect( cache.cachedBytes ).toEqual( 28 );
+		expect( cache.itemList.length ).toEqual( 7 );
 
 	} );
 

--- a/test/LRUCache.test.js
+++ b/test/LRUCache.test.js
@@ -118,4 +118,29 @@ describe( 'LRUCache', () => {
 
 	} );
 
+	it( 'should limit the amount of bytes allowed in the cache.', () => {
+
+		const cache = new LRUCache();
+		cache.minBytesSize = 5;
+		cache.maxBytesSize = 25;
+		cache.unloadPercent = 1;
+		cache.getMemoryUsageCallback = () => 4;
+
+		for ( let i = 0; i < 10; i ++ ) {
+
+			const item = { priority: 1 };
+			cache.add( item, () => {} );
+
+		}
+
+		expect( cache.itemList.length ).toEqual( 6 );
+		expect( cache.cachedBytes ).toEqual( 24 );
+
+		cache.markAllUnused();
+		cache.unloadUnusedContent();
+		expect( cache.itemList.length ).toEqual( 1 );
+		expect( cache.cachedBytes ).toEqual( 4 );
+
+	} );
+
 } );

--- a/test/LRUCache.test.js
+++ b/test/LRUCache.test.js
@@ -143,4 +143,42 @@ describe( 'LRUCache', () => {
 
 	} );
 
+	it( 'should update memory usage when the items are triggers.', () => {
+
+		const cache = new LRUCache();
+		cache.minBytesSize = 10;
+		cache.maxBytesSize = 25;
+		cache.unloadPercent = 1;
+		cache.getMemoryUsageCallback = () => 1;
+
+		const items = new Array( 10 ).fill().map( () => ( { priority: 1 } ) );
+		for ( let i = 0; i < 10; i ++ ) {
+
+			cache.add( items[ i ], () => {} );
+
+		}
+
+		expect( cache.cachedBytes ).toEqual( 10 );
+		expect( cache.itemList.length ).toEqual( 10 );
+
+		cache.unloadUnusedContent();
+		expect( cache.cachedBytes ).toEqual( 10 );
+		expect( cache.itemList.length ).toEqual( 10 );
+
+		cache.getMemoryUsageCallback = () => 4;
+		for ( let i = 0; i < 10; i ++ ) {
+
+			cache.updateMemoryUsage( items[ i ] );
+
+		}
+
+		expect( cache.cachedBytes ).toEqual( 40 );
+		expect( cache.itemList.length ).toEqual( 10 );
+
+		cache.unloadUnusedContent();
+		expect( cache.cachedBytes ).toEqual( 24 );
+		expect( cache.itemList.length ).toEqual( 6 );
+
+	} );
+
 } );

--- a/test/LRUCache.test.js
+++ b/test/LRUCache.test.js
@@ -95,4 +95,27 @@ describe( 'LRUCache', () => {
 
 	} );
 
+	it( 'should evict items if they are the max item length even if they are used.', () => {
+
+		const cache = new LRUCache();
+		cache.unloadPriorityCallback = ( itemA, itemB ) => itemA.priority - itemB.priority;
+		cache.minSize = 0;
+		cache.maxSize = 10;
+
+		for ( let i = 0; i < 10; i ++ ) {
+
+			const item = { priority: 1 };
+			cache.add( item, () => {} );
+			cache.markUsed( item );
+
+		}
+
+		expect( cache.itemList.length ).toEqual( 10 );
+
+		cache.maxSize = 3;
+		cache.unloadUnusedContent();
+		expect( cache.itemList.length ).toEqual( 3 );
+
+	} );
+
 } );


### PR DESCRIPTION
Fix #384 
Somewhat related to #428 

Requires latest version of three.js.

**TODO**
- Hone default cache size
- Prevent alternation of adding then removing items based on increase in size during first load 