### PR TITLE
eslint: add the `no-wrapper-object-types` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,8 @@
 		"rules": {
 			"no-unused-vars": [ "error", { "args": "none" } ],
 			"indent": [ "error", "tab" ],
-			"no-dupe-class-members": "off"
+			"no-dupe-class-members": "off",
+			"@typescript-eslint/no-wrapper-object-types": "error"
 		}
 	}, {
 		"files": [ "*.jsx" ],

--- a/src/base/TilesRendererBase.d.ts
+++ b/src/base/TilesRendererBase.d.ts
@@ -3,13 +3,13 @@ import { PriorityQueue } from '../utilities/PriorityQueue';
 
 export class TilesRendererBase {
 
-	readonly rootTileSet : Object | null;
-	readonly root : Object | null;
+	readonly rootTileSet : object | null;
+	readonly root : object | null;
 
-	errorTarget : Number;
-	errorThreshold : Number;
-	displayActiveTiles : Boolean;
-	maxDepth : Number;
+	errorTarget : number;
+	errorThreshold : number;
+	displayActiveTiles : boolean;
+	maxDepth : number;
 
 	fetchOptions : RequestInit;
 	preprocessURL : ( ( uri: string | URL ) => string ) | null;
@@ -18,16 +18,16 @@ export class TilesRendererBase {
 	parseQueue : PriorityQueue;
 	downloadQueue : PriorityQueue;
 
-	constructor( url?: String );
+	constructor( url?: string );
 	update() : void;
-	registerPlugin( plugin: Object ) : void;
-	unregisterPlugin( plugin: Object | String ) : Boolean;
-	getPluginByName( plugin: Object | String ) : Object;
+	registerPlugin( plugin: object ) : void;
+	unregisterPlugin( plugin: object | string ) : boolean;
+	getPluginByName( plugin: object | string ) : object;
 	traverse(
-		beforeCb : ( ( tile : Object, parent : Object, depth : Number ) => Boolean ) | null,
-		afterCb : ( ( tile : Object, parent : Object, depth : Number ) => Boolean ) | null
+		beforeCb : ( ( tile : object, parent : object, depth : number ) => boolean ) | null,
+		afterCb : ( ( tile : object, parent : object, depth : number ) => boolean ) | null
 	) : void;
-	getAttributions( target? : Array<{ type: String, value: any }> ) : Array<{ type: String, value: any }>;
+	getAttributions( target? : Array<{ type: string, value: any }> ) : Array<{ type: string, value: any }>;
 
 	dispose() : void;
 	resetFailedTiles() : void;

--- a/src/base/Tileset.d.ts
+++ b/src/base/Tileset.d.ts
@@ -32,7 +32,7 @@ export interface Tileset {
 	/**
 	 * The error, in meters, introduced if this tileset is not rendered. At runtime, the geometric error is used to compute screen space error (SSE), i.e., the error measured in pixels.
 	 */
-	geometricError: Number;
+	geometricError: number;
 
 	/**
 	 * The root tile.

--- a/src/base/loaders/B3DMLoaderBase.d.ts
+++ b/src/base/loaders/B3DMLoaderBase.d.ts
@@ -3,7 +3,7 @@ import { FeatureTable } from '../../utilities/FeatureTable';
 
 export interface B3DMBaseResult {
 
-	version : String;
+	version : string;
 	featureTable: FeatureTable;
 	batchTable : BatchTable;
 	glbBytes : Uint8Array;

--- a/src/base/loaders/CMPTLoaderBase.d.ts
+++ b/src/base/loaders/CMPTLoaderBase.d.ts
@@ -1,14 +1,14 @@
 interface TileInfo {
 
-	type : String;
+	type : string;
 	buffer : Uint8Array;
-	version : String;
+	version : string;
 
 }
 
 export interface CMPTBaseResult {
 
-	version : String;
+	version : string;
 	tiles : Array< TileInfo >;
 
 }
@@ -16,7 +16,7 @@ export interface CMPTBaseResult {
 export class CMPTLoaderBase {
 
 	workingPath : string;
-	load( url : String ) : Promise< CMPTBaseResult >;
+	load( url : string ) : Promise< CMPTBaseResult >;
 	parse( buffer : ArrayBuffer ) : CMPTBaseResult;
 
 }

--- a/src/base/loaders/I3DMLoaderBase.d.ts
+++ b/src/base/loaders/I3DMLoaderBase.d.ts
@@ -3,7 +3,7 @@ import { FeatureTable } from '../../utilities/FeatureTable';
 
 export interface I3DMBaseResult {
 
-	version : String;
+	version : string;
 	featureTable: FeatureTable;
 	batchTable : BatchTable;
 	glbBytes : Uint8Array;

--- a/src/base/loaders/PNTSLoaderBase.d.ts
+++ b/src/base/loaders/PNTSLoaderBase.d.ts
@@ -3,7 +3,7 @@ import { FeatureTable } from '../../utilities/FeatureTable';
 
 export interface PNTSBaseResult {
 
-	version : String;
+	version : string;
 	featureTable: FeatureTable;
 	batchTable : BatchTable;
 

--- a/src/plugins/three/CesiumIonAuthPlugin.d.ts
+++ b/src/plugins/three/CesiumIonAuthPlugin.d.ts
@@ -1,9 +1,9 @@
 export class CesiumIonAuthPlugin {
 
 	constructor( options : {
-		apiToken: String,
-		assetId?: String | null,
-		autoRefreshToken?: Boolean
+		apiToken: string,
+		assetId?: string | null,
+		autoRefreshToken?: boolean
 	} );
 
 }

--- a/src/plugins/three/DebugTilesPlugin.d.ts
+++ b/src/plugins/three/DebugTilesPlugin.d.ts
@@ -14,16 +14,16 @@ export const RANDOM_NODE_COLOR: ColorMode;
 export const CUSTOM_COLOR: ColorMode;
 export class DebugTilesPlugin {
 
-	displayBoxBounds : Boolean;
-	displaySphereBounds : Boolean;
-	displayRegionBounds : Boolean;
+	displayBoxBounds : boolean;
+	displaySphereBounds : boolean;
+	displayRegionBounds : boolean;
 	colorMode : ColorMode;
 
-	maxDebugDepth : Number;
-	maxDebugDistance : Number;
-	maxDebugError : Number;
+	maxDebugDepth : number;
+	maxDebugDistance : number;
+	maxDebugError : number;
 
-	getDebugColor : ( val: Number, target: Color ) => void;
+	getDebugColor : ( val: number, target: Color ) => void;
 	customColorCallback : ( val: Tile, target: Color ) => void;
 
 }

--- a/src/plugins/three/GLTFExtensionsPlugin.d.ts
+++ b/src/plugins/three/GLTFExtensionsPlugin.d.ts
@@ -5,14 +5,14 @@ import { GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoa
 export class GLTFExtensionsPlugin {
 
 	constructor( options: {
-		metadata: Boolean,
-		rtc: Boolean,
+		metadata: boolean,
+		rtc: boolean,
 
 		plugins: Array<( parser: GLTFParser ) => GLTFLoaderPlugin>,
 
 		dracoLoader: DRACOLoader | null,
 		ktxLoader: KTX2Loader | null,
-		autoDispose: Boolean,
+		autoDispose: boolean,
 	} );
 
 }

--- a/src/plugins/three/GoogleCloudAuthPlugin.d.ts
+++ b/src/plugins/three/GoogleCloudAuthPlugin.d.ts
@@ -1,5 +1,5 @@
 export class GoogleCloudAuthPlugin {
 
-	constructor( options : { apiToken: String, autoRefreshToken?: Boolean } );
+	constructor( options : { apiToken: string, autoRefreshToken?: boolean } );
 
 }

--- a/src/plugins/three/ReorientationPlugin.d.ts
+++ b/src/plugins/three/ReorientationPlugin.d.ts
@@ -2,11 +2,11 @@ export class GLTFExtensionsPlugin {
 
 	constructor( options: {
 		up: '+x' | '-x' | '+y' | '-y' | '+z' | '-z',
-		recenter: Boolean,
+		recenter: boolean,
 
-		lat: Number | null,
-		lon: Number | null,
-		height: Number,
+		lat: number | null,
+		lon: number | null,
+		height: number,
 	} );
 
 }

--- a/src/plugins/three/TileCompressionPlugin.d.ts
+++ b/src/plugins/three/TileCompressionPlugin.d.ts
@@ -3,12 +3,12 @@ import { TypedArray } from 'three';
 export class TileCompressionPlugin {
 
 	constructor( options: {
-		generateNormals: Boolean,
-		disableMipmaps: Boolean,
-		compressIndex: Boolean,
-		compressNormals: Boolean,
-		compressUvs: Boolean,
-		compressPosition: Boolean,
+		generateNormals: boolean,
+		disableMipmaps: boolean,
+		compressIndex: boolean,
+		compressNormals: boolean,
+		compressUvs: boolean,
+		compressPosition: boolean,
 
 		uvType: TypedArray,
 		normalType: TypedArray,

--- a/src/plugins/three/fade/TilesFadePlugin.d.ts
+++ b/src/plugins/three/fade/TilesFadePlugin.d.ts
@@ -1,9 +1,9 @@
 export class TilesFadePlugin {
 
 	constructor( options: {
-		maximumFadeOutTiles: Number,
-		fadeRootTiles: Boolean,
-		fadeDuration: Number,
+		maximumFadeOutTiles: number,
+		fadeRootTiles: boolean,
+		fadeDuration: number,
 	} );
 
 }

--- a/src/plugins/three/gltf/GLTFMeshFeaturesExtension.d.ts
+++ b/src/plugins/three/gltf/GLTFMeshFeaturesExtension.d.ts
@@ -8,9 +8,9 @@ export class GLTFMeshFeaturesExtension {
 
 export class MeshFeatures {
 
-	getFeatures( triangle: Number, barycoord: Vector3 ): Array<Number>;
-	getFeaturesAsync( triangle: Number, barycoord: Vector3 ): Promise<Array<Number>>;
-	getFeaturesInfo(): Array<{ label: String, propertyTable: Number, nullFeatureId: Number | null }>;
+	getFeatures( triangle: number, barycoord: Vector3 ): Array<number>;
+	getFeaturesAsync( triangle: number, barycoord: Vector3 ): Promise<Array<number>>;
+	getFeaturesInfo(): Array<{ label: string, propertyTable: number, nullFeatureId: number | null }>;
 	dispose(): void;
 
 }

--- a/src/plugins/three/gltf/GLTFStructuralMetadataExtension.d.ts
+++ b/src/plugins/three/gltf/GLTFStructuralMetadataExtension.d.ts
@@ -10,25 +10,25 @@ class StructuralMetadata {
 
 	textures: Array<Texture | null>;
 
-	getPropertyTableData( tableIndices: Array<Number>, ids: Array<Number>, target: Array = [] ): Array<any>;
-	getPropertyTableInfo( tableIndices: Array<Number> | null = null ): Array<{ name: String, className: string }>;
+	getPropertyTableData( tableIndices: Array<number>, ids: Array<number>, target: Array = [] ): Array<any>;
+	getPropertyTableInfo( tableIndices: Array<number> | null = null ): Array<{ name: string, className: string }>;
 
-	getPropertyTextureData( triangle: Number, barycoord: Vector3, target: Array = [] ): Array<any>;
-	getPropertyTextureDataAsync( triangle: Number, barycoord: Vector3, target: Array = [] ): Promise<Array<any>>;
+	getPropertyTextureData( triangle: number, barycoord: Vector3, target: Array = [] ): Array<any>;
+	getPropertyTextureDataAsync( triangle: number, barycoord: Vector3, target: Array = [] ): Promise<Array<any>>;
 	getPropertyTextureInfo(): Array<{
-		name: String,
+		name: string,
 		className: string,
 		properties: {
 			[key: string]: {
-				index: Number,
-				texCoord: Number,
-				channels: Array<Number>,
+				index: number,
+				texCoord: number,
+				channels: Array<number>,
 			}
 		}
 	}>;
 
-	getPropertyAttributeData( attributeIndex: Number, target: Array = [] ): Array<any>;
-	getPropertyAttributeInfo(): Array<{ name: String, className: string }>;
+	getPropertyAttributeData( attributeIndex: number, target: Array = [] ): Array<any>;
+	getPropertyAttributeInfo(): Array<{ name: string, className: string }>;
 
 	dispose(): void;
 

--- a/src/three/DebugTilesRenderer.d.ts
+++ b/src/three/DebugTilesRenderer.d.ts
@@ -14,15 +14,15 @@ export const RANDOM_NODE_COLOR: ColorMode;
 export const CUSTOM_COLOR: ColorMode;
 export class DebugTilesRenderer extends TilesRenderer {
 
-	displayBoxBounds : Boolean;
-	displaySphereBounds : Boolean;
-	displayRegionBounds : Boolean;
+	displayBoxBounds : boolean;
+	displaySphereBounds : boolean;
+	displayRegionBounds : boolean;
 	colorMode : ColorMode;
 
-	maxDebugDepth : Number;
-	maxDebugDistance : Number;
-	maxDebugError : Number;
+	maxDebugDepth : number;
+	maxDebugDistance : number;
+	maxDebugError : number;
 
-	getDebugColor : ( val: Number, target: Color ) => void;
+	getDebugColor : ( val: number, target: Color ) => void;
 
 }

--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -7,30 +7,30 @@ import { Ellipsoid } from './math/Ellipsoid';
 export class TilesRenderer extends TilesRendererBase {
 
 	ellipsoid: Ellipsoid;
-	autoDisableRendererCulling : Boolean;
-	optimizeRaycast : Boolean;
+	autoDisableRendererCulling : boolean;
+	optimizeRaycast : boolean;
 
 	manager : LoadingManager;
 
 	group : TilesGroup;
 
-	getBoundingBox( box : Box3 ) : Boolean;
-	getOrientedBoundingBox( box : Box3, matrix : Matrix4 ) : Boolean;
-	getBoundingSphere( sphere: Sphere ) : Boolean;
+	getBoundingBox( box : Box3 ) : boolean;
+	getOrientedBoundingBox( box : Box3, matrix : Matrix4 ) : boolean;
+	getBoundingSphere( sphere: Sphere ) : boolean;
 
-	hasCamera( camera : Camera ) : Boolean;
-	setCamera( camera : Camera ) : Boolean;
-	deleteCamera( camera : Camera ) : Boolean;
+	hasCamera( camera : Camera ) : boolean;
+	setCamera( camera : Camera ) : boolean;
+	deleteCamera( camera : Camera ) : boolean;
 
-	setResolution( camera : Camera, x : Number, y : Number ) : Boolean;
-	setResolution( camera : Camera, resolution : Vector2 ) : Boolean;
-	setResolutionFromRenderer( camera : Camera, renderer : WebGLRenderer ) : Boolean;
+	setResolution( camera : Camera, x : number, y : number ) : boolean;
+	setResolution( camera : Camera, resolution : Vector2 ) : boolean;
+	setResolutionFromRenderer( camera : Camera, renderer : WebGLRenderer ) : boolean;
 
 	forEachLoadedModel( callback : ( scene : Object3D, tile : Tile ) => void ) : void;
 
-	addEventListener( type: String, cb: ( e : Object ) => void );
-	hasEventListener( type: String, cb: ( e : Object ) => void );
-	removeEventListener( type: String, cb: ( e : Object ) => void );
-	dispatchEvent( e : Object );
+	addEventListener( type: string, cb: ( e : object ) => void );
+	hasEventListener( type: string, cb: ( e : object ) => void );
+	removeEventListener( type: string, cb: ( e : object ) => void );
+	dispatchEvent( e : object );
 
 }

--- a/src/three/loaders/B3DMLoader.d.ts
+++ b/src/three/loaders/B3DMLoader.d.ts
@@ -20,7 +20,7 @@ export interface B3DMResult extends GLTF, B3DMBaseResult {
 export class B3DMLoader {
 
 	constructor( manager : LoadingManager );
-	load( url : String ) : Promise< B3DMResult >;
+	load( url : string ) : Promise< B3DMResult >;
 	parse( buffer : ArrayBuffer ) : Promise < B3DMResult >;
 
 }

--- a/src/three/loaders/CMPTLoader.d.ts
+++ b/src/three/loaders/CMPTLoader.d.ts
@@ -13,7 +13,7 @@ export interface CMPTResult {
 export class CMPTLoader {
 
 	constructor( manager : LoadingManager );
-	load( url : String ) : Promise< CMPTResult >;
+	load( url : string ) : Promise< CMPTResult >;
 	parse( buffer : ArrayBuffer ) : Promise< CMPTResult >;
 
 }

--- a/src/three/loaders/I3DMLoader.d.ts
+++ b/src/three/loaders/I3DMLoader.d.ts
@@ -20,7 +20,7 @@ export interface I3DMResult extends GLTF, I3DMBaseResult {
 export class I3DMLoader {
 
 	constructor( manager : LoadingManager );
-	load( url : String ) : Promise< I3DMResult >;
+	load( url : string ) : Promise< I3DMResult >;
 	parse( buffer : ArrayBuffer ) : Promise< I3DMResult >;
 
 }

--- a/src/three/loaders/PNTSLoader.d.ts
+++ b/src/three/loaders/PNTSLoader.d.ts
@@ -19,7 +19,7 @@ export interface PNTSResult extends PNTSBaseResult {
 export class PNTSLoader extends PNTSLoaderBase {
 
 	constructor( manager : LoadingManager );
-	load( url : String ) : Promise< PNTSResult >;
+	load( url : string ) : Promise< PNTSResult >;
 	parse( buffer : ArrayBuffer ) : Promise< PNTSResult >;
 
 }

--- a/src/three/math/Ellipsoid.d.ts
+++ b/src/three/math/Ellipsoid.d.ts
@@ -9,23 +9,23 @@ export class Ellipsoid {
 
 	radius: Vector3;
 
-	constructor( x: Number, y: Number, z: Number );
-	getCartographicToPosition( lat: Number, lon: Number, height: Number, target: Vector3 ): Vector3;
-	getPositionToCartographic( pos: Vector3, target: Object ): { lat: Number, lon: Number, height: Number };
-	getCartographicToNormal( lat: Number, lon: Number, target: Vector3 ): Vector3;
+	constructor( x: number, y: number, z: number );
+	getCartographicToPosition( lat: number, lon: number, height: number, target: Vector3 ): Vector3;
+	getPositionToCartographic( pos: Vector3, target: object ): { lat: number, lon: number, height: number };
+	getCartographicToNormal( lat: number, lon: number, target: Vector3 ): Vector3;
 	getPositionToNormal( pos: Vector3, target: Vector3 ): Vector3;
 	getPositionToSurfacePoint( pos: Vector3, target: Vector3 ): Vector3;
 
 	getAzElRollFromRotationMatrix(
-		lat: Number, lon: Number, rotationMatrix: Matrix4,
-		target: Object, frame: Frames,
-	): { azimuth: Number, elevation: Number, roll: Number };
+		lat: number, lon: number, rotationMatrix: Matrix4,
+		target: object, frame: Frames,
+	): { azimuth: number, elevation: number, roll: number };
 	getRotationMatrixFromAzElRoll(
-		lat: Number, lon: Number, az: Number, el: Number, roll: Number,
+		lat: number, lon: number, az: number, el: number, roll: number,
 		target: Matrix4, frame: Frames,
 	): Matrix4;
 
-	getEastNorthUpFrame( lat: Number, lon: Number, target: Matrix4 ): Matrix4;
-	getEastNorthUpAxes( lat: Number, lon: Number, vecEast: Vector3, vecNorth: Vector3, vecUp: Vector3, point?: Vector3 );
+	getEastNorthUpFrame( lat: number, lon: number, target: Matrix4 ): Matrix4;
+	getEastNorthUpAxes( lat: number, lon: number, vecEast: Vector3, vecNorth: Vector3, vecUp: Vector3, point?: Vector3 );
 
 }

--- a/src/three/math/EllipsoidRegion.d.ts
+++ b/src/three/math/EllipsoidRegion.d.ts
@@ -3,18 +3,18 @@ import { Ellipsoid } from './Ellipsoid';
 
 export class EllipsoidRegion extends Ellipsoid {
 
-	latStart: Number;
-	latEnd: Number;
-	lonStart: Number;
-	lonEnd: Number;
-	heightStart: Number;
-	heightEnd: Number;
+	latStart: number;
+	latEnd: number;
+	lonStart: number;
+	lonEnd: number;
+	heightStart: number;
+	heightEnd: number;
 
 	constructor(
-		x: Number, y: Number, z: Number,
-		latStart: Number, latEnd: Number,
-		lonStart: Number, lonEnd: Number,
-		heightStart: Number, heightEnd: Number
+		x: number, y: number, z: number,
+		latStart: number, latEnd: number,
+		lonStart: number, lonEnd: number,
+		heightStart: number, heightEnd: number
 	);
 
 	getBoundingBox( box : Box3, matrix : Matrix4 );

--- a/src/three/math/GeoUtils.d.ts
+++ b/src/three/math/GeoUtils.d.ts
@@ -4,6 +4,6 @@ export function swapToGeoFrame( target : Vector3 ) : Vector3;
 
 export function swapToThreeFrame( target : Vector3 ) : Vector3;
 
-export function sphericalPhiToLatitude( phi : Number ) : Number;
+export function sphericalPhiToLatitude( phi : number ) : number;
 
-export function latitudeToSphericalPhi( latitude : Number ) : Number;
+export function latitudeToSphericalPhi( latitude : number ) : number;

--- a/src/three/renderers/CesiumIonTilesRenderer.d.ts
+++ b/src/three/renderers/CesiumIonTilesRenderer.d.ts
@@ -3,12 +3,12 @@ import { DebugTilesRenderer } from '../DebugTilesRenderer';
 
 export class CesiumIonTilesRenderer extends TilesRenderer {
 
-	constructor( ionAssetId: String, ionAccessToken: String );
+	constructor( ionAssetId: string, ionAccessToken: string );
 
 }
 
 export class DebugCesiumIonTilesRenderer extends DebugTilesRenderer {
 
-	constructor( ionAssetId: String, ionAccessToken: String );
+	constructor( ionAssetId: string, ionAccessToken: string );
 
 }

--- a/src/three/renderers/GoogleTilesRenderer.d.ts
+++ b/src/three/renderers/GoogleTilesRenderer.d.ts
@@ -6,9 +6,9 @@ export class GoogleTilesRenderer extends TilesRenderer {
 
 	ellipsoid: Ellipsoid;
 
-	constructor( apiKey: String );
-	getCreditsString(): String;
-	setLatLonToYUp( lat: Number, lon: Number ): void;
+	constructor( apiKey: string );
+	getCreditsString(): string;
+	setLatLonToYUp( lat: number, lon: number ): void;
 
 }
 
@@ -16,9 +16,9 @@ export class DebugGoogleTilesRenderer extends DebugTilesRenderer {
 
 	ellipsoid: Ellipsoid;
 
-	constructor( apiKey: String );
-	getCreditsString(): String;
-	setLatLonToYUp( lat: Number, lon: Number ): void;
+	constructor( apiKey: string );
+	getCreditsString(): string;
+	setLatLonToYUp( lat: number, lon: number ): void;
 
 }
 
@@ -27,8 +27,8 @@ export class GooglePhotorealisticTilesRenderer extends TilesRenderer {
 	ellipsoid: Ellipsoid;
 
 	constructor( url?: string );
-	getCreditsString(): String;
-	setLatLonToYUp( lat: Number, lon: Number ): void;
+	getCreditsString(): string;
+	setLatLonToYUp( lat: number, lon: number ): void;
 
 }
 
@@ -37,7 +37,7 @@ export class DebugGooglePhotorealisticTilesRenderer extends DebugTilesRenderer {
 	ellipsoid: Ellipsoid;
 
 	constructor( url?: string );
-	getCreditsString(): String;
-	setLatLonToYUp( lat: Number, lon: Number ): void;
+	getCreditsString(): string;
+	setLatLonToYUp( lat: number, lon: number ): void;
 
 }

--- a/src/utilities/BatchTable.d.ts
+++ b/src/utilities/BatchTable.d.ts
@@ -1,24 +1,24 @@
 export class BatchTable {
 
-	count : Number;
+	count : number;
 
 	constructor(
 		buffer : ArrayBuffer,
-		count : Number,
-		start : Number,
-		headerLength : Number,
-		binLength : Number
+		count : number,
+		start : number,
+		headerLength : number,
+		binLength : number
 	);
 
-	getKeys() : Array< String >;
+	getKeys() : Array< string >;
 
 	getDataFromId(
-		id: Number,
-		target?: Object
-	) : Object;
+		id: number,
+		target?: object
+	) : object;
 
 	getPropertyArray(
-		key: String,
-	) : Number | String | ArrayBufferView;
+		key: string,
+	) : number | string | ArrayBufferView;
 
 }

--- a/src/utilities/FeatureTable.d.ts
+++ b/src/utilities/FeatureTable.d.ts
@@ -1,6 +1,6 @@
 interface FeatureTableHeader {
 
-	extensions?: Object;
+	extensions?: object;
 	extras?: any;
 
 }
@@ -11,20 +11,20 @@ export class FeatureTable {
 
 	constructor(
 		buffer : ArrayBuffer,
-		start : Number,
-		headerLength : Number,
-		binLength : Number
+		start : number,
+		headerLength : number,
+		binLength : number
 	);
 
-	getKeys() : Array< String >;
+	getKeys() : Array< string >;
 
 	getData(
-		key : String,
-		count : Number,
-		defaultComponentType? : String | null,
-		defaultType? : String | null
-	) : Number | String | ArrayBufferView;
+		key : string,
+		count : number,
+		defaultComponentType? : string | null,
+		defaultType? : string | null
+	) : number | string | ArrayBufferView;
 
-	getBuffer( byteOffset : Number, byteLength : Number ) : ArrayBuffer;
+	getBuffer( byteOffset : number, byteLength : number ) : ArrayBuffer;
 
 }

--- a/src/utilities/LRUCache.d.ts
+++ b/src/utilities/LRUCache.d.ts
@@ -1,8 +1,8 @@
 export class LRUCache {
 
-	maxSize : Number;
-	minSize : Number;
-	unloadPercent : Number;
-	unloadPriorityCallback : ( item : any ) => Number;
+	maxSize : number;
+	minSize : number;
+	unloadPercent : number;
+	unloadPriorityCallback : ( item : any ) => number;
 
 }

--- a/src/utilities/PriorityQueue.d.ts
+++ b/src/utilities/PriorityQueue.d.ts
@@ -1,8 +1,8 @@
 export class PriorityQueue {
 
-	maxJobs : Number;
-	autoUpdate : Boolean;
-	priorityCallback : ( itemA : any, itemB : any ) => Number;
+	maxJobs : number;
+	autoUpdate : boolean;
+	priorityCallback : ( itemA : any, itemB : any ) => number;
 
 	schedulingCallback : ( func : Function ) => void;
 


### PR DESCRIPTION
This [rule](https://typescript-eslint.io/rules/no-wrapper-object-types) disallow so-called wrapper types in favor of primitives types: `boolean` instead of `Boolean`, `number` instead of `Number`, etc.

The official Typescript documentation [says](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#the-primitives-string-number-and-boolean):

> The type names String, Number, and Boolean (starting with capital letters) are legal, but refer to some special built-in types that will very rarely appear in your code. Always use string, number, or boolean for types.