### PR TITLE
Update cache, dispose of loaded tiles if the cache is full

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -733,17 +733,16 @@ export class TilesRendererBase {
 
 				stats.parsing --;
 				tile.__loadingState = LOADED;
-				lruCache.updateMemoryUsage( tile );
 
-				if ( tile.__wasSetVisible ) {
+				// if the cache is full due to newly loaded memory then lets discard this tile - it will
+				// be loaded again later from the disk cache if needed.
+				if ( lruCache.isFull() ) {
 
-					this.setTileVisible( tile, true );
+					lruCache.remove( tile );
 
-				}
+				} else {
 
-				if ( tile.__wasSetActive ) {
-
-					this.setTileActive( tile, true );
+					lruCache.updateMemoryUsage( tile );
 
 				}
 

--- a/test/LRUCache.test.js
+++ b/test/LRUCache.test.js
@@ -95,7 +95,7 @@ describe( 'LRUCache', () => {
 
 	} );
 
-	it.skip( 'should evict items if they are the max item length even if they are used.', () => {
+	it( 'should evict items if they are the max item length even if they are used.', () => {
 
 		const cache = new LRUCache();
 		cache.unloadPriorityCallback = ( itemA, itemB ) => itemA.priority - itemB.priority;
@@ -143,7 +143,7 @@ describe( 'LRUCache', () => {
 
 	} );
 
-	it.skip( 'should update memory usage when the items are triggers.', () => {
+	it( 'should update memory usage when the items are triggers.', () => {
 
 		const cache = new LRUCache();
 		cache.minBytesSize = 10;


### PR DESCRIPTION
Fix #739 

- Remove unnecessary visibility setting on load
- Re-enable tests
- Dispose of tiles after loading if the cache is suddenly full
- Evict tiles if we are above the max cap

**TODO**
- Re-enable the frustum-test optimization which is causing an infinite loop of tile loads
  - Possibly need to check children's frustum before traversing for whether they are used
