### PR TITLE
R3F: Add Cesium Ion demo

### DIFF
--- a/example/r3f/ion.html
+++ b/example/r3f/ion.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@react-three/fiber Cesium Ion</title>
+		<style>
+			html {
+				overflow: hidden;
+				font-family: Arial, Helvetica, sans-serif;
+				user-select: none;
+			}
+
+			#info {
+				position: absolute;
+				top: 0;
+				left: 0;
+				color: white;
+				width: 100%;
+				text-align: center;
+				padding: 5px;
+				pointer-events: none;
+				line-height: 1.5em;
+				z-index: 1;
+			}
+
+			#info a {
+				color: white;
+				pointer-events: all;
+			}
+		</style>
+  </head>
+  <body>
+		<div id="info">
+			Example using <a href="https://ion.cesium.com/">Cesium Ion</a> & <a href="https://r3f.docs.pmnd.rs">@react-three/fiber</a>.
+			<br/>
+			Paste the evaluation token from the <a target="_blank" href="https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Ion.js#L6-L7">Cesium repository</a> or your own.
+		</div>
+    <div id="root"></div>
+    <script type="module" src="./ion.jsx"></script>
+  </body>
+</html>

--- a/example/r3f/ion.html
+++ b/example/r3f/ion.html
@@ -1,9 +1,9 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@react-three/fiber Cesium Ion</title>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>@react-three/fiber Cesium Ion</title>
 		<style>
 			html {
 				overflow: hidden;
@@ -29,14 +29,14 @@
 				pointer-events: all;
 			}
 		</style>
-  </head>
-  <body>
+	</head>
+	<body>
 		<div id="info">
 			Example using <a href="https://ion.cesium.com/">Cesium Ion</a> & <a href="https://r3f.docs.pmnd.rs">@react-three/fiber</a>.
 			<br/>
 			Paste the evaluation token from the <a target="_blank" href="https://github.com/CesiumGS/cesium/blob/main/packages/engine/Source/Core/Ion.js#L6-L7">Cesium repository</a> or your own.
 		</div>
-    <div id="root"></div>
-    <script type="module" src="./ion.jsx"></script>
-  </body>
+		<div id="root"></div>
+		<script type="module" src="./ion.jsx"></script>
+	</body>
 </html>

--- a/example/r3f/ion.jsx
+++ b/example/r3f/ion.jsx
@@ -1,0 +1,95 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+// TilesRenderer, controls and attribution imports
+import { TilesPlugin, TilesRenderer, TilesAttributionOverlay, EnvironmentControls } from '../../src/r3f/index.jsx';
+import { CesiumIonAuthPlugin } from '../../src/index.js';
+
+// Plugins
+import { GLTFExtensionsPlugin } from '../src/plugins/GLTFExtensionsPlugin.js';
+import { ReorientationPlugin } from '../src/plugins/ReorientationPlugin.js';
+
+// R3F, DREI and LEVA imports
+import { Canvas } from '@react-three/fiber';
+import { Environment, GizmoHelper, GizmoViewport } from '@react-three/drei';
+import { useControls } from 'leva';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+
+const dracoLoader = new DRACOLoader().setDecoderPath( 'https://www.gstatic.com/draco/v1/decoders/' );
+
+function App() {
+
+	const ionAccessToken_ = localStorage.getItem( 'ion-token' ) || 'put-your-api-key-here';
+	const levaParams = {
+		apiToken: {
+			value: ionAccessToken_,
+			onChange: ( value ) => localStorage.setItem( 'ion-token', value ),
+			transient: false,
+		},
+		assetId: {
+			value: '40866',
+			options: {
+				'Aerometrex - San Francisco': '1415196',
+				'Aerometrex - Denver': '354307',
+				'New York City 3D Buildings': '75343',
+				'Melbourne Photogrammetry': '69380',
+				'Cesium HQ': '40866',
+				'Melbourne Point Cloud': '43978',
+				'Montreal Point Cloud': '28945',
+			},
+		},
+	};
+
+	const { apiToken, assetId } = useControls( levaParams );
+	return (
+		<Canvas
+			camera={ {
+				position: [ 300, 300, 300 ],
+				near: 1,
+				far: 1e5,
+			} }
+			style={ {
+				width: '100%',
+				height: '100%',
+				position: 'absolute',
+				margin: 0,
+				left: 0,
+				top: 0,
+			} }
+		>
+			{/*
+				3D Tiles renderer tile set
+				Use a "key" property to ensure the tiles renderer gets recreated when the api token or asset change
+			*/}
+			<TilesRenderer key={ assetId + apiToken }>
+				<TilesPlugin plugin={ CesiumIonAuthPlugin } args={ { apiToken, assetId, autoRefreshToken: true } } />
+				<TilesPlugin plugin={ ReorientationPlugin } />
+				<TilesPlugin plugin={ GLTFExtensionsPlugin } dracoLoader={ dracoLoader } autoDispose={ false } />
+
+				<TilesAttributionOverlay />
+			</TilesRenderer>
+
+			{/* Controls */}
+			<EnvironmentControls enableDamping={ true } />
+
+			{/* other r3f staging */}
+			<Environment
+				preset="sunset" background={ true }
+				backgroundBlurriness={ 0.9 }
+				environmentIntensity={ 1 }
+			/>
+			<GizmoHelper alignment="bottom-right">
+				<GizmoViewport />
+			</GizmoHelper>
+
+		</Canvas>
+	);
+
+}
+
+createRoot( document.getElementById( 'root' ) ).render(
+	<StrictMode>
+		<App />
+	</StrictMode>,
+);
+

--- a/example/r3f/simple.html
+++ b/example/r3f/simple.html
@@ -1,9 +1,9 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@react-three/fiber 3D Tiles Renderer</title>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>@react-three/fiber 3D Tiles Renderer</title>
 		<style>
 			html {
 				overflow: hidden;
@@ -29,10 +29,10 @@
 				pointer-events: all;
 			}
 		</style>
-  </head>
-  <body>
+	</head>
+	<body>
 	<div id="info">Demonstration using <a href="https://r3f.docs.pmnd.rs">@react-three/fiber</a> and <a href="https://drei.docs.pmnd.rs/">@react-three/drei</a></div>
-    <div id="root"></div>
-    <script type="module" src="./simple.jsx"></script>
-  </body>
+		<div id="root"></div>
+		<script type="module" src="./simple.jsx"></script>
+	</body>
 </html>


### PR DESCRIPTION
Related to #770, #793

Created a simple cesium ion demo, removed any asset ids that are not available via the evaluation token and fixed the point cloud tile sets which were not working.

cc @jo-chemla 