### PR TITLE
Fix errors in the PNTS Draco decoding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,13 @@ scene.add( tilesRenderer2.group );
 
 ## Adding DRACO Decompression Support
 
-Adding support for DRACO decompression within the GLTF files that are transported in B3DM and I3DM formats. The same approach can be used to add support for KTX2 and DDS textures. Note that GLTF decoding and PNTS decoding require separate decoders.
+Adding support for DRACO decompression within the GLTF files that are transported in B3DM and I3DM formats. The same approach can be used to add support for KTX2 and DDS textures.
 
 ```js
 
 // Note the DRACO compression files need to be supplied via an explicit source.
 // We use unpkg here but in practice should be provided by the application.
+// Decompressing GLTF requires the GLTF branch of the draco decoder
 const tilesRenderer = new TilesRenderer( './path/to/tileset.json' );
 
 const dracoLoader = new DRACOLoader();
@@ -193,6 +194,7 @@ Adding support for DRACO decompression within the PNTS files.
 
 // Note the DRACO compression files need to be supplied via an explicit source.
 // We use unpkg here but in practice should be provided by the application.
+// Decompressing point clouds should use the master branch of the draco decoder in place of the GLTF branch
 const dracoLoader = new DRACOLoader();
 dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.123.0/examples/js/libs/draco/' );
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ scene.add( tilesRenderer2.group );
 
 ## Adding DRACO Decompression Support
 
-Adding support for DRACO decompression within the GLTF files that are transported in B3DM and I3DM formats. The same approach can be used to add support for KTX2 and DDS textures.
+Adding support for DRACO decompression within the GLTF files that are transported in B3DM and I3DM formats. The same approach can be used to add support for KTX2 and DDS textures. Note that GLTF decoding and PNTS decoding require separate decoders.
 
 ```js
 
@@ -194,11 +194,10 @@ Adding support for DRACO decompression within the PNTS files.
 // Note the DRACO compression files need to be supplied via an explicit source.
 // We use unpkg here but in practice should be provided by the application.
 const dracoLoader = new DRACOLoader();
-dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.123.0/examples/js/libs/draco/gltf/' );
-
+dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.123.0/examples/js/libs/draco/' );
 
 const tilesRenderer = new TilesRenderer( './path/to/tileset.json' );
-tilesRenderer.manager.addHandler( /\.drc$/g, loader );
+tilesRenderer.manager.addHandler( /\.drc$/g, dracoLoader );
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ scene.add( tilesRenderer2.group );
 ## Adding DRACO Decompression Support
 
 Adding support for DRACO decompression within the GLTF files that are transported in B3DM and I3DM formats. The same approach can be used to add support for KTX2 and DDS textures.
+There are different builds of the draco decoder, pick the appropriate one depending on your model type. [More info](https://github.com/mrdoob/three.js/tree/dev/examples/jsm/libs/draco)
 
 ```js
 


### PR DESCRIPTION
The PNTS decoding docs reference the wrong decoder as well as the wrong loader. Spent a bit of time hair pulling and hunting down confusing errors till I realized this.