### PR TITLE
Rename threejs `REVISION_165` to `REVISION_LESS/GEQ_165` to clearify its usage

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -20,7 +20,7 @@ import { ExtendedFrustum } from './math/ExtendedFrustum.js';
 import { estimateBytesUsed } from './utilities.js';
 
 // In three.js r165 and higher raycast traversal can be ended early
-const REVISION_165 = parseInt( REVISION ) < 165;
+const REVISION_LESS_165 = parseInt( REVISION ) < 165;
 const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
 const tempMat2 = new Matrix4();
@@ -100,7 +100,7 @@ export class TilesRenderer extends TilesRendererBase {
 		} );
 		this.manager = manager;
 
-		if ( REVISION_165 ) {
+		if ( REVISION_LESS_165 ) {
 
 			// Setting up the override raycasting function to be used by
 			// 3D objects created by this renderer
@@ -735,7 +735,7 @@ export class TilesRenderer extends TilesRendererBase {
 		} );
 		updateFrustumCulled( scene, ! this.autoDisableRendererCulling );
 
-		if ( REVISION_165 ) {
+		if ( REVISION_LESS_165 ) {
 
 			// We handle raycasting in a custom way so remove it from here
 			scene.traverse( c => {

--- a/src/three/loaders/gltf/metadata/utilities/TextureReadUtility.js
+++ b/src/three/loaders/gltf/metadata/utilities/TextureReadUtility.js
@@ -1,8 +1,8 @@
 import { WebGLRenderTarget, WebGLRenderer, Box2, Vector2, Vector4, ShaderMaterial, REVISION, CustomBlending, ZeroFactor, OneFactor } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 
-const REVISION_165 = parseInt( REVISION ) >= 165;
-const REVISION_166 = parseInt( REVISION ) >= 166;
+const REVISION_GEQ_165 = parseInt( REVISION ) >= 165;
+const REVISION_GEQ_166 = parseInt( REVISION ) >= 166;
 const _box = /* @__PURE__ */ new Box2();
 const _currentScissor = /* @__PURE__ */ new Vector4();
 const _pos = /* @__PURE__ */ new Vector2();
@@ -64,7 +64,7 @@ export const TextureReadUtility = new ( class {
 	readDataAsync( buffer ) {
 
 		const { _renderer, _target } = this;
-		if ( REVISION_165 ) {
+		if ( REVISION_GEQ_165 ) {
 
 			return _renderer.readRenderTargetPixelsAsync( _target, 0, 0, buffer.length / 4, 1, buffer );
 
@@ -90,7 +90,7 @@ export const TextureReadUtility = new ( class {
 
 		const { _quad, _renderer, _target, _texTarget } = this;
 
-		if ( REVISION_166 ) {
+		if ( REVISION_GEQ_166 ) {
 
 			// copies the pixel directly to the target buffer
 			_box.min.copy( pixel );
@@ -114,7 +114,7 @@ export const TextureReadUtility = new ( class {
 
 			// render the data
 			_pos.set( 0, 0 );
-			if ( REVISION_165 ) {
+			if ( REVISION_GEQ_165 ) {
 
 				_renderer.copyTextureToTexture( texture, _texTarget.texture, null, _pos );
 

--- a/src/three/raycastTraverse.js
+++ b/src/three/raycastTraverse.js
@@ -1,7 +1,7 @@
 import { Matrix4, Ray, Vector3, REVISION } from 'three';
 
 // In three.js r165 and higher raycast traversal can be ended early
-const REVISION_165 = parseInt( REVISION ) < 165;
+const REVISION_LESS_165 = parseInt( REVISION ) < 165;
 const _mat = new Matrix4();
 const _localRay = new Ray();
 const _vec = new Vector3();
@@ -15,7 +15,7 @@ function distanceSort( a, b ) {
 
 function intersectTileScene( scene, raycaster, intersects ) {
 
-	if ( REVISION_165 ) {
+	if ( REVISION_LESS_165 ) {
 
 		// Don't intersect the box3 helpers because those are used for debugging
 		scene.traverse( c => {


### PR DESCRIPTION
I think `REVISION` definition is wrong currently, preventing a raycast optimization?
(Also renamed the variable to be more clear that it's greater equals that version)