### PR TITLE
fix: load i3dm with external gtlf

### DIFF
--- a/src/base/loaders/I3DMLoaderBase.js
+++ b/src/base/loaders/I3DMLoaderBase.js
@@ -77,6 +77,7 @@ export class I3DMLoaderBase extends LoaderBase {
 
 		let glbBytes = null;
 		let promise = null;
+		let gltfWorkingPath = null;
 		if ( gltfFormat ) {
 
 			glbBytes = bodyBytes;
@@ -84,13 +85,19 @@ export class I3DMLoaderBase extends LoaderBase {
 
 		} else {
 
-			this.workingPath = this.resolveExternalURL( arrayToString( bodyBytes ) );
-			promise = fetch( this.workingPath, this.fetchOptions )
+			const externalUri = this.resolveExternalURL( arrayToString( bodyBytes ) );
+
+			//Store the gltf working path
+			const uriSplits = externalUri.split( /[\\/]/g );
+			uriSplits.pop();
+			gltfWorkingPath = uriSplits.join( '/' );
+
+			promise = fetch( externalUri, this.fetchOptions )
 				.then( res => {
 
 					if ( ! res.ok ) {
 
-						throw new Error( `I3DMLoaderBase : Failed to load file "${ this.workingPath }" with status ${ res.status } : ${ res.statusText }` );
+						throw new Error( `I3DMLoaderBase : Failed to load file "${ externalUri }" with status ${ res.status } : ${ res.statusText }` );
 
 					}
 
@@ -112,7 +119,7 @@ export class I3DMLoaderBase extends LoaderBase {
 				featureTable,
 				batchTable,
 				glbBytes,
-
+				gltfWorkingPath
 			};
 
 		} );

--- a/src/base/loaders/I3DMLoaderBase.js
+++ b/src/base/loaders/I3DMLoaderBase.js
@@ -84,13 +84,13 @@ export class I3DMLoaderBase extends LoaderBase {
 
 		} else {
 
-			const externalUri = this.resolveExternalURL( arrayToString( bodyBytes ) );
-			promise = fetch( externalUri, this.fetchOptions )
+			this.workingPath = this.resolveExternalURL( arrayToString( bodyBytes ) );
+			promise = fetch( this.workingPath, this.fetchOptions )
 				.then( res => {
 
 					if ( ! res.ok ) {
 
-						throw new Error( `I3DMLoaderBase : Failed to load file "${ externalUri }" with status ${ res.status } : ${ res.statusText }` );
+						throw new Error( `I3DMLoaderBase : Failed to load file "${ this.workingPath }" with status ${ res.status } : ${ res.statusText }` );
 
 					}
 
@@ -112,6 +112,7 @@ export class I3DMLoaderBase extends LoaderBase {
 				featureTable,
 				batchTable,
 				glbBytes,
+
 			};
 
 		} );

--- a/src/base/loaders/LoaderBase.js
+++ b/src/base/loaders/LoaderBase.js
@@ -43,7 +43,7 @@ export class LoaderBase {
 
 	resolveExternalURL( url ) {
 
-		if ( /^[^\\/]/.test( url ) ) {
+		if ( /^[^\\/]/.test( url ) && !/^http/.test(url)) {
 
 			return this.workingPath + '/' + url;
 

--- a/src/base/loaders/LoaderBase.js
+++ b/src/base/loaders/LoaderBase.js
@@ -43,7 +43,7 @@ export class LoaderBase {
 
 	resolveExternalURL( url ) {
 
-		if ( /^[^\\/]/.test( url ) && !/^http/.test(url)) {
+		if ( /^[^\\/]/.test( url ) && ! /^http/.test( url ) ) {
 
 			return this.workingPath + '/' + url;
 

--- a/src/three/loaders/I3DMLoader.js
+++ b/src/three/loaders/I3DMLoader.js
@@ -59,9 +59,7 @@ export class I3DMLoader extends I3DMLoaderBase {
 					}
 
 					// GLTFLoader assumes the working path ends in a slash
-					const uriSplits = this.workingPath.split( /[\\/]/g );
-					uriSplits.pop();
-					let workingPath = uriSplits.join( '/' );
+					let workingPath = i3dm.gltfWorkingPath ?? this.workingPath;
 					if ( ! /[\\/]$/.test( workingPath ) ) {
 
 						workingPath += '/';

--- a/src/three/loaders/I3DMLoader.js
+++ b/src/three/loaders/I3DMLoader.js
@@ -59,7 +59,9 @@ export class I3DMLoader extends I3DMLoaderBase {
 					}
 
 					// GLTFLoader assumes the working path ends in a slash
-					let workingPath = this.workingPath;
+					const uriSplits = this.workingPath.split( /[\\/]/g );
+					uriSplits.pop();
+					let workingPath = uriSplits.join( '/' );
 					if ( ! /[\\/]$/.test( workingPath ) ) {
 
 						workingPath += '/';


### PR DESCRIPTION
Load correctly the i3dm files when the gltf is external and doesn't share the same base url

This adaptation is made to comply with this part of the [documentation](https://portal.ogc.org/files/102132#tileformats-instanced3dmodel-instanced-3d-model):
>When the glTF field contains a URI, then this URI may point to a [relative external reference (RFC3986)](https://tools.ietf.org/html/rfc3986#section-4.2). When the URI is relative, its base is always relative to the referring .i3dm file. Client implementations are required to support relative external references. **Optionally, client implementations may support other schemes (such as http://). All URIs shall be valid and resolvable.**

We should be able to load i3dm containing an URL starting by "http"

