### PR TITLE
feat(ImplicitTiling): add octree support

### DIFF
--- a/src/base/plugins/SUBTREELoader.js
+++ b/src/base/plugins/SUBTREELoader.js
@@ -16,7 +16,7 @@ function isOctreeSubdivision( tile ) {
 
 function getBoundsDivider( tile ) {
 
-	return isOctreeSubdivision(tile) ? 8 : 4;
+	return isOctreeSubdivision( tile ) ? 8 : 4;
 
 }
 
@@ -31,7 +31,7 @@ function getSubtreeCoordinates( tile, parentTile ) {
 
 	const x = 2 * parentTile.__x + ( tile.__subtreeIdx % 2 );
 	const y = 2 * parentTile.__y + ( Math.floor( tile.__subtreeIdx / 2 ) % 2 );
-	const z = isOctreeSubdivision(tile) ?
+	const z = isOctreeSubdivision( tile ) ?
 		2 * parentTile.__z + ( Math.floor( tile.__subtreeIdx / 4 ) % 2 ) : 0;
 
 	return [ x, y, z ];
@@ -754,7 +754,7 @@ export class SUBTREELoader extends LoaderBase {
 			}
 
 			//Also divide the height in the case of octree.
-			if ( isOctreeSubdivision(tile) ) {
+			if ( isOctreeSubdivision( tile ) ) {
 
 				const minZ = region[ 4 ];
 				const maxZ = region[ 5 ];
@@ -780,7 +780,7 @@ export class SUBTREELoader extends LoaderBase {
 			const box = [ ...this.rootTile.boundingVolume.box ];
 			const cellSteps = 2 ** tile.__level - 1;
 			const scale = Math.pow( 2, - tile.__level );
-			const axisNumber = isOctreeSubdivision(tile) ? 3 : 2;
+			const axisNumber = isOctreeSubdivision( tile ) ? 3 : 2;
 
 
 			for ( let i = 0; i < axisNumber; i ++ ) {

--- a/src/base/plugins/SUBTREELoader.js
+++ b/src/base/plugins/SUBTREELoader.js
@@ -769,10 +769,10 @@ export class SUBTREELoader extends LoaderBase {
 			const box = [ ...this.rootTile.boundingVolume.box ];
 			const cellSteps = 2 ** tile.__level - 1;
 			const scale = Math.pow( 2, - tile.__level );
+			const axisNumber = 	tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE' ? 3 : 2 ;
 
-			// Iterate over the three obb axes. Skip the z axis since octree
-			// implicit bounds are not supported.
-			for ( let i = 0; i < 2; i ++ ) {
+
+			for ( let i = 0; i < axisNumber; i ++ ) {
 
 				// scale the bounds axes
 				box[ 3 + i * 3 + 0 ] *= scale;
@@ -785,7 +785,7 @@ export class SUBTREELoader extends LoaderBase {
 				const z = box[ 3 + i * 3 + 2 ];
 
 				// adjust the center by the x and y axes
-				const axisOffset = i === 0 ? tile.__x : tile.__y;
+				const axisOffset = i === 0 ? tile.__x : (i === 1 ? tile.__y : tile.__z);
 				box[ 0 ] += 2 * x * ( - 0.5 * cellSteps + axisOffset );
 				box[ 1 ] += 2 * y * ( - 0.5 * cellSteps + axisOffset );
 				box[ 2 ] += 2 * z * ( - 0.5 * cellSteps + axisOffset );

--- a/src/base/plugins/SUBTREELoader.js
+++ b/src/base/plugins/SUBTREELoader.js
@@ -23,7 +23,7 @@ function getSubtreeCoordinates( tile, parentTile ) {
 	const x = 2 * parentTile.__x + ( tile.__subtreeIdx % 2 );
 	const y = 2 * parentTile.__y + ( Math.floor( tile.__subtreeIdx / 2 ) % 2 );
 	const z = tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE' ?
-		2 * parentTile.__z + (Math.floor(tile.__subtreeIdx / 4) % 2) : 0;
+		2 * parentTile.__z + ( Math.floor( tile.__subtreeIdx / 4 ) % 2 ) : 0;
 
 	return [ x, y, z ];
 
@@ -53,7 +53,7 @@ class SubtreeTile {
 
 		// Index inside the tree
 		copyTile.__subtreeIdx = tile.__subtreeIdx;
-		[ copyTile.__x, copyTile.__y , copyTile.__z ] = [ tile.__x, tile.__y, tile.__z ];
+		[ copyTile.__x, copyTile.__y, copyTile.__z ] = [ tile.__x, tile.__y, tile.__z ];
 
 		copyTile.boundingVolume = tile.boundingVolume;
 		copyTile.geometricError = tile.geometricError;
@@ -744,14 +744,14 @@ export class SUBTREELoader extends LoaderBase {
 
 			}
 
-			if (tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE') {
+			if ( tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE' ) {
 
-				let minZ = region[4];
-				let maxZ = region[5];
+				const minZ = region[ 4 ];
+				const maxZ = region[ 5 ];
 
-				const sizeZ = (maxZ - minZ) / Math.pow( 2, tile.__level );
-				region[4] += tile.__z * sizeZ;
-				region[5] = region[4] + sizeZ;
+				const sizeZ = ( maxZ - minZ ) / Math.pow( 2, tile.__level );
+				region[ 4 ] += tile.__z * sizeZ;
+				region[ 5 ] = region[ 4 ] + sizeZ;
 
 			}
 
@@ -769,7 +769,7 @@ export class SUBTREELoader extends LoaderBase {
 			const box = [ ...this.rootTile.boundingVolume.box ];
 			const cellSteps = 2 ** tile.__level - 1;
 			const scale = Math.pow( 2, - tile.__level );
-			const axisNumber = 	tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE' ? 3 : 2 ;
+			const axisNumber = 	tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE' ? 3 : 2;
 
 
 			for ( let i = 0; i < axisNumber; i ++ ) {
@@ -785,7 +785,7 @@ export class SUBTREELoader extends LoaderBase {
 				const z = box[ 3 + i * 3 + 2 ];
 
 				// adjust the center by the x and y axes
-				const axisOffset = i === 0 ? tile.__x : (i === 1 ? tile.__y : tile.__z);
+				const axisOffset = i === 0 ? tile.__x : ( i === 1 ? tile.__y : tile.__z );
 				box[ 0 ] += 2 * x * ( - 0.5 * cellSteps + axisOffset );
 				box[ 1 ] += 2 * y * ( - 0.5 * cellSteps + axisOffset );
 				box[ 2 ] += 2 * z * ( - 0.5 * cellSteps + axisOffset );

--- a/src/base/plugins/SUBTREELoader.js
+++ b/src/base/plugins/SUBTREELoader.js
@@ -16,15 +16,16 @@ function getSubtreeCoordinates( tile, parentTile ) {
 
 	if ( ! parentTile ) {
 
-		return [ 0, 0 ];
+		return [ 0, 0, 0 ];
 
 	}
 
 	const x = 2 * parentTile.__x + ( tile.__subtreeIdx % 2 );
 	const y = 2 * parentTile.__y + ( Math.floor( tile.__subtreeIdx / 2 ) % 2 );
-	//TODO z coord
+	const z = tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE' ?
+		2 * parentTile.__z + (Math.floor(tile.__subtreeIdx / 4) % 2) : 0;
 
-	return [ x, y ];
+	return [ x, y, z ];
 
 }
 
@@ -39,7 +40,7 @@ class SubtreeTile {
 
 		// Index inside the tree
 		this.__subtreeIdx = childMortonIndex;
-		[ this.__x, this.__y ] = getSubtreeCoordinates( this, parentTile );
+		[ this.__x, this.__y, this.__z ] = getSubtreeCoordinates( this, parentTile );
 
 	}
 
@@ -52,7 +53,7 @@ class SubtreeTile {
 
 		// Index inside the tree
 		copyTile.__subtreeIdx = tile.__subtreeIdx;
-		[ copyTile.__x, copyTile.__y ] = [ tile.__x, tile.__y ];
+		[ copyTile.__x, copyTile.__y , copyTile.__z ] = [ tile.__x, tile.__y, tile.__z ];
 
 		copyTile.boundingVolume = tile.boundingVolume;
 		copyTile.geometricError = tile.geometricError;
@@ -740,6 +741,17 @@ export class SUBTREELoader extends LoaderBase {
 					region[ k ] -= 2 * Math.PI;
 
 				}
+
+			}
+
+			if (tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE') {
+
+				let minZ = region[4];
+				let maxZ = region[5];
+
+				const sizeZ = (maxZ - minZ) / Math.pow( 2, tile.__level );
+				region[4] += tile.__z * sizeZ;
+				region[5] = region[4] + sizeZ;
 
 			}
 

--- a/src/base/plugins/SUBTREELoader.js
+++ b/src/base/plugins/SUBTREELoader.js
@@ -753,7 +753,7 @@ export class SUBTREELoader extends LoaderBase {
 
 			}
 
-			//	Also divide the height in the case of octree.
+			//Also divide the height in the case of octree.
 			if ( isOctreeSubdivision(tile) ) {
 
 				const minZ = region[ 4 ];
@@ -761,8 +761,8 @@ export class SUBTREELoader extends LoaderBase {
 
 				const sizeZ = ( maxZ - minZ ) / Math.pow( 2, tile.__level );
 
-				region[ 4 ] = minZ + sizeZ * tile.__z;
-				region[ 5 ] = minZ + sizeZ * ( tile.__z + 1 );
+				region[ 4 ] = minZ + sizeZ * tile.__z;	//minimum height
+				region[ 5 ] = minZ + sizeZ * ( tile.__z + 1 );	// maximum height
 
 			}
 


### PR DESCRIPTION
Add octree support for implicitTiling.

TODO:
- add a method to get directly the type of subdivision or use getBoundsDivider ?
- test on region octree tileset. I don't have a tileset to try on