### PR TITLE
Fix visible pivot mesh and intertia in `EnvironmentControls` when controls are disabled

### DIFF
--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -58,9 +58,16 @@ export class EnvironmentControls extends EventDispatcher {
 
 		if ( v !== this.enabled ) {
 
+			this._enabled = v;
 			this.resetState();
 			this.pointerTracker.reset();
-			this._enabled = v;
+
+			if ( ! this.enabled ) {
+
+				this.dragInertia.set( 0, 0, 0 );
+				this.rotationInertia.set( 0, 0 );
+
+			}
 
 		}
 
@@ -382,7 +389,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 						} else if ( this.state === ROTATE ) {
 
-							this.pivotMesh.visible = true;
+							this.pivotMesh.visible = this.enabled;
 
 						}
 
@@ -556,7 +563,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 		this.state = NONE;
 		this.pivotMesh.removeFromParent();
-		this.pivotMesh.visible = true;
+		this.pivotMesh.visible = this.enabled;
 		this.actionHeightOffset = 0;
 
 	}
@@ -575,7 +582,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 		}
 
-		this.pivotMesh.visible = true;
+		this.pivotMesh.visible = this.enabled;
 		this.dragInertia.set( 0, 0, 0 );
 		this.rotationInertia.set( 0, 0 );
 		this.state = state;
@@ -1089,10 +1096,7 @@ export class EnvironmentControls extends EventDispatcher {
 		let altitude = y * rotationSpeed;
 
 		// calculate current angles and clamp
-		_forward
-			.set( 0, 0, - 1 )
-			.transformDirection( camera.matrixWorld )
-			.multiplyScalar( - 1 );
+		_forward.set( 0, 0, 1 ).transformDirection( camera.matrixWorld );
 
 		this.getUpDirection( pivotPoint, _localUp );
 


### PR DESCRIPTION
When clicking/dragging while the controls are disabled, the pivot mesh is still visible, this should fix that issue.
The `drag`/`rotationInertia` is also reset when disabling the controls, to avoid a "fling" when enabling the controls again.
(+ removal of `multiplyScalar` which doesn't seem to be necessary)