### PR TITLE
EnvironmentControls: Add rotation + position momentum

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -450,6 +450,14 @@ enabled = true : boolean
 
 Whether the controls are enabled and active.
 
+### .enableDamping
+
+```js
+enableDamping = false : boolean
+```
+
+Flag indicating whether residual inertial animation is played after interaction finishes.
+
 ### .constructor
 
 ```js
@@ -497,10 +505,10 @@ The scene to raycast against for control interactions.
 ### .update
 
 ```js
-update() : void
+update( deltaTime = 16 / 1000 ) : void
 ```
 
-Updates the controls.
+Updates the controls. Takes a delta time value in seconds to normalize inertia and damping speeds.
 
 ### .dispose
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -505,10 +505,10 @@ The scene to raycast against for control interactions.
 ### .update
 
 ```js
-update( deltaTime = 16 / 1000 ) : void
+update( deltaTime = null ) : void
 ```
 
-Updates the controls. Takes a delta time value in seconds to normalize inertia and damping speeds.
+Updates the controls. Takes a delta time value in seconds to normalize inertia and damping speeds. Defaults to the time between call to the function.
 
 ### .dispose
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -625,7 +625,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 		if ( inertiaNeedsUpdate ) {
 
-			this._updateInertiaDamping();
+			this._updateInertiaDamping( deltaTime );
 
 		}
 
@@ -691,7 +691,7 @@ export class EnvironmentControls extends EventDispatcher {
 	}
 
 	// private
-	_updateInertiaDamping() {
+	_updateInertiaDamping( deltaTime ) {
 
 		// update the damping of momentum variables
 		const {
@@ -701,14 +701,14 @@ export class EnvironmentControls extends EventDispatcher {
 			dampingFactor,
 		} = this;
 
-		rotationInertia.multiplyScalar( 1 - dampingFactor );
+		rotationInertia.multiplyScalar( 1 - dampingFactor * deltaTime );
 		if ( rotationInertia.lengthSq() < 1e-8 || ! enableDamping ) {
 
 			rotationInertia.set( 0, 0 );
 
 		}
 
-		dragInertia.multiplyScalar( 1 - dampingFactor );
+		dragInertia.multiplyScalar( 1 - dampingFactor * deltaTime );
 		if ( dragInertia.lengthSq() < 1e-8 || ! enableDamping ) {
 
 			dragInertia.set( 0, 0, 0 );

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -1021,11 +1021,12 @@ export class EnvironmentControls extends EventDispatcher {
 			pointerTracker.getCenterPoint( _pointer );
 			pointerTracker.getPreviousCenterPoint( _prevPointer );
 			_deltaPointer.subVectors( _pointer, _prevPointer ).multiplyScalar( 2 * Math.PI / domElement.clientHeight );
-			rotationInertia.lerp( _deltaPointer, 0.9 );
 
 			// update rotation inertia
-			_deltaPointer.multiplyScalar( 1 / deltaTime );
 			this._applyRotation( _deltaPointer.x, _deltaPointer.y, pivotPoint );
+
+			_deltaPointer.multiplyScalar( 1 / deltaTime );
+			rotationInertia.lerp( _deltaPointer, 0.9 );
 
 		} else if ( enableDamping ) {
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -338,8 +338,8 @@ export class EnvironmentControls extends EventDispatcher {
 						pointerTracker.getCenterPoint( _centerPoint );
 
 						// detect zoom transition
-						const startDist = pointerTracker.getStartPointerDistance();
-						const pointerDist = pointerTracker.getPointerDistance();
+						const startDist = pointerTracker.getStartTouchPointerDistance();
+						const pointerDist = pointerTracker.getTouchPointerDistance();
 						const separateDelta = pointerDist - startDist;
 						if ( this.state === NONE || this.state === WAITING ) {
 
@@ -370,7 +370,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 						if ( this.state === ZOOM ) {
 
-							const previousDist = pointerTracker.getPreviousPointerDistance();
+							const previousDist = pointerTracker.getPreviousTouchPointerDistance();
 							this.zoomDelta += pointerDist - previousDist;
 
 						} else if ( this.state === ROTATE ) {

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -87,7 +87,7 @@ export class EnvironmentControls extends EventDispatcher {
 		this.zoomSpeed = 1;
 		this.adjustHeight = true;
 		this.enableDamping = true;
-		this.dampingFactor = 0.05;
+		this.dampingFactor = 0.2;
 
 		// settings for GlobeControls
 		this.reorientOnDrag = true;

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -600,7 +600,7 @@ export class EnvironmentControls extends EventDispatcher {
 		} = this;
 
 		// update the actions
-		const inertiaNeedsUpdate = this._momentumNeedsUpdate();
+		const inertiaNeedsUpdate = this._inertiaNeedsUpdate();
 		if ( this.needsUpdate || inertiaNeedsUpdate ) {
 
 			const zoomDelta = this.zoomDelta;
@@ -722,7 +722,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 	}
 
-	_momentumNeedsUpdate() {
+	_inertiaNeedsUpdate() {
 
 		const {
 			rotationInertia,

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -571,6 +571,7 @@ export class EnvironmentControls extends EventDispatcher {
 		this.dragInertia.set( 0, 0, 0 );
 		this.rotationInertia.set( 0, 0 );
 		this.state = state;
+
 		if ( state !== NONE && state !== WAITING ) {
 
 			this._lastUsedState = state;
@@ -985,7 +986,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 				// update the drag inertia
 				_delta.multiplyScalar( 1 / deltaTime );
-				if ( _delta.lengthSq() < 1e-3 ) {
+				if ( pointerTracker.getMoveDistance() / deltaTime < 2 * window.devicePixelRatio ) {
 
 					dragInertia.lerp( _delta, 0.5 );
 
@@ -999,7 +1000,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 		} else if ( enableDamping ) {
 
-			camera.position.add( dragInertia * deltaTime );
+			camera.position.addScaledVector( dragInertia, deltaTime );
 			camera.updateMatrixWorld();
 
 		}
@@ -1024,11 +1025,11 @@ export class EnvironmentControls extends EventDispatcher {
 			pointerTracker.getPreviousCenterPoint( _prevPointer );
 			_deltaPointer.subVectors( _pointer, _prevPointer ).multiplyScalar( 2 * Math.PI / domElement.clientHeight );
 
-			// update rotation inertia
 			this._applyRotation( _deltaPointer.x, _deltaPointer.y, pivotPoint );
 
+			// update rotation inertia
 			_deltaPointer.multiplyScalar( 1 / deltaTime );
-			if ( _deltaPointer.lengthSq() < 1e-3 ) {
+			if ( pointerTracker.getMoveDistance() / deltaTime < 2 * window.devicePixelRatio ) {
 
 				rotationInertia.lerp( _deltaPointer, 0.5 );
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -701,14 +701,16 @@ export class EnvironmentControls extends EventDispatcher {
 			dampingFactor,
 		} = this;
 
-		rotationInertia.multiplyScalar( 1 - dampingFactor * deltaTime );
+
+		const factor = Math.pow( 2, - deltaTime / dampingFactor );
+		rotationInertia.multiplyScalar( factor );
 		if ( rotationInertia.lengthSq() < 1e-8 || ! enableDamping ) {
 
 			rotationInertia.set( 0, 0 );
 
 		}
 
-		dragInertia.multiplyScalar( 1 - dampingFactor * deltaTime );
+		dragInertia.multiplyScalar( factor );
 		if ( dragInertia.lengthSq() < 1e-8 || ! enableDamping ) {
 
 			dragInertia.set( 0, 0, 0 );
@@ -983,7 +985,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 				// update the drag inertia
 				_delta.multiplyScalar( 1 / deltaTime );
-				if ( _delta.lengthSq() < 1e-8 ) {
+				if ( _delta.lengthSq() < 1e-3 ) {
 
 					dragInertia.lerp( _delta, 0.5 );
 
@@ -1026,7 +1028,15 @@ export class EnvironmentControls extends EventDispatcher {
 			this._applyRotation( _deltaPointer.x, _deltaPointer.y, pivotPoint );
 
 			_deltaPointer.multiplyScalar( 1 / deltaTime );
-			rotationInertia.lerp( _deltaPointer, 0.9 );
+			if ( _deltaPointer.lengthSq() < 1e-3 ) {
+
+				rotationInertia.lerp( _deltaPointer, 0.5 );
+
+			} else {
+
+				rotationInertia.copy( _deltaPointer );
+
+			}
 
 		} else if ( enableDamping ) {
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -105,8 +105,8 @@ export class EnvironmentControls extends EventDispatcher {
 		this.zoomPoint = new Vector3();
 		this.zoomDelta = 0;
 
-		this.rotationMomentum = new Vector2();
-		this.dragMomentum = new Vector3();
+		this.rotationInertia = new Vector2();
+		this.dragInertia = new Vector3();
 
 		this.pivotMesh = new PivotPointMesh();
 		this.pivotMesh.raycast = () => {};
@@ -565,8 +565,8 @@ export class EnvironmentControls extends EventDispatcher {
 
 		}
 
-		this.dragMomentum.set( 0, 0, 0 );
-		this.rotationMomentum.set( 0, 0 );
+		this.dragInertia.set( 0, 0, 0 );
+		this.rotationInertia.set( 0, 0 );
 		this.state = state;
 		if ( state !== NONE && state !== WAITING ) {
 
@@ -684,21 +684,21 @@ export class EnvironmentControls extends EventDispatcher {
 
 		// update the damping of momentum variables
 		const {
-			rotationMomentum,
-			dragMomentum,
+			rotationInertia,
+			dragInertia,
 		} = this;
 
-		rotationMomentum.multiplyScalar( 0.95 );
-		if ( rotationMomentum.lengthSq() < 1e-8 ) {
+		rotationInertia.multiplyScalar( 0.95 );
+		if ( rotationInertia.lengthSq() < 1e-8 ) {
 
-			rotationMomentum.set( 0, 0 );
+			rotationInertia.set( 0, 0 );
 
 		}
 
-		dragMomentum.multiplyScalar( 0.95 );
-		if ( dragMomentum.lengthSq() < 1e-8 ) {
+		dragInertia.multiplyScalar( 0.95 );
+		if ( dragInertia.lengthSq() < 1e-8 ) {
 
-			dragMomentum.set( 0, 0, 0 );
+			dragInertia.set( 0, 0, 0 );
 
 		}
 
@@ -707,10 +707,10 @@ export class EnvironmentControls extends EventDispatcher {
 	_momentumNeedsUpdate() {
 
 		const {
-			rotationMomentum,
-			dragMomentum,
+			rotationInertia,
+			dragInertia,
 		} = this;
-		return rotationMomentum.lengthSq() !== 0 || dragMomentum.lengthSq() !== 0;
+		return rotationInertia.lengthSq() !== 0 || dragInertia.lengthSq() !== 0;
 
 	}
 
@@ -908,7 +908,7 @@ export class EnvironmentControls extends EventDispatcher {
 			pointerTracker,
 			domElement,
 			state,
-			dragMomentum,
+			dragInertia,
 		} = this;
 
 		if ( state === DRAG ) {
@@ -969,11 +969,11 @@ export class EnvironmentControls extends EventDispatcher {
 
 				if ( _delta.lengthSq() < 1e-8 ) {
 
-					dragMomentum.lerp( _delta, 0.5 );
+					dragInertia.lerp( _delta, 0.5 );
 
 				} else {
 
-					dragMomentum.copy( _delta );
+					dragInertia.copy( _delta );
 
 				}
 
@@ -981,7 +981,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 		} else {
 
-			camera.position.add( dragMomentum );
+			camera.position.add( dragInertia );
 			camera.updateMatrixWorld();
 
 		}
@@ -995,7 +995,7 @@ export class EnvironmentControls extends EventDispatcher {
 			pointerTracker,
 			domElement,
 			state,
-			rotationMomentum,
+			rotationInertia,
 		} = this;
 
 		if ( state === ROTATE ) {
@@ -1004,13 +1004,13 @@ export class EnvironmentControls extends EventDispatcher {
 			pointerTracker.getCenterPoint( _pointer );
 			pointerTracker.getPreviousCenterPoint( _prevPointer );
 			_deltaPointer.subVectors( _pointer, _prevPointer ).multiplyScalar( 2 * Math.PI / domElement.clientHeight );
-			rotationMomentum.lerp( _deltaPointer, 0.9 );
+			rotationInertia.lerp( _deltaPointer, 0.9 );
 
 			this._applyRotation( _deltaPointer.x, _deltaPointer.y, pivotPoint );
 
 		} else {
 
-			this._applyRotation( rotationMomentum.x, rotationMomentum.y, pivotPoint );
+			this._applyRotation( rotationInertia.x, rotationInertia.y, pivotPoint );
 
 		}
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -7,6 +7,7 @@ import {
 	Plane,
 	EventDispatcher,
 	MathUtils,
+	Clock,
 } from 'three';
 import { PivotPointMesh } from './PivotPointMesh.js';
 import { PointerTracker } from './PointerTracker.js';
@@ -87,7 +88,7 @@ export class EnvironmentControls extends EventDispatcher {
 		this.zoomSpeed = 1;
 		this.adjustHeight = true;
 		this.enableDamping = true;
-		this.dampingFactor = 0.2;
+		this.dampingFactor = 0.15;
 
 		// settings for GlobeControls
 		this.reorientOnDrag = true;
@@ -118,6 +119,7 @@ export class EnvironmentControls extends EventDispatcher {
 		this.raycaster.firstHitOnly = true;
 
 		this.up = new Vector3( 0, 1, 0 );
+		this.clock = new Clock();
 
 		this.fallbackPlane = new Plane( new Vector3( 0, 1, 0 ), 0 );
 		this.useFallbackPlane = true;
@@ -580,7 +582,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 	}
 
-	update( deltaTime = 16 / 1000 ) {
+	update( deltaTime = Math.min( this.clock.getDelta(), 64 / 1000 ) ) {
 
 		if ( ! this.enabled || ! this.camera ) {
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -579,7 +579,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 	}
 
-	update() {
+	update( deltaTime = 16 / 1000 ) {
 
 		if ( ! this.enabled || ! this.camera ) {
 
@@ -610,8 +610,8 @@ export class EnvironmentControls extends EventDispatcher {
 
 			}
 
-			this._updatePosition();
-			this._updateRotation();
+			this._updatePosition( deltaTime );
+			this._updateRotation( deltaTime );
 
 			if ( state !== NONE || zoomDelta !== 0 || inertiaNeedsUpdate ) {
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -704,8 +704,10 @@ export class EnvironmentControls extends EventDispatcher {
 			dampingFactor,
 		} = this;
 
-
+		// Based on Freya Holmer's frame-rate independent lerp function
 		const factor = Math.pow( 2, - deltaTime / dampingFactor );
+
+		// scale the residual motion
 		rotationInertia.multiplyScalar( factor );
 		if ( rotationInertia.lengthSq() < 1e-8 || ! enableDamping ) {
 
@@ -724,10 +726,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 	_inertiaNeedsUpdate() {
 
-		const {
-			rotationInertia,
-			dragInertia,
-		} = this;
+		const { rotationInertia, dragInertia } = this;
 		return rotationInertia.lengthSq() !== 0 || dragInertia.lengthSq() !== 0;
 
 	}

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -911,7 +911,7 @@ export class EnvironmentControls extends EventDispatcher {
 	}
 
 	// update the drag action
-	_updatePosition() {
+	_updatePosition( deltaTime ) {
 
 		const {
 			raycaster,
@@ -981,6 +981,8 @@ export class EnvironmentControls extends EventDispatcher {
 				camera.position.add( _delta );
 				camera.updateMatrixWorld();
 
+				// update the drag inertia
+				_delta.multiplyScalar( 1 / deltaTime );
 				if ( _delta.lengthSq() < 1e-8 ) {
 
 					dragInertia.lerp( _delta, 0.5 );
@@ -995,14 +997,14 @@ export class EnvironmentControls extends EventDispatcher {
 
 		} else if ( enableDamping ) {
 
-			camera.position.add( dragInertia );
+			camera.position.add( dragInertia * deltaTime );
 			camera.updateMatrixWorld();
 
 		}
 
 	}
 
-	_updateRotation() {
+	_updateRotation( deltaTime ) {
 
 		const {
 			pivotPoint,
@@ -1021,11 +1023,13 @@ export class EnvironmentControls extends EventDispatcher {
 			_deltaPointer.subVectors( _pointer, _prevPointer ).multiplyScalar( 2 * Math.PI / domElement.clientHeight );
 			rotationInertia.lerp( _deltaPointer, 0.9 );
 
+			// update rotation inertia
+			_deltaPointer.multiplyScalar( 1 / deltaTime );
 			this._applyRotation( _deltaPointer.x, _deltaPointer.y, pivotPoint );
 
 		} else if ( enableDamping ) {
 
-			this._applyRotation( rotationInertia.x, rotationInertia.y, pivotPoint );
+			this._applyRotation( rotationInertia.x * deltaTime, rotationInertia.y * deltaTime, pivotPoint );
 
 		}
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -408,7 +408,7 @@ export class GlobeControls extends EnvironmentControls {
 
 			const angle = getAxisAngle( _quaternion, _vec ) * 1000 / deltaTime;
 			const { dragInertia, inertiaAxis } = this;
-			if ( angle < 1e-1 ) {
+			if ( pointerTracker.getMoveDistance() / deltaTime < 2 * window.devicePixelRatio ) {
 
 				dragInertia.x = MathUtils.lerp( dragInertia.x, angle, 0.5 );
 				dragInertia.y = 0;

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -504,7 +504,7 @@ export class GlobeControls extends EnvironmentControls {
 
 			this.inertiaDragMode = - 1;
 			_deltaPointer.multiplyScalar( 1 / deltaTime );
-			if ( _deltaPointer.lengthSq() < 1e-8 ) {
+			if ( _deltaPointer.lengthSq() < 1e-3 ) {
 
 				this.dragInertia.lerp( _deltaPointer, 0.5 );
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -179,7 +179,7 @@ export class GlobeControls extends EnvironmentControls {
 
 	}
 
-	update( deltaTime ) {
+	update( deltaTime = Math.min( this.clock.getDelta(), 64 / 1000 ) ) {
 
 		if ( ! this.enabled || ! this.tilesGroup || ! this.camera ) {
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -314,28 +314,32 @@ export class GlobeControls extends EnvironmentControls {
 
 		if ( this.state !== DRAG ) {
 
-			if ( this.inertiaDragMode === 1 ) {
+			if ( this.enableDamping ) {
 
-				const {
-					tilesGroup,
-					inertiaAxis,
-					dragInertia,
-					camera,
-				} = this;
+				if ( this.inertiaDragMode === 1 ) {
 
-				const angle = dragInertia.x * 1e-3;
-				_quaternion.setFromAxisAngle( inertiaAxis, angle * deltaTime );
-				_center.setFromMatrixPosition( tilesGroup.matrixWorld );
-				makeRotateAroundPoint( _center, _quaternion, _rotMatrix );
+					const {
+						tilesGroup,
+						inertiaAxis,
+						dragInertia,
+						camera,
+					} = this;
 
-				// apply the rotation
-				camera.matrixWorld.premultiply( _rotMatrix );
-				camera.matrixWorld.decompose( camera.position, camera.quaternion, _vec );
+					const angle = dragInertia.x * 1e-3;
+					_quaternion.setFromAxisAngle( inertiaAxis, angle * deltaTime );
+					_center.setFromMatrixPosition( tilesGroup.matrixWorld );
+					makeRotateAroundPoint( _center, _quaternion, _rotMatrix );
 
-			} else {
+					// apply the rotation
+					camera.matrixWorld.premultiply( _rotMatrix );
+					camera.matrixWorld.decompose( camera.position, camera.quaternion, _vec );
 
-				const { dragInertia } = this;
-				this._applyZoomedOutRotation( dragInertia.x * deltaTime, dragInertia.y * deltaTime );
+				} else {
+
+					const { dragInertia } = this;
+					this._applyZoomedOutRotation( dragInertia.x * deltaTime, dragInertia.y * deltaTime );
+
+				}
 
 			}
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -3,6 +3,7 @@ import {
 	Quaternion,
 	Vector2,
 	Vector3,
+	Vector4,
 	MathUtils,
 	Ray,
 } from 'three';
@@ -26,28 +27,13 @@ const _toCenter = new Vector3();
 const _latLon = {};
 const _ray = new Ray();
 const _ellipsoid = new Ellipsoid();
+const _axisAngle = new Vector4();
 
 const _pointer = new Vector2();
 const _prevPointer = new Vector2();
 const _deltaPointer = new Vector2();
 
 const MIN_ELEVATION = 400;
-function getAxisAngle( quaternion, target ) {
-
-	const qx = quaternion.x;
-	const qy = quaternion.y;
-	const qz = quaternion.z;
-	const qw = quaternion.w;
-
-	const angle = 2 * Math.acos( qw );
-	const x = qx / Math.sqrt( 1 - qw * qw );
-	const y = qy / Math.sqrt( 1 - qw * qw );
-	const z = qz / Math.sqrt( 1 - qw * qw );
-
-	target.set( x, y, z );
-	return angle;
-
-}
 
 export class GlobeControls extends EnvironmentControls {
 
@@ -406,7 +392,10 @@ export class GlobeControls extends EnvironmentControls {
 			// track inertia variables
 			this.inertiaDragMode = 1;
 
-			const angle = getAxisAngle( _quaternion, _vec ) * 1000 / deltaTime;
+			_axisAngle.setAxisAngleFromQuaternion( _quaternion );
+			const angle = _axisAngle.w * 1000 / deltaTime;
+			_vec.copy( _axisAngle );
+
 			const { dragInertia, inertiaAxis } = this;
 			if ( pointerTracker.getMoveDistance() / deltaTime < 2 * window.devicePixelRatio ) {
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -179,7 +179,7 @@ export class GlobeControls extends EnvironmentControls {
 
 	}
 
-	update() {
+	update( deltaTime ) {
 
 		if ( ! this.enabled || ! this.tilesGroup || ! this.camera ) {
 
@@ -211,7 +211,7 @@ export class GlobeControls extends EnvironmentControls {
 		}
 
 		// fire basic controls update
-		super.update();
+		super.update( deltaTime );
 
 		if ( camera.isPerspectiveCamera ) {
 
@@ -310,7 +310,7 @@ export class GlobeControls extends EnvironmentControls {
 
 	}
 
-	_updatePosition() {
+	_updatePosition( deltaTime ) {
 
 		if ( this.state !== DRAG ) {
 
@@ -324,7 +324,7 @@ export class GlobeControls extends EnvironmentControls {
 				} = this;
 
 				const angle = dragInertia.x * 1e-3;
-				_quaternion.setFromAxisAngle( inertiaAxis, angle );
+				_quaternion.setFromAxisAngle( inertiaAxis, angle * deltaTime );
 				_center.setFromMatrixPosition( tilesGroup.matrixWorld );
 				makeRotateAroundPoint( _center, _quaternion, _rotMatrix );
 
@@ -334,7 +334,8 @@ export class GlobeControls extends EnvironmentControls {
 
 			} else {
 
-				this._applyZoomedOutRotation( this.dragInertia.x, this.dragInertia.y );
+				const { dragInertia } = this;
+				this._applyZoomedOutRotation( dragInertia.x * deltaTime, dragInertia.y * deltaTime );
 
 			}
 
@@ -401,7 +402,7 @@ export class GlobeControls extends EnvironmentControls {
 			// track inertia variables
 			this.inertiaDragMode = 1;
 
-			const angle = getAxisAngle( _quaternion, _vec ) * 1000;
+			const angle = getAxisAngle( _quaternion, _vec ) * 1000 / deltaTime;
 			const { dragInertia, inertiaAxis } = this;
 			if ( angle < 1e-1 ) {
 
@@ -498,6 +499,7 @@ export class GlobeControls extends EnvironmentControls {
 			pivotMesh.visible = false;
 
 			this.inertiaDragMode = - 1;
+			_deltaPointer.multiplyScalar( 1 / deltaTime );
 			if ( _deltaPointer.lengthSq() < 1e-8 ) {
 
 				this.dragInertia.lerp( _deltaPointer, 0.5 );

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -300,16 +300,20 @@ export class GlobeControls extends EnvironmentControls {
 
 		if ( this.state !== DRAG ) {
 
-			if ( this.enableDamping ) {
+			const {
+				enableDamping,
+				inertiaDragMode,
+				tilesGroup,
+				inertiaAxis,
+				dragInertia,
+				camera,
+			} = this;
 
-				if ( this.inertiaDragMode === 1 ) {
+			// apply inertia for movement
+			if ( enableDamping ) {
 
-					const {
-						tilesGroup,
-						inertiaAxis,
-						dragInertia,
-						camera,
-					} = this;
+				// drag mode 1 means we're near the globe
+				if ( inertiaDragMode === 1 ) {
 
 					const angle = dragInertia.x * 1e-3;
 					_quaternion.setFromAxisAngle( inertiaAxis, angle * deltaTime );
@@ -322,7 +326,6 @@ export class GlobeControls extends EnvironmentControls {
 
 				} else {
 
-					const { dragInertia } = this;
 					this._applyZoomedOutRotation( dragInertia.x * deltaTime, dragInertia.y * deltaTime );
 
 				}

--- a/src/three/controls/PointerTracker.js
+++ b/src/three/controls/PointerTracker.js
@@ -1,5 +1,7 @@
 import { Vector2 } from 'three';
 
+const _vec = new Vector2();
+const _vec2 = new Vector2();
 export class PointerTracker {
 
 	constructor() {
@@ -182,7 +184,16 @@ export class PointerTracker {
 
 	}
 
-	getPointerDistance( pointerPositions = this.pointerPositions ) {
+	getMoveDistance() {
+
+		this.getCenterPoint( _vec );
+		this.getPreviousCenterPoint( _vec2 );
+
+		return _vec.sub( _vec2 ).length();
+
+	}
+
+	getTouchPointerDistance( pointerPositions = this.pointerPositions ) {
 
 		if ( this.getPointerCount() <= 1 || this.getPointerType() === 'mouse' ) {
 
@@ -201,15 +212,15 @@ export class PointerTracker {
 
 	}
 
-	getPreviousPointerDistance() {
+	getPreviousTouchPointerDistance() {
 
-		return this.getPointerDistance( this.previousPositions );
+		return this.getTouchPointerDistance( this.previousPositions );
 
 	}
 
-	getStartPointerDistance() {
+	getStartTouchPointerDistance() {
 
-		return this.getPointerDistance( this.startPositions );
+		return this.getTouchPointerDistance( this.startPositions );
 
 	}
 


### PR DESCRIPTION
Fix #654 

**TODO**
- ~Reset momentum on zoom update~
- ~Add "change" events on momentum update~
- ~Add flags for disabling~
- ~Update inertia dampening and application to be frame rate dependent~
- ~Add position inertia support to globe controls~
- ~Adjust dampening approach to be consistent / reliable~
  - https://medium.com/@lemapp09/beginning-game-development-lerp-is-broken-1f92ae0cd2bb
  - https://kemono.su/patreon/user/6559406/post/105228270
  - https://x.com/FreyaHolmer/status/1757836988495847568
- ~Docs~
- ~Limit scale based on screen drag rather than world drag~
- ~Zoom in too far causes reversal~
- Add built in clock
- Hone inertia setting scales

**Future**
- Refreshing google maps example causes odd camera rotation (caused by Globe controls - review separately) #705