### PR TITLE
fix(GLTFCesiumRTCExtension.d.ts): implements THREE.js's GLTFLoaderPlugin

### DIFF
--- a/src/plugins/three/gltf/GLTFCesiumRTCExtension.d.ts
+++ b/src/plugins/three/gltf/GLTFCesiumRTCExtension.d.ts
@@ -1,4 +1,6 @@
-export class GLTFCesiumRTCExtension {
+import { GLTFLoaderPlugin } from 'three/examples/jsm/loaders/GLTFLoader.js';
+
+export class GLTFCesiumRTCExtension implements GLTFLoaderPlugin {
 
 	name: 'CESIUM_RTC';
 

--- a/src/plugins/three/gltf/GLTFMeshFeaturesExtension.d.ts
+++ b/src/plugins/three/gltf/GLTFMeshFeaturesExtension.d.ts
@@ -1,6 +1,7 @@
 import { Vector3 } from 'three';
+import { GLTFLoaderPlugin } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
-export class GLTFMeshFeaturesExtension {
+export class GLTFMeshFeaturesExtension implements GLTFLoaderPlugin {
 
 	name: 'EXT_mesh_features';
 

--- a/src/plugins/three/gltf/GLTFStructuralMetadataExtension.d.ts
+++ b/src/plugins/three/gltf/GLTFStructuralMetadataExtension.d.ts
@@ -1,6 +1,7 @@
 import { Vector3, Texture } from 'three';
+import { GLTFLoaderPlugin } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
-export class GLTFStructuralMetadataExtension {
+export class GLTFStructuralMetadataExtension implements GLTFLoaderPlugin {
 
 	name: 'EXT_structural_metadata';
 


### PR DESCRIPTION
This typing is necessary to register this extension on the three.js GLTFLoader.