### PR TITLE
export BatchTable and FeatureTable types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,9 +2,9 @@
 export { DebugTilesRenderer } from './three/DebugTilesRenderer';
 export { TilesRenderer } from './three/TilesRenderer';
 export { TilesGroup } from './three/TilesGroup';
-export { B3DMLoader } from './three/loaders/B3DMLoader';
-export { I3DMLoader } from './three/loaders/I3DMLoader';
-export { PNTSLoader } from './three/loaders/PNTSLoader';
+export { B3DMLoader, B3DMScene } from './three/loaders/B3DMLoader';
+export { I3DMLoader, I3DMScene } from './three/loaders/I3DMLoader';
+export { PNTSLoader, PNTSScene } from './three/loaders/PNTSLoader';
 export { CMPTLoader } from './three/loaders/CMPTLoader';
 export { GLTFCesiumRTCExtension } from './three/loaders/gltf/GLTFCesiumRTCExtension';
 export { GLTFExtensionLoader } from './three/loaders/GLTFExtensionLoader';
@@ -37,3 +37,5 @@ export * from './base/constants';
 
 export { LRUCache } from './utilities/LRUCache';
 export { PriorityQueue } from './utilities/PriorityQueue';
+export { BatchTable } from './utilities/BatchTable';
+export { FeatureTable } from './utilities/FeatureTable';

--- a/src/three/loaders/PNTSLoader.d.ts
+++ b/src/three/loaders/PNTSLoader.d.ts
@@ -1,9 +1,11 @@
 import { PNTSBaseResult, PNTSLoaderBase } from '../../base/loaders/PNTSLoaderBase';
+import { BatchTable } from '../../utilities/BatchTable';
 import { FeatureTable } from '../../utilities/FeatureTable';
 import { Points, LoadingManager } from 'three';
 
 interface PNTSScene extends Points {
 
+	batchTable : BatchTable
 	featureTable : FeatureTable;
 
 }


### PR DESCRIPTION
This simple PR exposes the `FeatureTable` and `BatchTable` types in the exported types, as well as add the missing `batchTable` property in the `PNTSScene` .

Context: I am integrating this package into the [Giro3D library](https://giro3d.org/) and we are missing some types to implement a `processTileModel` for `PNTSScene`s.