### PR TITLE
docs: add missing tiles-load-start/end events documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,12 @@ _extends `THREE.EventDispatcher` & [TilesRendererBase](https://github.com/NASA-A
 
 // fired when a tiles visibility changes
 { type: 'tile-visibility-change', scene: THREE.Group, tile: Object }
+
+// fired when tiles start loading
+{ type: 'tiles-load-start' }
+
+// fired when all tiles finish loading
+{ type: 'tiles-load-end' }
 ```
 
 ### .fetchOptions


### PR DESCRIPTION
docs: add missing tiles-load-start/end events documentation

Add documentation for two missing events:
- tiles-load-start: fired when tiles start loading
- tiles-load-end: fired when all tiles finish loading

These events are implemented in the code but were not documented in the README.