### PR TITLE
CameraTransitionManager: Support positional differences, globe controls clamping

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -673,6 +673,14 @@ getPivotPoint( target : Vector3 ) : target
 
 Gets the last used interaction point.
 
+### .adjustCamera
+
+```js
+updateCameraClipPlanes( camera : Camera ) : void
+```
+
+Updates the clip planes and position of the given camera so the globe is encapsulated correctly and is positioned appropriately above the terrain. Used when working with the transition manager to make sure both cameras being transitioned are positioned properly.
+
 ## GlobeControls
 
 _extends [EnvironmentControls](#environmentcontrols)_
@@ -689,14 +697,6 @@ constructor(
 ```
 
 Takes the same items as `EnvironmentControls` in addition to the Google globe tiles renderer.
-
-### .updateCameraClipPlanes
-
-```js
-updateCameraClipPlanes( camera : Camera ) : void
-```
-
-Updates the clip planes (and position if orthographic) of the given camera so the globe is encapsulated correctly. Used when working with the transition manager to make sure both cameras being transitioned are positioned properly.
 
 ## CameraTransitionManager
 

--- a/example/fadingTiles.js
+++ b/example/fadingTiles.js
@@ -51,6 +51,8 @@ function init() {
 	);
 	transition.camera.position.set( 20, 10, 20 );
 	transition.camera.lookAt( 0, 0, 0 );
+	transition.autoSync = false;
+
 	transition.addEventListener( 'camera-changed', ( { camera, prevCamera } ) => {
 
 		skyTiles.deleteCamera( prevCamera );
@@ -86,6 +88,11 @@ function init() {
 	cameraFolder.add( params, 'orthographic' ).onChange( v => {
 
 		transition.fixedPoint.copy( controls.pivotPoint );
+
+		// adjust the camera before the transition begins
+		transition.syncCameras();
+		controls.adjustCamera( transition.perspectiveCamera );
+		controls.adjustCamera( transition.orthographicCamera );
 		transition.toggle();
 
 	} );

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -95,7 +95,6 @@ function init() {
 		new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 160000000 ),
 		new OrthographicCamera( - 1, 1, 1, - 1, 1, 160000000 ),
 	);
-
 	transition.perspectiveCamera.position.set( 4800000, 2570000, 14720000 );
 	transition.perspectiveCamera.lookAt( 0, 0, 0 );
 	transition.autoSync = false;

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -98,6 +98,7 @@ function init() {
 
 	transition.perspectiveCamera.position.set( 4800000, 2570000, 14720000 );
 	transition.perspectiveCamera.lookAt( 0, 0, 0 );
+	transition.autoSync = false;
 
 	transition.addEventListener( 'camera-changed', ( { camera, prevCamera } ) => {
 
@@ -127,13 +128,12 @@ function init() {
 
 	gui.add( params, 'orthographic' ).onChange( v => {
 
-		// TODO: this updates the clip planes based on the current position of the camera which is
-		// synced by the transition manager. However the position and clip planes that would be applied
-		// by the globe controls when using the controls with the camera are different resulting in
-		// some clipping artifacts during transition that "pop" once finished.
 		controls.getPivotPoint( transition.fixedPoint );
-		controls.updateCameraClipPlanes( transition.perspectiveCamera );
-		controls.updateCameraClipPlanes( transition.orthographicCamera );
+
+		// sync the camera positions and then adjust the camera views
+		transition.syncCameras();
+		controls.adjustCamera( transition.perspectiveCamera );
+		controls.adjustCamera( transition.orthographicCamera );
 
 		transition.toggle();
 

--- a/example/src/camera/CameraTransitionManager.js
+++ b/example/src/camera/CameraTransitionManager.js
@@ -246,54 +246,76 @@ export class CameraTransitionManager extends EventDispatcher {
 		transitionCamera.fov = targetFov;
 		transitionCamera.near = Math.max( targetNearPlane, planeDelta * 1e-5 );
 		transitionCamera.far = targetFarPlane;
-		transitionCamera.position.copy( perspectiveCamera );
+		transitionCamera.position.copy( targetPos );
 		transitionCamera.rotation.copy( perspectiveCamera.rotation );
 		transitionCamera.updateProjectionMatrix();
 		transitionCamera.updateMatrixWorld();
 
+		// TODO: this works but the above does not
+		const perspDistanceToPoint = Math.abs( _vec.subVectors( perspectiveCamera.position, fixedPoint ).dot( _forward ) );
+		transitionCamera.position.copy( perspectiveCamera.position ).addScaledVector( _forward, perspDistanceToPoint - targetDistance );
 
 
+		// old variation
+		{
 
+			// const { perspectiveCamera, orthographicCamera, transitionCamera, fixedPoint } = this;
+			// const alpha = this._alpha;
 
+			// // get the forward vector
+			// _forward.set( 0, 0, - 1 ).transformDirection( perspectiveCamera.matrixWorld ).normalize();
 
+			// // compute the projection height based on the perspective camera
+			// const distToPoint = Math.abs( _vec.subVectors( perspectiveCamera.position, fixedPoint ).dot( _forward ) );
+			// const projectionHeight = 2 * Math.tan( MathUtils.DEG2RAD * perspectiveCamera.fov * 0.5 ) * distToPoint;
 
+			// // Perform transition interpolation between the orthographic and perspective camera
 
+			// // alpha === 0 : perspective
+			// // alpha === 1 : orthographic
 
+			// // calculate the target distance and fov to position the camera at
+			// const targetFov = MathUtils.lerp( perspectiveCamera.fov, 1, alpha );
+			// const targetDistance = projectionHeight * 0.5 / Math.tan( MathUtils.DEG2RAD * targetFov * 0.5 );
 
-		// // virtual orthographic position to support negative near plane
-		// const virtOrthoNear = 0;
-		// const virtOrthoFar = orthographicCamera.far - orthographicCamera.near;
-		// _virtOrthoPos.copy( orthographicCamera.position ).addScaledVector( _forward, orthographicCamera.near );
+			// console.log( targetFov, targetDistance )
 
-		// // calculate all distance to the focus point
-		// const perspDistanceToPoint = Math.abs( _vec.subVectors( perspectiveCamera.position, fixedPoint ).dot( _forward ) );
-		// const orthoDistanceToPoint = Math.abs( _vec.subVectors( _virtOrthoPos, fixedPoint ).dot( _forward ) );
+			// // virtual orthographic position to support negative near plane
+			// const virtOrthoNear = 0;
+			// const virtOrthoFar = orthographicCamera.far - orthographicCamera.near;
+			// _virtOrthoPos.copy( orthographicCamera.position ).addScaledVector( _forward, orthographicCamera.near );
 
-		// // find the target near and far positions
-		// const perspNearPlane = perspDistanceToPoint - perspectiveCamera.near;
-		// const orthoNearPlane = orthoDistanceToPoint - virtOrthoNear;
-		// const targetNearPlane = MathUtils.lerp( perspNearPlane, orthoNearPlane, alpha );
+			// // calculate all distance to the focus point
+			// const perspDistanceToPoint = Math.abs( _vec.subVectors( perspectiveCamera.position, fixedPoint ).dot( _forward ) );
+			// const orthoDistanceToPoint = Math.abs( _vec.subVectors( _virtOrthoPos, fixedPoint ).dot( _forward ) );
 
-		// const perspFarPlane = perspDistanceToPoint - perspectiveCamera.far;
-		// const orthoFarPlane = orthoDistanceToPoint - virtOrthoFar;
-		// const targetFarPlane = MathUtils.lerp( perspFarPlane, orthoFarPlane, alpha );
+			// // find the target near and far positions
+			// const perspNearPlane = perspDistanceToPoint - perspectiveCamera.near;
+			// const orthoNearPlane = orthoDistanceToPoint - virtOrthoNear;
+			// const targetNearPlane = MathUtils.lerp( perspNearPlane, orthoNearPlane, alpha );
 
-		// // compute delta between planes so we can scale the minimum near plane value
-		// // and avoid depth artifacts from floating point calculations
-		// const finalNearPlane = targetDistance - targetNearPlane;
-		// const finalFarPlane = targetDistance - targetFarPlane;
-		// const planeDelta = finalFarPlane - finalNearPlane;
+			// const perspFarPlane = perspDistanceToPoint - perspectiveCamera.far;
+			// const orthoFarPlane = orthoDistanceToPoint - virtOrthoFar;
+			// const targetFarPlane = MathUtils.lerp( perspFarPlane, orthoFarPlane, alpha );
 
-		// // update the camera state
-		// transitionCamera.aspect = perspectiveCamera.aspect;
-		// transitionCamera.fov = targetFov;
-		// transitionCamera.near = Math.max( finalNearPlane, planeDelta * 1e-5 );
-		// transitionCamera.far = finalFarPlane;
-		// transitionCamera.position.copy( perspectiveCamera.position ).addScaledVector( _forward, perspDistanceToPoint - targetDistance );
-		// transitionCamera.rotation.copy( perspectiveCamera.rotation );
+			// // compute delta between planes so we can scale the minimum near plane value
+			// // and avoid depth artifacts from floating point calculations
+			// const finalNearPlane = targetDistance - targetNearPlane;
+			// const finalFarPlane = targetDistance - targetFarPlane;
+			// const planeDelta = finalFarPlane - finalNearPlane;
 
-		// transitionCamera.updateProjectionMatrix();
-		// transitionCamera.updateMatrixWorld();
+			// // update the camera state
+			// transitionCamera.aspect = perspectiveCamera.aspect;
+			// transitionCamera.fov = targetFov;
+			// transitionCamera.near = Math.max( finalNearPlane, planeDelta * 1e-5 );
+			// transitionCamera.far = finalFarPlane;
+			// transitionCamera.position.copy( perspectiveCamera.position ).addScaledVector( _forward, perspDistanceToPoint - targetDistance );
+			// transitionCamera.rotation.copy( perspectiveCamera.rotation );
+
+			// transitionCamera.updateProjectionMatrix();
+			// transitionCamera.updateMatrixWorld();
+
+		}
 
 	}
 

--- a/example/src/camera/CameraTransitionManager.js
+++ b/example/src/camera/CameraTransitionManager.js
@@ -2,10 +2,8 @@ import { Clock, EventDispatcher, MathUtils, OrthographicCamera, PerspectiveCamer
 
 const _forward = new Vector3();
 const _vec = new Vector3();
-const _virtOrthoPos = new Vector3();
 const _orthographicCamera = new OrthographicCamera();
 const _targetPos = new Vector3();
-
 
 export class CameraTransitionManager extends EventDispatcher {
 

--- a/example/src/camera/CameraTransitionManager.js
+++ b/example/src/camera/CameraTransitionManager.js
@@ -237,8 +237,8 @@ export class CameraTransitionManager extends EventDispatcher {
 		const targetPos = _targetPos.lerpVectors( perspectiveCamera.position, _orthographicCamera.position, alpha );
 		targetPos.addScaledVector( _forward, Math.abs( _vec.subVectors( targetPos, fixedPoint ).dot( _forward ) ) - targetDistance );
 
-		const distToPersp = Math.abs( _vec.subVectors( perspectiveCamera.position, targetPos ).dot( _forward ) );
-		const distToOrtho = Math.abs( _vec.subVectors( _orthographicCamera.position, targetPos ).dot( _forward ) );
+		const distToPersp = _vec.subVectors( perspectiveCamera.position, targetPos ).dot( _forward );
+		const distToOrtho = _vec.subVectors( _orthographicCamera.position, targetPos ).dot( _forward );
 
 		const targetNearPlane = MathUtils.lerp( distToPersp + perspectiveCamera.near, distToOrtho + _orthographicCamera.near, alpha );
 		const targetFarPlane = MathUtils.lerp( distToPersp + perspectiveCamera.far, distToOrtho + _orthographicCamera.far, alpha );

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -930,11 +930,11 @@ export class EnvironmentControls extends EventDispatcher {
 	}
 
 	// returns the point below the camera
-	_getPointBelowCamera() {
+	_getPointBelowCamera( point = this.camera.position, up = this.up ) {
 
-		const { camera, raycaster, up } = this;
+		const { raycaster } = this;
 		raycaster.ray.direction.copy( up ).multiplyScalar( - 1 );
-		raycaster.ray.origin.copy( camera.position ).addScaledVector( up, 1e5 );
+		raycaster.ray.origin.copy( point ).addScaledVector( up, 1e5 );
 		raycaster.near = 0;
 		raycaster.far = Infinity;
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -708,6 +708,30 @@ export class EnvironmentControls extends EventDispatcher {
 
 	}
 
+	// updates the camera to position it based on the constraints of the controls
+	adjustCamera( camera ) {
+
+		const { adjustHeight, cameraRadius } = this;
+		if ( camera.isPerspectiveCamera ) {
+
+			// adjust the camera height
+			this.getUpDirection( camera.position, _localUp );
+			const hit = adjustHeight && this._getPointBelowCamera( camera.position, _localUp ) || null;
+			if ( hit ) {
+
+				const dist = hit.distance;
+				if ( dist < cameraRadius ) {
+
+					camera.position.addScaledVector( _localUp, cameraRadius - dist );
+
+				}
+
+			}
+
+		}
+
+	}
+
 	dispose() {
 
 		this.detach();

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -187,7 +187,7 @@ export class GlobeControls extends EnvironmentControls {
 		super.update( deltaTime );
 
 		// update the camera planes and the ortho camera position
-		this.updateCameraClipPlanes( camera );
+		this.adjustCamera( camera );
 
 	}
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -198,10 +198,27 @@ export class GlobeControls extends EnvironmentControls {
 		const {
 			tilesGroup,
 			ellipsoid,
+			adjustHeight,
+			cameraRadius,
 		} = this;
 
 		if ( camera.isPerspectiveCamera ) {
 
+			// adjust the camera height
+			this.getUpDirection( camera.position, _vec );
+			const hit = adjustHeight && this._getPointBelowCamera( camera.position, _vec ) || null;
+			if ( hit ) {
+
+				const dist = hit.distance;
+				if ( dist < cameraRadius ) {
+
+					camera.position.addScaledVector( _vec, cameraRadius - dist );
+
+				}
+
+			}
+
+			// adjust the clip planes
 			const distanceToCenter = _vec
 				.setFromMatrixPosition( tilesGroup.matrixWorld )
 				.sub( camera.position ).length();

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -191,32 +191,14 @@ export class GlobeControls extends EnvironmentControls {
 
 	}
 
-	// Updates the passed camera near and far clip planes to encapsulate the
-	// ellipsoid from their current position.
-	updateCameraClipPlanes( camera ) {
+	// Updates the passed camera near and far clip planes to encapsulate the ellipsoid from the
+	// current position in addition to adjusting the height.
+	adjustCamera( camera ) {
 
-		const {
-			tilesGroup,
-			ellipsoid,
-			adjustHeight,
-			cameraRadius,
-		} = this;
+		super.adjustCamera( camera );
 
+		const { tilesGroup, ellipsoid } = this;
 		if ( camera.isPerspectiveCamera ) {
-
-			// adjust the camera height
-			this.getUpDirection( camera.position, _vec );
-			const hit = adjustHeight && this._getPointBelowCamera( camera.position, _vec ) || null;
-			if ( hit ) {
-
-				const dist = hit.distance;
-				if ( dist < cameraRadius ) {
-
-					camera.position.addScaledVector( _vec, cameraRadius - dist );
-
-				}
-
-			}
 
 			// adjust the clip planes
 			const distanceToCenter = _vec


### PR DESCRIPTION
Fix #619 

**TODO**
- ~Rename clip planes adjust function to `adjustCamera`~
- ~Update the demos~
- ~Add function for adjusting the camera to fit the globe bounds, adjust height~
- ~"near clip" at this position is broken:~
  - http://localhost:5173/googleMapsExample.html#lat=41.6199&lon=-67.5630&height=451452.77&az=32.19&el=-46.60&roll=0.01