### PR TITLE
`TilesRendererBase` `url` constructor parameter should be optional

### DIFF
--- a/example/googleMapsAerial.js
+++ b/example/googleMapsAerial.js
@@ -1,4 +1,4 @@
-import { GeoUtils, WGS84_ELLIPSOID, GooglePhotorealisticTilesRenderer, GoogleCloudAuthPlugin } from '../src/index.js';
+import { GeoUtils, WGS84_ELLIPSOID, TilesRenderer, GoogleCloudAuthPlugin } from '../src/index.js';
 import {
 	Scene,
 	WebGLRenderer,
@@ -42,7 +42,7 @@ function reinstantiateTiles() {
 
 	}
 
-	tiles = new GooglePhotorealisticTilesRenderer();
+	tiles = new TilesRenderer();
 	tiles.registerPlugin( new GoogleCloudAuthPlugin( { apiToken: params.apiKey } ) );
 	tiles.registerPlugin( new TileCompressionPlugin() );
 	tiles.registerPlugin( new TilesFadePlugin() );

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -3,7 +3,7 @@ import {
 	CAMERA_FRAME,
 	GeoUtils,
 	GlobeControls,
-	GooglePhotorealisticTilesRenderer,
+	TilesRenderer,
 	GoogleCloudAuthPlugin,
 } from '../src/index.js';
 import {
@@ -55,7 +55,7 @@ function reinstantiateTiles() {
 
 	localStorage.setItem( 'googleApiKey', params.apiKey );
 
-	tiles = new GooglePhotorealisticTilesRenderer();
+	tiles = new TilesRenderer();
 	tiles.registerPlugin( new GoogleCloudAuthPlugin( { apiToken: params.apiKey, autoRefreshToken: true } ) );
 	tiles.registerPlugin( new TileCompressionPlugin() );
 	tiles.registerPlugin( new UpdateOnChangePlugin() );

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -18,7 +18,7 @@ export class TilesRendererBase {
 	parseQueue : PriorityQueue;
 	downloadQueue : PriorityQueue;
 
-	constructor( url : String );
+	constructor( url?: String );
 	update() : void;
 	registerPlugin( plugin: Object ) : void;
 	unregisterPlugin( plugin: Object | String ) : Boolean;


### PR DESCRIPTION
I believe `TilesRendererBase` constructor `url` parameter should be optional, no?

Updated the Google examples so one doesn't get the `GooglePhotorealisticTilesRenderer: Class has been deprecated. Use "TilesRenderer" with "GoogleCloudAuthPlugin" instead.` warning.

That's how I noticed that it needs to be optional, as otherwise I can't follow the deprecation warning suggestions without getting TS errors because I didn't pass a `url` to `TileRenderer` constructor.