### PR TITLE
GlobeControls: Remove negative near plane option 

### DIFF
--- a/example/src/camera/CameraTransitionManager.js
+++ b/example/src/camera/CameraTransitionManager.js
@@ -48,12 +48,13 @@ export class CameraTransitionManager extends EventDispatcher {
 
 	update() {
 
+		// update transforms
+		this.syncCameras();
+
+		// perform transition
 		const { perspectiveCamera, orthographicCamera, transitionCamera, camera } = this;
 		const clock = this._clock;
 		const delta = clock.getDelta() * 1e3;
-
-		// update transforms
-		this._syncCameras();
 
 		if ( this._alpha !== this._target ) {
 
@@ -91,7 +92,7 @@ export class CameraTransitionManager extends EventDispatcher {
 
 	}
 
-	_syncCameras() {
+	syncCameras() {
 
 		const fromCamera = this._getFromCamera();
 		const { perspectiveCamera, orthographicCamera, transitionCamera, fixedPoint } = this;

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -55,7 +55,6 @@ export class GlobeControls extends EnvironmentControls {
 
 		this.dragQuaternion = new Quaternion();
 
-		this.allowNegativeNearPlanes = true;
 		this.setTilesRenderer( tilesRenderer );
 
 	}
@@ -264,13 +263,9 @@ export class GlobeControls extends EnvironmentControls {
 			camera.far = distanceToCenter + 0.1;
 
 			// adjust the position of the ortho camera such that the near value is 0
-			if ( ! this.allowNegativeNearPlanes && camera.near < 0 ) {
-
-				camera.position.addScaledVector( _forward, camera.near );
-				camera.far -= camera.near;
-				camera.near = 0;
-
-			}
+			camera.position.addScaledVector( _forward, camera.near );
+			camera.far -= camera.near;
+			camera.near = 0;
 
 			camera.updateProjectionMatrix();
 			camera.updateMatrixWorld();

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -270,7 +270,6 @@ export class GlobeControls extends EnvironmentControls {
 			camera.updateProjectionMatrix();
 			camera.updateMatrixWorld();
 
-
 		}
 
 	}


### PR DESCRIPTION
Related #619 
Related #821 

**TODO**
- Understand why "syncCameras" needs to be called every frame
- Clamp the camera positions, views based on the controls after sync
- Figure out occasional final "pop" of far plane during transition