### PR TITLE
Traversal: Remove check if a tile has renderable content before loading root sibling tiles

### DIFF
--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -206,7 +206,7 @@ export function markUsedTiles( tile, renderer ) {
 
 	// If this is a tile that needs children loaded to refine then recursively load child
 	// tiles until error is met
-	if ( anyChildrenUsed && tile.refine === 'REPLACE' && tile.__hasRenderableContent ) {
+	if ( anyChildrenUsed && tile.refine === 'REPLACE' ) {
 
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 


### PR DESCRIPTION
Reverts the change in #670 that avoids loading all contentful child tiles before refining if it's an empty tile near the root since it can cause gaps in tile sets as the camera moves which can be particularly noticeable with fade-in behavior. See https://github.com/iTowns/itowns/issues/2335 and https://github.com/CesiumGS/3d-tiles/issues/776.