### PR TITLE
Add r3f TilesAttributionComponent

### DIFF
--- a/src/r3f/AttributionsComponent.jsx
+++ b/src/r3f/AttributionsComponent.jsx
@@ -1,0 +1,92 @@
+import { useContext, useState, useEffect } from 'react';
+import { useThree } from '@react-three/fiber';
+import { TilesRendererContext } from './TilesRendererComponent.jsx';
+import { CanvasDOMOverlay } from './CanvasDOMOverlay.jsx';
+
+export function AttributionsComponent( { children, style, ...rest } ) {
+
+	const tiles = useContext( TilesRendererContext );
+	const [ attributions, setAttributions ] = useState( [] );
+	useEffect( () => {
+
+		if ( ! tiles ) {
+
+			return;
+
+		}
+
+		let queued = false;
+		const callback = () => {
+
+			if ( ! queued ) {
+
+				queued = true;
+				queueMicrotask( () => {
+
+					setAttributions( tiles.getAttributions() );
+					queued = false;
+
+				} );
+
+			}
+
+		};
+
+		tiles.addEventListener( 'tile-visibility-change', callback );
+		tiles.addEventListener( 'load-tile-set', callback );
+
+		return () => {
+
+			tiles.removeEventListener( 'tile-visibility-change', callback );
+			tiles.removeEventListener( 'load-tile-set', callback );
+
+		};
+
+	}, [ tiles ] );
+
+	const output = [];
+	attributions.forEach( ( att, i ) => {
+
+		let element = null;
+		if ( att.type === 'string' ) {
+
+			element = <div key={ i }>{ att.value }</div>;
+
+		} else if ( att.type === 'html' ) {
+
+			element = <div key={ i } dangerouslySetInnerHTML={ { __html: att.value } }/>;
+
+		} else if ( att.type === 'image' ) {
+
+			element = <div key={ i }><img src={ att.value } /></div>
+
+		}
+
+		if ( element ) {
+
+			output.push( element );
+
+		}
+
+	} );
+
+
+	console.log( attributions )
+	return (
+		<CanvasDOMOverlay
+			style={ {
+				position: 'absolute',
+				bottom: 0,
+				left: 0,
+				padding: '5px',
+				color: 'rgba( 255, 255, 255, 0.5 )',
+				fontSize: '12px',
+			} }
+			{ ...rest }
+		>
+			{ children }
+			{ output }
+		</CanvasDOMOverlay>
+	);
+
+}

--- a/src/r3f/CanvasDOMOverlay.jsx
+++ b/src/r3f/CanvasDOMOverlay.jsx
@@ -1,0 +1,46 @@
+import { useMemo, useEffect, createRoot } from 'react';
+import { useThree } from '@react-three/fiber';
+
+export function CanvasDOMOverlay( { children } ) {
+
+	const [ gl ] = useThree( state => state.gl );
+	const container = useMemo( () => {
+
+		const container = document.createElement( 'div' );
+		container.style.pointerEvents = 'none';
+
+	} );
+
+	const root = useMemo( () => {
+
+		return createRoot( container );
+
+	} );
+
+	const observer = useMemo( () => {
+
+		const observer = new ResizeObserver( ( [ { contentRect } ] ) => {
+
+			container.style.top = `${ contentRect.top }px`;
+			container.style.left = `${ contentRect.left }px`;
+			container.style.width = `${ contentRect.width }px`;
+			container.style.height = `${ contentRect.height }px`;
+
+		} );
+		observer.observe( gl.domElement );
+
+	}, [ gl ] );
+
+	useEffect( () => {
+
+		return () => {
+
+			observer.disconnect();
+
+		};
+
+	}, [ observer ] );
+
+	root.render( <StrictMode>{ children }</StrictMode> );
+
+}

--- a/src/r3f/CanvasDOMOverlay.jsx
+++ b/src/r3f/CanvasDOMOverlay.jsx
@@ -2,7 +2,7 @@ import { useMemo, useEffect, StrictMode } from 'react';
 import { createRoot } from 'react-dom/client'
 import { useThree } from '@react-three/fiber';
 
-export function CanvasDOMOverlay( { children, styles, ...rest } ) {
+export function CanvasDOMOverlay( { children, style, ...rest } ) {
 
 	const [ gl ] = useThree( state => [ state.gl ] );
 	const container = useMemo( () => document.createElement( 'div' ), [] );
@@ -19,6 +19,7 @@ export function CanvasDOMOverlay( { children, styles, ...rest } ) {
 
 		} );
 		observer.observe( gl.domElement );
+		return observer;
 
 	}, [ gl ] );
 
@@ -39,7 +40,7 @@ export function CanvasDOMOverlay( { children, styles, ...rest } ) {
 
 	root.render(
 		<StrictMode>
-			<div style={ { pointerEvents: 'all', ...styles } } { ...rest }>
+			<div style={ { pointerEvents: 'all', ...style } } { ...rest }>
 				{ children }
 			</div>
 		</StrictMode>

--- a/src/r3f/CanvasDOMOverlay.jsx
+++ b/src/r3f/CanvasDOMOverlay.jsx
@@ -1,21 +1,12 @@
-import { useMemo, useEffect, createRoot } from 'react';
+import { useMemo, useEffect, StrictMode } from 'react';
+import { createRoot } from 'react-dom/client'
 import { useThree } from '@react-three/fiber';
 
-export function CanvasDOMOverlay( { children } ) {
+export function CanvasDOMOverlay( { children, styles, ...rest } ) {
 
-	const [ gl ] = useThree( state => state.gl );
-	const container = useMemo( () => {
-
-		const container = document.createElement( 'div' );
-		container.style.pointerEvents = 'none';
-
-	} );
-
-	const root = useMemo( () => {
-
-		return createRoot( container );
-
-	} );
+	const [ gl ] = useThree( state => [ state.gl ] );
+	const container = useMemo( () => document.createElement( 'div' ), [] );
+	const root = useMemo( () => createRoot( container ), [ container ] );
 
 	const observer = useMemo( () => {
 
@@ -33,14 +24,24 @@ export function CanvasDOMOverlay( { children } ) {
 
 	useEffect( () => {
 
+		container.style.pointerEvents = 'none';
+		container.style.position = 'absolute';
+		document.body.appendChild( container );
+
 		return () => {
 
+			container.remove();
 			observer.disconnect();
 
 		};
 
-	}, [ observer ] );
+	}, [ observer, container ] );
 
-	root.render( <StrictMode>{ children }</StrictMode> );
-
+	root.render(
+		<StrictMode>
+			<div style={ { pointerEvents: 'all', ...styles } } { ...rest }>
+				{ children }
+			</div>
+		</StrictMode>
+	);
 }

--- a/src/r3f/CanvasDOMOverlay.jsx
+++ b/src/r3f/CanvasDOMOverlay.jsx
@@ -2,7 +2,7 @@ import { useMemo, useEffect, StrictMode } from 'react';
 import { createRoot } from 'react-dom/client'
 import { useThree } from '@react-three/fiber';
 
-export function CanvasDOMOverlay( { children, style, ...rest } ) {
+export function CanvasDOMOverlay( { children, ...rest } ) {
 
 	const [ gl ] = useThree( state => [ state.gl ] );
 	const container = useMemo( () => document.createElement( 'div' ), [] );
@@ -40,7 +40,7 @@ export function CanvasDOMOverlay( { children, style, ...rest } ) {
 
 	root.render(
 		<StrictMode>
-			<div style={ { pointerEvents: 'all', ...style } } { ...rest }>
+			<div { ...rest }>
 				{ children }
 			</div>
 		</StrictMode>

--- a/src/r3f/TilesAttributionComponent.jsx
+++ b/src/r3f/TilesAttributionComponent.jsx
@@ -54,7 +54,7 @@ export function TilesAttributionComponent( { children, style, ...rest } ) {
 
 		} else if ( att.type === 'html' ) {
 
-			element = <div key={ i } dangerouslySetInnerHTML={ { __html: att.value } }/>;
+			element = <div key={ i } dangerouslySetInnerHTML={ { __html: att.value } } style={ { pointerEvents: 'all' } }/>;
 
 		} else if ( att.type === 'image' ) {
 

--- a/src/r3f/TilesAttributionComponent.jsx
+++ b/src/r3f/TilesAttributionComponent.jsx
@@ -3,7 +3,7 @@ import { useThree } from '@react-three/fiber';
 import { TilesRendererContext } from './TilesRendererComponent.jsx';
 import { CanvasDOMOverlay } from './CanvasDOMOverlay.jsx';
 
-export function AttributionsComponent( { children, style, ...rest } ) {
+export function TilesAttributionComponent( { children, style, ...rest } ) {
 
 	const tiles = useContext( TilesRendererContext );
 	const [ attributions, setAttributions ] = useState( [] );

--- a/src/r3f/TilesRendererComponent.jsx
+++ b/src/r3f/TilesRendererComponent.jsx
@@ -1,6 +1,6 @@
-import { createContext, useContext, useState, useEffect, useMemo, useRef } from 'react';
+import { createContext, useContext, useState, useEffect, useRef } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
-import { Matrix4, Vector3 } from 'three';
+import { Vector3 } from 'three';
 import { TilesRenderer } from '../three/TilesRenderer.js';
 import { WGS84_ELLIPSOID } from '../three/math/GeoConstants.js';
 

--- a/src/three/plugins/CesiumIonAuthPlugin.js
+++ b/src/three/plugins/CesiumIonAuthPlugin.js
@@ -14,6 +14,7 @@ export class CesiumIonAuthPlugin {
 		this._bearerToken = null;
 		this._tileSetVersion = - 1;
 		this._tokenRefreshPromise = null;
+		this._attributions = [];
 
 	}
 
@@ -88,6 +89,12 @@ export class CesiumIonAuthPlugin {
 
 	}
 
+	getAttributions( target ) {
+
+		target.push( ...this._attributions );
+
+	}
+
 	_refreshToken( options ) {
 
 		if ( this._tokenRefreshPromise === null ) {
@@ -124,6 +131,11 @@ export class CesiumIonAuthPlugin {
 						}
 
 						this._bearerToken = json.accessToken;
+						this._attributions = json.attributions.map( att => ( {
+							value: att.html,
+							type: 'html',
+							required: att.required,
+						} ) );
 
 					}
 

--- a/src/three/plugins/CesiumIonAuthPlugin.js
+++ b/src/three/plugins/CesiumIonAuthPlugin.js
@@ -91,7 +91,11 @@ export class CesiumIonAuthPlugin {
 
 	getAttributions( target ) {
 
-		target.push( ...this._attributions );
+		if ( this.tiles.visibleTiles.size > 0 ) {
+
+			target.push( ...this._attributions );
+
+		}
 
 	}
 

--- a/src/three/plugins/GoogleCloudAuthPlugin.js
+++ b/src/three/plugins/GoogleCloudAuthPlugin.js
@@ -39,6 +39,7 @@ export class GoogleCloudAuthPlugin {
 		this._attribution = {
 			value: '',
 			type: 'string',
+			collapsible: true,
 		};
 
 	}
@@ -78,8 +79,11 @@ export class GoogleCloudAuthPlugin {
 
 	getAttributions( target ) {
 
-		this._attribution.value = this._attributionsManager.toString();
-		target.push( this._attribution );
+		if ( this._attribution.value ) {
+
+			target.push( this._attribution );
+
+		}
 
 	}
 


### PR DESCRIPTION
Related to #777 
Related to #770 

- Adds attribution support for Cesium Ion
- Adds a "CanvasDOMOverlay" component for easily laying objects out on top of the canvas from within r3f.
- Adds an "AttributionComponent" that adds easy support for including attributions on top of the canvas.

This is how it will show up for Cesium Ion:

<img width="550" alt="image" src="https://github.com/user-attachments/assets/c1a30718-82ed-40fd-91f7-c90b416f6e99">

By just adding this:

```html
<TilesRendererComponent ...>
  <TilesAttributionComponent />
</TilesRendererComponent>
```

I think it needs some design work and could probably be made more flexible so users can control styles per-attribution a bit more, position items as desired, and allow for "collapsing" items that don't need to always be shown. But this can be handled later, I think.

cc @jo-chemla 