### PR TITLE
Fix `TileBoundingVolume.intersectsRay` (typo)

### DIFF
--- a/src/three/math/TileBoundingVolume.js
+++ b/src/three/math/TileBoundingVolume.js
@@ -35,7 +35,7 @@ export class TileBoundingVolume {
 		}
 
 		// Early out if we don't this this tile box
-		if ( obb && ! obb.intersectRay( ray ) ) {
+		if ( obb && ! obb.intersectsRay( ray ) ) {
 
 			return false;
 


### PR DESCRIPTION
I think the wrong function was called? This lead to an exception for me when raycasting the scene. 