### PR TITLE
R3F: Add transform roots, other updates

### DIFF
--- a/example/r3f-3dtilesrenderer/src/DemoTiles.jsx
+++ b/example/r3f-3dtilesrenderer/src/DemoTiles.jsx
@@ -10,9 +10,9 @@ import { TransformControls, Grid, GizmoHelper, GizmoViewport } from "@react-thre
 import { useControls, folder } from 'leva'
 
 import {DebugTilesPlugin, NONE, SCREEN_ERROR, GEOMETRIC_ERROR, DISTANCE, DEPTH, RELATIVE_DEPTH, IS_LEAF, RANDOM_COLOR, RANDOM_NODE_COLOR, CUSTOM_COLOR, LOAD_ORDER} from '../../../src/three/plugins/DebugTilesPlugin'
-import { TileCompressionPlugin } from '../../example/src/plugins/TileCompressionPlugin.js';
-import { UpdateOnChangePlugin } from '../../example/src/plugins/UpdateOnChangePlugin.js';
-import { TilesFadePlugin } from '../../example/src/plugins/fade/TilesFadePlugin.js';
+// import { TileCompressionPlugin } from '../../example/src/plugins/TileCompressionPlugin.js';
+// import { UpdateOnChangePlugin } from '../../example/src/plugins/UpdateOnChangePlugin.js';
+// import { TilesFadePlugin } from '../../example/src/plugins/fade/TilesFadePlugin.js';
 
 function Simple3dTileset(props) {
 
@@ -27,27 +27,27 @@ function Simple3dTileset(props) {
     '+proj=geocent +datum=WGS84 +units=m +no_defs +type=crs'        // EPSG:4978 metric
   )
 
-  const { debug, tilesRendererType, latlon, googleApiKey, ionAccessToken, ionAssetId, resetTransform, tilesetPath } = useControls({ 
+  const { debug, tilesRendererType, latlon, googleApiKey, ionAccessToken, ionAssetId, resetTransform, tilesetPath } = useControls({
     debug: false, // TODO DEBUG RENDERERS WERE REPLACED BY A PLUGIN
     tilesRendererType: {
-      value: TilesRendererType.Google, 
+      value: TilesRendererType.Google,
       options : {
-        [TilesRendererType.Standard]: TilesRendererType.Standard, 
-        [TilesRendererType.Google]: TilesRendererType.Google, 
-        [TilesRendererType.CesiumIon]: TilesRendererType.CesiumIon, 
+        [TilesRendererType.Standard]: TilesRendererType.Standard,
+        [TilesRendererType.Google]: TilesRendererType.Google,
+        [TilesRendererType.CesiumIon]: TilesRendererType.CesiumIon,
       }
-    }, 
+    },
     latlon: [0, 0],
     'Standard': folder(
-      {tilesetPath: '3dtiles tileset path'}, 
+      {tilesetPath: '3dtiles tileset path'},
       { render: (get) => get('tilesRendererType') == TilesRendererType.Standard }
-    ), 
+    ),
     'Google 3D Cities': folder(
       {
         googleApiKey: import.meta.env.VITE_GOOGLEAPIKEY
-      }, 
+      },
       { render: (get) => get('tilesRendererType') == TilesRendererType.Google }
-    ), 
+    ),
     CesiumIon: folder(
       {
         ionAccessToken: import.meta.env.VITE_IONACCESSTOKEN,
@@ -58,7 +58,7 @@ function Simple3dTileset(props) {
         //   max: 10e6,
         //   step: 1,
         // }
-      }, 
+      },
       { render: (get) => get('tilesRendererType') == TilesRendererType.CesiumIon }
     ), // 2684829, 2644092, 2275207, 1415196, 354759, 354307, 96188, 75343, 69380, 57590, 57588, 57587, 43978, 29335, 29332, 29331, 28945
     resetTransform: true,
@@ -77,15 +77,15 @@ function Simple3dTileset(props) {
 			// maxDebugDistance: - 1,
 			// maxDebugError: - 1,
 			// customColorCallback: null,
-    }), 
+    }),
     // new TileCompressionPlugin(),
     // new UpdateOnChangePlugin(),
     // new TilesFadePlugin(),
   ]
-  
+
   // Add event listeners to tilesRenderer
   const addRendererEventListeners = tilesRenderer => {
-    
+
     // Handle Clipping Planes and material properties applied to every tile mesh
     if (false || props.clippingPlanes) {
       tilesRenderer.addEventListener( 'load-model', ({scene}) => {
@@ -137,7 +137,7 @@ function Simple3dTileset(props) {
     matrixTransform={matrixTransform_Roma}
     addRendererEventListeners={addRendererEventListeners}
     // matrixTransform={matrixTransform_NY}
-    
+
     // path={tilesetPath}
     googleApiKey={googleApiKey}
     ionAssetId={'57587'} // 57587 cesium ion asset is oer New York
@@ -160,11 +160,11 @@ function DemoTiles() {
 
   return (
     <>
-      <Grid 
+      <Grid
         infiniteGrid={ true }
         fadeDistance={ 200 }
         fadeStrength={ 0.5 }
-        fadeFrom={ 1 } 
+        fadeFrom={ 1 }
         cellSize={ 1 }
         sectionSize={ 5 }
         cellColor={ '#6f6f6f' }
@@ -179,7 +179,7 @@ function DemoTiles() {
 
       {/* <group rotation={[ -0*Math.PI / 2, 0*Math.PI / 2, 0*Math.PI / 2]}> */}
       {/* <TransformControls mode='rotate' > */}
-        <Simple3dTileset 
+        <Simple3dTileset
         />
         {/*<EnvLayer /> */}
       {/* </TransformControls> */}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
   "files": [
     "src/*"
   ],
+	"exports": {
+		".": "./src/index.js",
+		"./r3f": "./src/r3f/TilesRendererComponent.jsx"
+	},
   "scripts": {
     "start": "vite --config ./vite.config.js --host",
     "build-examples": "vite build --config ./vite.config.js",

--- a/src/r3f/TilesRendererComponent.jsx
+++ b/src/r3f/TilesRendererComponent.jsx
@@ -1,6 +1,6 @@
-import { createContext, useContext, useState, useEffect, useMemo } from 'react';
+import { createContext, useContext, useState, useEffect, useMemo, useRef } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
-import { Group, Matrix4, Vector3 } from 'three';
+import { Matrix4, Vector3 } from 'three';
 import { TilesRenderer } from '../three/TilesRenderer.js';
 import { WGS84_ELLIPSOID } from '../three/math/GeoConstants.js';
 
@@ -72,17 +72,22 @@ function setValueAtPath( object, path, value ) {
 export const TilesRendererContext = createContext( null );
 
 // group that matches the transform of the tile set root group
-function TileSetRoot() {
+function TileSetRoot( { children } ) {
 
 	const tiles = useContext( TilesRendererContext );
-	const group = useMemo( () => new Group(), [] );
-	if ( tiles ) {
+	const ref = useRef();
+	useEffect( () => {
 
-		group.matrixWorld = tiles.group.matrixWorld;
+		if ( tiles ) {
 
-	}
+			ref.current.matrixWorld = tiles.group.matrixWorld;
 
-	return <primitive object={ group }/>;
+		}
+
+
+	}, [ tiles ] );
+
+	return <group ref={ ref }>{ children }</group>;
 
 }
 
@@ -99,9 +104,10 @@ export function EastNorthUpFrame( props ) {
 		el = 0,
 		roll = 0,
 	} = props;
-	const group = useMemo( () => new Group(), [] );
+	const ref = useRef();
 	useEffect( () => {
 
+		const group = ref.current;
 		group.matrix.identity()
 
 		// TODO: use the ellipsoid associated with the tiles renderer
@@ -118,7 +124,7 @@ export function EastNorthUpFrame( props ) {
 
 	}, [ lat, lon, height, az, el, roll ] );
 
-	return <primitive object={ group }/>;
+	return <group ref={ ref }>{ children }</group>;
 
 }
 

--- a/src/r3f/TilesRendererComponent.jsx
+++ b/src/r3f/TilesRendererComponent.jsx
@@ -87,12 +87,10 @@ function TileSetRoot( { children } ) {
 
 	}, [ tiles ] );
 
-	return <group ref={ ref }>{ children }</group>;
+	return <group ref={ ref } matrixWorldAutoUpdate={ false } matrixAutoUpdate={ false }>{ children }</group>;
 
 }
 
-// TODO: test
-const _matrix = /* @__PURE__ */ new Matrix4();
 const _vec = /* @__PURE__ */ new Vector3();
 export function EastNorthUpFrame( props ) {
 
@@ -103,6 +101,7 @@ export function EastNorthUpFrame( props ) {
 		az = 0,
 		el = 0,
 		roll = 0,
+		children,
 	} = props;
 	const ref = useRef();
 	useEffect( () => {
@@ -111,15 +110,10 @@ export function EastNorthUpFrame( props ) {
 		group.matrix.identity()
 
 		// TODO: use the ellipsoid associated with the tiles renderer
-		WGS84_ELLIPSOID.getRotationMatrixFromAzElRoll( lat, lon, az, el, roll, _matrix );
-		group.matrix.premultiply( _matrix );
-
-		WGS84_ELLIPSOID.getEastNorthUpFrame( lat, lon, _matrix );
-		group.matrix.premultiply( _matrix );
+		WGS84_ELLIPSOID.getRotationMatrixFromAzElRoll( lat, lon, az, el, roll, group.matrix );
+		WGS84_ELLIPSOID.getCartographicToPosition( lat, lon, height, _vec );
+		group.matrix.setPosition( _vec );
 		group.matrix.decompose( group.position, group.quaternion, group.scale );
-
-		_vec.set( 0, 0, 1 ).transformDirection( _matrix );
-		group.position.addScaledVector( _vec, height );
 		group.updateMatrixWorld();
 
 	}, [ lat, lon, height, az, el, roll ] );

--- a/src/r3f/TilesRendererComponent.jsx
+++ b/src/r3f/TilesRendererComponent.jsx
@@ -1,6 +1,7 @@
-import { createContext, useContext, useState, useEffect } from 'react';
-import { TilesRenderer } from '../three/TilesRenderer.js';
+import { createContext, useContext, useState, useEffect, useMemo } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
+import { Group } from 'three';
+import { TilesRenderer } from '../three/TilesRenderer.js';
 
 // returns a sorted dependency array from an object
 function getDepsArray( object ) {
@@ -70,7 +71,7 @@ function setValueAtPath( object, path, value ) {
 export const TilesRendererContext = createContext( null );
 
 // group that matches the transform of the tile set root group
-function TileSetRoot( props ) {
+function TileSetRoot() {
 
 	const tiles = useContext( TilesRendererContext );
 	const group = useMemo( () => new Group(), [] );

--- a/src/r3f/TilesRendererComponent.jsx
+++ b/src/r3f/TilesRendererComponent.jsx
@@ -69,6 +69,21 @@ function setValueAtPath( object, path, value ) {
 // context for accessing the tile set
 export const TilesRendererContext = createContext( null );
 
+// group that matches the transform of the tile set root group
+function TileSetRoot( props ) {
+
+	const tiles = useContext( TilesRendererContext );
+	const group = useMemo( () => new Group(), [] );
+	if ( tiles ) {
+
+		group.matrixWorld = tiles.group.matrixWorld;
+
+	}
+
+	return <primitive object={ group }/>;
+
+}
+
 // component for registering a plugin
 export function TilesPluginComponent( props ) {
 
@@ -230,7 +245,9 @@ export function TilesRendererComponent( props ) {
 	return <>
 		{ tiles ? <primitive object={ tiles.group }/> : null }
 		<TilesRendererContext.Provider value={ tiles }>
-			{ children }
+			<TileSetRoot>
+				{ children }
+			</TileSetRoot>
 		</TilesRendererContext.Provider>
 	</>;
 


### PR DESCRIPTION
Related to #770 

- Add a transform for tiles renderer children to ensure they align with the tile root.
- Add EastNorthUpFrame component for positioning things on the globe surface.
- Remove trailing white space in example
- Add `3d-tiles-renderer/r3f` export.

cc @jo-chemla 

I was also trying to test with the google tile renderer but the tiles seemed to be loading in the wrong spot. I'm wondering if this has anything to do with the multiple three.js imports. We may have to fix the vite situation sooner rather than later.