### PR TITLE
TilesRenderer: Don't modify tiles fields to clean up implicit tiling

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -305,13 +305,6 @@ export class TilesRendererBase {
 
 			}
 
-			if ( tile.content.uri ) {
-
-				// tile content uri has to be interpreted relative to the tileset.json
-				tile.content.uri = new URL( tile.content.uri, tileSetDir + '/' ).toString();
-
-			}
-
 			// NOTE: fix for some cases where tilesets provide the bounding volume
 			// but volumes are not present.
 			if (
@@ -530,11 +523,12 @@ export class TilesRendererBase {
 
 		}
 
+		let uri = new URL( tile.content.uri, tile.__basePath + '/' ).toString();
 		const stats = this.stats;
 		const lruCache = this.lruCache;
 		const downloadQueue = this.downloadQueue;
 		const parseQueue = this.parseQueue;
-		const uriExtension = getUrlExtension( tile.content.uri );
+		const uriExtension = getUrlExtension( uri );
 		const isExternalTileSet = Boolean( uriExtension && /json$/.test( uriExtension ) );
 		const addedSuccessfully = lruCache.add( tile, t => {
 
@@ -644,10 +638,9 @@ export class TilesRendererBase {
 
 				}
 
-				let processedUrl = tileCb.content.uri;
-				this.invokeAllPlugins( plugin => processedUrl = plugin.preprocessURL ? plugin.preprocessURL( processedUrl ) : processedUrl );
+				this.invokeAllPlugins( plugin => uri = plugin.preprocessURL ? plugin.preprocessURL( uri ) : uri );
 
-				return this.fetchTileSet( processedUrl, Object.assign( { signal }, this.fetchOptions ), tileCb );
+				return this.fetchTileSet( uri, Object.assign( { signal }, this.fetchOptions ), tileCb );
 
 			} )
 				.then( json => {
@@ -678,10 +671,9 @@ export class TilesRendererBase {
 
 				}
 
-				let processedUrl = downloadTile.content.uri;
-				this.invokeAllPlugins( plugin => processedUrl = plugin.preprocessURL ? plugin.preprocessURL( processedUrl ) : processedUrl );
+				this.invokeAllPlugins( plugin => uri = plugin.preprocessURL ? plugin.preprocessURL( uri ) : uri );
 
-				return fetch( processedUrl, Object.assign( { signal }, this.fetchOptions ) );
+				return fetch( uri, Object.assign( { signal }, this.fetchOptions ) );
 
 			} )
 				.then( res => {
@@ -726,10 +718,8 @@ export class TilesRendererBase {
 
 						}
 
-						const uri = parseTile.content.uri;
 						const extension = getUrlExtension( uri );
-
-						return this.invokeOnePlugin( plugin => plugin.parseTile && plugin.parseTile( buffer, parseTile, extension ) );
+						return this.invokeOnePlugin( plugin => plugin.parseTile && plugin.parseTile( buffer, parseTile, extension, uri ) );
 
 					} );
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -104,6 +104,19 @@ export class TilesRendererBase {
 
 	}
 
+	set preprocessURL( v ) {
+
+		console.warn( 'TilesRendererBase: The "preprocessURL" callback has been deprecated. Use a plugin, instead.' );
+		this._preprocessURL = v;
+
+	}
+
+	get preprocessURL() {
+
+		return this._preprocessURL;
+
+	}
+
 	constructor( url = null ) {
 
 		// state
@@ -112,7 +125,7 @@ export class TilesRendererBase {
 		this.fetchOptions = {};
 		this.plugins = [];
 
-		this.preprocessURL = null;
+		this._preprocessURL = null;
 
 		const lruCache = new LRUCache();
 		lruCache.unloadPriorityCallback = lruPriorityCallback;
@@ -480,7 +493,7 @@ export class TilesRendererBase {
 		if ( ! ( url in tileSets ) ) {
 
 			let processedUrl = url;
-			this.invokeAllPlugins( plugin => processedUrl = plugin.preprocessURL ? plugin.preprocessURL( processedUrl ) : processedUrl );
+			this.invokeAllPlugins( plugin => processedUrl = plugin.preprocessURL ? plugin.preprocessURL( processedUrl, null ) : processedUrl );
 
 			const pr = this
 				.fetchTileSet( processedUrl, this.fetchOptions )
@@ -524,6 +537,8 @@ export class TilesRendererBase {
 		}
 
 		let uri = new URL( tile.content.uri, tile.__basePath + '/' ).toString();
+		this.invokeAllPlugins( plugin => uri = plugin.preprocessURL ? plugin.preprocessURL( uri, tile ) : uri );
+
 		const stats = this.stats;
 		const lruCache = this.lruCache;
 		const downloadQueue = this.downloadQueue;
@@ -638,8 +653,6 @@ export class TilesRendererBase {
 
 				}
 
-				this.invokeAllPlugins( plugin => uri = plugin.preprocessURL ? plugin.preprocessURL( uri ) : uri );
-
 				return this.fetchTileSet( uri, Object.assign( { signal }, this.fetchOptions ), tileCb );
 
 			} )
@@ -670,8 +683,6 @@ export class TilesRendererBase {
 					return Promise.resolve();
 
 				}
-
-				this.invokeAllPlugins( plugin => uri = plugin.preprocessURL ? plugin.preprocessURL( uri ) : uri );
 
 				return fetch( uri, Object.assign( { signal }, this.fetchOptions ) );
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -305,9 +305,6 @@ export class TilesRendererBase {
 
 	preprocessNode( tile, tileSetDir, parentTile = null ) {
 
-		// Store the original content uri
-		const uri = tile.content?.uri;
-
 		if ( tile.content ) {
 
 			// Fix old file formats
@@ -338,7 +335,7 @@ export class TilesRendererBase {
 		tile.parent = parentTile;
 		tile.children = tile.children || [];
 
-		if ( uri ) {
+		if ( tile.content?.uri ) {
 
 			// "content" should only indicate loadable meshes, not external tile sets
 			const extension = getUrlExtension( tile.content.uri );
@@ -400,7 +397,7 @@ export class TilesRendererBase {
 
 		this.invokeAllPlugins( plugin => {
 
-			plugin !== this && plugin.preprocessNode && plugin.preprocessNode( tile, uri, parentTile );
+			plugin !== this && plugin.preprocessNode && plugin.preprocessNode( tile, tileSetDir, parentTile );
 
 		} );
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -563,12 +563,11 @@ export class TilesRenderer extends TilesRendererBase {
 
 	}
 
-	async parseTile( buffer, tile, extension ) {
+	async parseTile( buffer, tile, extension, uri ) {
 
 		const cached = tile.cached;
 		cached._loadIndex ++;
 
-		const uri = tile.content.uri;
 		const uriSplits = uri.split( /[\\/]/g );
 		uriSplits.pop();
 		const workingPath = uriSplits.join( '/' );

--- a/src/three/plugins/GoogleCloudAuthPlugin.js
+++ b/src/three/plugins/GoogleCloudAuthPlugin.js
@@ -22,7 +22,7 @@ export class GoogleCloudAuthPlugin {
 
 				if ( tile.content && tile.content.uri ) {
 
-					this.sessionToken = new URL( tile.content.uri ).searchParams.get( 'session' );
+					this.sessionToken = new URL( tile.content.uri, tile.__basePath ).searchParams.get( 'session' );
 					return true;
 
 				}

--- a/src/three/plugins/ImplicitTilingPlugin.js
+++ b/src/three/plugins/ImplicitTilingPlugin.js
@@ -58,7 +58,7 @@ export class ImplicitTilingPlugin {
 
 	preprocessURL( url, tile ) {
 
-		if ( tile.implicitTiling ) {
+		if ( tile && tile.implicitTiling ) {
 
 			const implicitUri = tile.implicitTiling.subtrees.uri
 				.replace( '{level}', tile.__level )
@@ -69,6 +69,8 @@ export class ImplicitTilingPlugin {
 			return new URL( implicitUri, tile.__basePath + '/' ).toString();
 
 		}
+
+		return url;
 
 	}
 

--- a/src/three/plugins/ImplicitTilingPlugin.js
+++ b/src/three/plugins/ImplicitTilingPlugin.js
@@ -14,15 +14,12 @@ export class ImplicitTilingPlugin {
 
 	}
 
-	preprocessNode( tile, uri, parentTile ) {
+	preprocessNode( tile, tileSetDir, parentTile ) {
 
-		if ( tile.implicitTiling ) {	//Check if the tile is an Implicit Root Tile
+		if ( tile.implicitTiling ) {
 
 			tile.__hasUnrenderableContent = true;
 			tile.__hasRenderableContent = false;
-
-			// Keep the original content uri
-			tile.__contentUri = uri ?? tile.content?.uri;
 
 			// Declare some properties
 			tile.__subtreeIdx = 0;	// Idx of the tile in its subtree

--- a/src/three/plugins/ImplicitTilingPlugin.js
+++ b/src/three/plugins/ImplicitTilingPlugin.js
@@ -34,15 +34,6 @@ export class ImplicitTilingPlugin {
 			tile.__z = 0;
 			tile.__level = 0;
 
-			// Replace the original content uri to the subtree uri
-			const implicitUri = tile.implicitTiling.subtrees.uri
-				.replace( '{level}', tile.__level )
-				.replace( '{x}', tile.__x )
-				.replace( '{y}', tile.__y )
-				.replace( '{z}', tile.__z );
-
-			tile.content.uri = new URL( implicitUri, tile.__basePath + '/' ).toString();
-
 		} else if ( /.subtree$/i.test( tile.content?.uri ) ) {
 
 			// Handling content uri pointing to a subtree file
@@ -55,12 +46,27 @@ export class ImplicitTilingPlugin {
 
 	parseTile( buffer, parseTile, extension ) {
 
-		//todo use extension instead ?
-		if ( /.subtree$/i.test( parseTile.content.uri ) ) {
+		if ( /^subtree$/i.test( extension ) ) {
 
 			const loader = new SUBTREELoader( parseTile );
 			loader.parse( buffer );
 			return Promise.resolve();
+
+		}
+
+	}
+
+	preprocessURL( url, tile ) {
+
+		if ( tile.implicitTiling ) {
+
+			const implicitUri = tile.implicitTiling.subtrees.uri
+				.replace( '{level}', tile.__level )
+				.replace( '{x}', tile.__x )
+				.replace( '{y}', tile.__y )
+				.replace( '{z}', tile.__z );
+
+			return new URL( implicitUri, tile.__basePath + '/' ).toString();
 
 		}
 

--- a/src/three/plugins/SUBTREELoader.js
+++ b/src/three/plugins/SUBTREELoader.js
@@ -490,7 +490,7 @@ export class SUBTREELoader extends LoaderBase {
 			if ( subtree && this.getBit( subtree._contentAvailabilityBitstreams[ i ], 0 ) ) {
 
 				// Create a child holding the content uri, this child is similar to its parent and doesn't have any children
-				contentTile.content = { uri: this.parseImplicitURI( subtreeRoot, this.rootTile.__contentUri ) };
+				contentTile.content = { uri: this.parseImplicitURI( subtreeRoot, this.rootTile.content.uri ) };
 				break;
 
 			}
@@ -615,7 +615,7 @@ export class SUBTREELoader extends LoaderBase {
 
 			if ( subtree && this.getBit( subtree._contentAvailabilityBitstreams[ i ], childBitIndex ) ) {
 
-				subtreeTile.content = { uri: this.parseImplicitURI( subtreeTile, this.rootTile.__contentUri ) };
+				subtreeTile.content = { uri: this.parseImplicitURI( subtreeTile, this.rootTile.content.uri ) };
 				break;
 
 			}


### PR DESCRIPTION
Related to #608 

- Process URL to final version as-needed instead of processing ahead of time to avoid overwriting original URL data.
- Adjust `preprocessNode` signature so it takes the same arguments as the original function.
- Deprecate "preprocessURL" callback function.

cc @AnthonyGlt 