### PR TITLE
Add "UnloadTilesPlugin" to save GPU memory

### DIFF
--- a/example/src/plugins/UnloadTilesPlugin.js
+++ b/example/src/plugins/UnloadTilesPlugin.js
@@ -34,7 +34,7 @@ export class UnloadTilesPlugin {
 
 				if ( ! visible ) {
 
-					tiles.invokeOnePlugin( plugin => plugin.unloadTileFromGPU && plugin.unloadTileFromGPU( tile, scene ) );
+					tiles.invokeOnePlugin( plugin => plugin.unloadTileFromGPU && plugin.unloadTileFromGPU( scene, tile ) );
 
 				}
 

--- a/example/src/plugins/UnloadTilesPlugin.js
+++ b/example/src/plugins/UnloadTilesPlugin.js
@@ -14,16 +14,7 @@ export class UnloadTilesPlugin {
 
 	constructor( options = {} ) {
 
-		const {
-			unloadGeometry = true,
-			unloadTextures = true,
-			unloadMaterials = true,
-		} = options;
-
 		this.tiles = null;
-		this.unloadGeometry = unloadGeometry;
-		this.unloadMaterials = unloadMaterials;
-		this.unloadTextures = unloadTextures;
 		this.estimatedGpuBytes = 0;
 
 	}
@@ -46,22 +37,14 @@ export class UnloadTilesPlugin {
 						if ( c.material ) {
 
 							const material = c.material;
-							if ( this.unloadMaterials ) {
+							material.dispose();
 
-								material.dispose();
+							for ( const key in material ) {
 
-							}
+								const value = material[ key ];
+								if ( value && value.isTexture ) {
 
-							if ( this.unloadTextures ) {
-
-								for ( const key in material ) {
-
-									const value = material[ key ];
-									if ( value && value.isTexture ) {
-
-										value.dispose();
-
-									}
+									value.dispose();
 
 								}
 
@@ -69,7 +52,7 @@ export class UnloadTilesPlugin {
 
 						}
 
-						if ( c.geometry && this.unloadGeometry ) {
+						if ( c.geometry ) {
 
 							c.geometry.dispose();
 
@@ -82,7 +65,6 @@ export class UnloadTilesPlugin {
 			}
 
 		};
-
 
 		tiles.forEachLoadedModel( ( scene, tile ) => {
 

--- a/example/src/plugins/UnloadTilesPlugin.js
+++ b/example/src/plugins/UnloadTilesPlugin.js
@@ -6,10 +6,6 @@ import { estimateBytesUsed } from '../../../src/three/utilities.js';
 // - abstract the "tile visible" callback so fade tiles can call it when tiles are _actually_ marked as non-visible
 // - add a memory unload function to the tiles renderer that can be called and reacted to by any plugin including BatchedMesh,
 // though this may prevent different options. Something like a subfunction that "disposeTile" calls without full disposal.
-// - For BatchedMeshPlugin
-//    - Needs flag indicating whether tiles should be fully disposed on upload
-//    - Needs to be smarter and reupload if-needed
-//    - Raycasting needs to be smarter and raycast against non-uploaded geometry
 export class UnloadTilesPlugin {
 
 	constructor() {

--- a/example/src/plugins/UnloadTilesPlugin.js
+++ b/example/src/plugins/UnloadTilesPlugin.js
@@ -12,7 +12,7 @@ import { estimateBytesUsed } from '../../../src/three/utilities.js';
 //    - Raycasting needs to be smarter and raycast against non-uploaded geometry
 export class UnloadTilesPlugin {
 
-	constructor( options = {} ) {
+	constructor() {
 
 		this.tiles = null;
 		this.estimatedGpuBytes = 0;

--- a/example/src/plugins/UnloadTilesPlugin.js
+++ b/example/src/plugins/UnloadTilesPlugin.js
@@ -1,0 +1,105 @@
+import { estimateBytesUsed } from '../../../src/three/utilities.js';
+
+// Plugin that disposes tiles on unload to remove them from the GPU, saving memory
+
+// TODO:
+// - abstract the "tile visible" callback so fade tiles can call it when tiles are _actually_ marked as non-visible
+// - add a memory unload function to the tiles renderer that can be called and reacted to by any plugin including BatchedMesh,
+// though this may prevent different options. Something like a subfunction that "disposeTile" calls without full disposal.
+// - For BatchedMeshPlugin
+//    - Needs flag indicating whether tiles should be fully disposed on upload
+//    - Needs to be smarter and reupload if-needed
+//    - Raycasting needs to be smarter and raycast against non-uploaded geometry
+export class UnloadTilesPlugin {
+
+	constructor( options = {} ) {
+
+		const {
+			unloadGeometry = true,
+			unloadTextures = true,
+			unloadMaterials = true,
+		} = options;
+
+		this.tiles = null;
+		this.unloadGeometry = unloadGeometry;
+		this.unloadMaterials = unloadMaterials;
+		this.unloadTextures = unloadTextures;
+		this.estimatedGpuBytes = 0;
+
+	}
+
+	init( tiles ) {
+
+		this.tiles = tiles;
+
+		this._onVisibilityChangeCallback = ( { scene, visible } ) => {
+
+			if ( scene ) {
+
+				const size = estimateBytesUsed( scene );
+				this.estimatedGpuBytes += visible ? size : - size;
+
+				if ( ! visible ) {
+
+					scene.traverse( c => {
+
+						if ( c.material ) {
+
+							const material = c.material;
+							if ( this.unloadMaterials ) {
+
+								material.dispose();
+
+							}
+
+							if ( this.unloadTextures ) {
+
+								for ( const key in material ) {
+
+									const value = material[ key ];
+									if ( value && value.isTexture ) {
+
+										value.dispose();
+
+									}
+
+								}
+
+							}
+
+						}
+
+						if ( c.geometry && this.unloadGeometry ) {
+
+							c.geometry.dispose();
+
+						}
+
+					} );
+
+				}
+
+			}
+
+		};
+
+
+		tiles.forEachLoadedModel( ( scene, tile ) => {
+
+			const visible = tiles.visibleSet.has( tile );
+			this._onVisibilityChangeCallback( { scene, visible } );
+
+		} );
+
+		tiles.addEventListener( 'tile-visibility-change', this._onVisibilityChangeCallback );
+
+	}
+
+	dispose() {
+
+		this.tiles.removeEventListener( 'tile-visibility-change', this._onVisibilityChangeCallback );
+		this.estimatedGpuBytes = 0;
+
+	}
+
+}

--- a/example/src/plugins/UnloadTilesPlugin.js
+++ b/example/src/plugins/UnloadTilesPlugin.js
@@ -14,6 +14,8 @@ export class UnloadTilesPlugin {
 
 	constructor() {
 
+		this.name = 'UNLOAD_TILES_PLUGIN';
+
 		this.tiles = null;
 		this.estimatedGpuBytes = 0;
 
@@ -23,7 +25,7 @@ export class UnloadTilesPlugin {
 
 		this.tiles = tiles;
 
-		this._onVisibilityChangeCallback = ( { scene, visible } ) => {
+		this._onVisibilityChangeCallback = ( { scene, visible, tile } ) => {
 
 			if ( scene ) {
 
@@ -32,33 +34,7 @@ export class UnloadTilesPlugin {
 
 				if ( ! visible ) {
 
-					scene.traverse( c => {
-
-						if ( c.material ) {
-
-							const material = c.material;
-							material.dispose();
-
-							for ( const key in material ) {
-
-								const value = material[ key ];
-								if ( value && value.isTexture ) {
-
-									value.dispose();
-
-								}
-
-							}
-
-						}
-
-						if ( c.geometry ) {
-
-							c.geometry.dispose();
-
-						}
-
-					} );
+					tiles.invokeOnePlugin( plugin => plugin.unloadTileFromGPU && plugin.unloadTileFromGPU( tile, scene ) );
 
 				}
 
@@ -74,6 +50,42 @@ export class UnloadTilesPlugin {
 		} );
 
 		tiles.addEventListener( 'tile-visibility-change', this._onVisibilityChangeCallback );
+
+	}
+
+	unloadTileFromGPU( scene, tile ) {
+
+		if ( scene ) {
+
+			scene.traverse( c => {
+
+				if ( c.material ) {
+
+					const material = c.material;
+					material.dispose();
+
+					for ( const key in material ) {
+
+						const value = material[ key ];
+						if ( value && value.isTexture ) {
+
+							value.dispose();
+
+						}
+
+					}
+
+				}
+
+				if ( c.geometry ) {
+
+					c.geometry.dispose();
+
+				}
+
+			} );
+
+		}
 
 	}
 

--- a/example/src/plugins/batched/BatchedTilesPlugin.js
+++ b/example/src/plugins/batched/BatchedTilesPlugin.js
@@ -43,6 +43,7 @@ export class BatchedTilesPlugin {
 		this.expandPercent = options.expandPercent;
 		this.maxInstanceCount = Math.min( options.maxInstanceCount, gl.getParameter( gl.MAX_3D_TEXTURE_SIZE ) );
 		this.renderer = options.renderer;
+		this.disposeOriginalTiles = true;
 
 		// local variables
 		this.batchedMesh = null;
@@ -52,6 +53,12 @@ export class BatchedTilesPlugin {
 		this._onDisposeModel = null;
 		this._onVisibilityChange = null;
 		this._tileToInstanceId = new Map();
+
+	}
+
+	setTileVisible( tile, visible ) {
+
+		return true;
 
 	}
 
@@ -100,7 +107,7 @@ export class BatchedTilesPlugin {
 				if ( this.disposeOriginalTiles ) {
 
 					// TODO: ideally we could just set these to null
-					tile.cached.scene = new Group();
+					tile.cached.scene = null;
 					tile.cached.materials = [];
 					tile.cached.geometries = [];
 					tile.cached.textures = [];

--- a/example/src/plugins/batched/BatchedTilesPlugin.js
+++ b/example/src/plugins/batched/BatchedTilesPlugin.js
@@ -78,6 +78,14 @@ export class BatchedTilesPlugin {
 
 			} );
 
+			// dispatch the event that is blocked otherwise
+			this.tiles.dispatchEvent( {
+				type: 'tile-visibility-change',
+				scene,
+				tile,
+				visible,
+			} );
+
 			return true;
 
 		}

--- a/example/src/plugins/batched/BatchedTilesPlugin.js
+++ b/example/src/plugins/batched/BatchedTilesPlugin.js
@@ -1,4 +1,4 @@
-import { WebGLArrayRenderTarget, MeshBasicMaterial, Group, DataTexture, REVISION } from 'three';
+import { WebGLArrayRenderTarget, MeshBasicMaterial, DataTexture, REVISION } from 'three';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { ExpandingBatchedMesh } from './ExpandingBatchedMesh.js';
 import { convertMapToArrayTexture, isColorWhite } from './utilities.js';

--- a/example/src/plugins/batched/BatchedTilesPlugin.js
+++ b/example/src/plugins/batched/BatchedTilesPlugin.js
@@ -23,6 +23,7 @@ export class BatchedTilesPlugin {
 			indexCount: 2000,
 			expandPercent: 0.25,
 			maxInstanceCount: Infinity,
+			disposeOriginalTiles: true,
 
 			material: null,
 			renderer: null,
@@ -96,11 +97,15 @@ export class BatchedTilesPlugin {
 			const canAddMeshes = ! this.batchedMesh || this.batchedMesh.instanceCount + meshes.length <= this.maxInstanceCount;
 			if ( hasCorrectAttributes && canAddMeshes ) {
 
-				// TODO: ideally we could just set these to null
-				tile.cached.scene = new Group();
-				tile.cached.materials = [];
-				tile.cached.geometries = [];
-				tile.cached.textures = [];
+				if ( this.disposeOriginalTiles ) {
+
+					// TODO: ideally we could just set these to null
+					tile.cached.scene = new Group();
+					tile.cached.materials = [];
+					tile.cached.geometries = [];
+					tile.cached.textures = [];
+
+				}
 
 				scene.updateMatrixWorld();
 

--- a/example/src/plugins/batched/BatchedTilesPlugin.js
+++ b/example/src/plugins/batched/BatchedTilesPlugin.js
@@ -133,8 +133,20 @@ export class BatchedTilesPlugin {
 
 			} );
 
+			// TODO: this should be handled by the base tiles renderer
+			const tiles = this.tiles;
+			if ( visible ) {
+
+				tiles.visibleTiles.add( tile );
+
+			} else {
+
+				tiles.visibleTiles.delete( tile );
+
+			}
+
 			// dispatch the event that is blocked otherwise
-			this.tiles.dispatchEvent( {
+			tiles.dispatchEvent( {
 				type: 'tile-visibility-change',
 				scene,
 				tile,

--- a/example/src/plugins/batched/BatchedTilesPlugin.js
+++ b/example/src/plugins/batched/BatchedTilesPlugin.js
@@ -23,7 +23,7 @@ export class BatchedTilesPlugin {
 			indexCount: 2000,
 			expandPercent: 0.25,
 			maxInstanceCount: Infinity,
-			disposeOriginalTiles: true,
+			dynamicallyUnloadTiles: false,
 
 			material: null,
 			renderer: null,
@@ -43,7 +43,7 @@ export class BatchedTilesPlugin {
 		this.expandPercent = options.expandPercent;
 		this.maxInstanceCount = Math.min( options.maxInstanceCount, gl.getParameter( gl.MAX_3D_TEXTURE_SIZE ) );
 		this.renderer = options.renderer;
-		this.disposeOriginalTiles = options.disposeOriginalTiles;
+		this.dynamicallyUnloadTiles = options.dynamicallyUnloadTiles;
 
 		// local variables
 		this.batchedMesh = null;
@@ -63,7 +63,7 @@ export class BatchedTilesPlugin {
 
 			this.addSceneToBatchedMesh( scene, tile );
 
-		} else if ( ! this.disposeOriginalTiles ) {
+		} else if ( this.dynamicallyUnloadTiles ) {
 
 			this.removeSceneFromBatchedMesh( scene, tile );
 
@@ -261,10 +261,8 @@ export class BatchedTilesPlugin {
 		const canAddMeshes = ! this.batchedMesh || this.batchedMesh.instanceCount + meshes.length <= this.maxInstanceCount;
 		if ( hasCorrectAttributes && canAddMeshes ) {
 
-			if ( this.disposeOriginalTiles ) {
+			if ( ! this.dynamicallyUnloadTiles ) {
 
-				// TODO: ideally we could just set these to null
-				// TODO: check if this is adding unnecessary groups to the scene
 				tile.cached.scene = null;
 				tile.cached.materials = [];
 				tile.cached.geometries = [];

--- a/example/src/plugins/batched/BatchedTilesPlugin.js
+++ b/example/src/plugins/batched/BatchedTilesPlugin.js
@@ -120,6 +120,7 @@ export class BatchedTilesPlugin {
 		const scene = tile.cached.scene;
 		if ( visible ) {
 
+			// Add tile set to the batched mesh if it hasn't been added already
 			this.addSceneToBatchedMesh( scene, tile );
 
 		}

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -166,7 +166,24 @@ export class TilesRendererBase {
 
 		}
 
-		this.plugins.push( plugin );
+		// insert the plugin based on the priority registered on the plugin
+		const plugins = this.plugins;
+		const priority = plugin.priority || 0;
+		let insertionPoint = 0;
+		for ( let i = 0; i < plugins.length; i ++ ) {
+
+			insertionPoint = i;
+
+			const otherPriority = plugins[ i ].priority || 0;
+			if ( otherPriority > priority ) {
+
+				break;
+
+			}
+
+		}
+
+		plugin.splice( insertionPoint, 0, plugin );
 		plugin[ PLUGIN_REGISTERED ] = true;
 		if ( plugin.init ) {
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -363,16 +363,17 @@ export class TilesRendererBase {
 
 	disposeTile( tile ) {
 
+		// TODO: are these necessary? Are we disposing tiles when they are currently visible?
 		if ( tile.__visible ) {
 
-			this.setTileVisible( tile, false );
+			this.invokeOnePlugin( plugin => plugin.setTileVisible && plugin.setTileVisible( tile, false ) );
 			tile.__visible = false;
 
 		}
 
 		if ( tile.__active ) {
 
-			this.setTileActive( tile, false );
+			this.invokeOnePlugin( plugin => plugin.setTileActive && plugin.setTileActive( tile, false ) );
 			tile.__active = false;
 
 		}

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -183,7 +183,7 @@ export class TilesRendererBase {
 
 		}
 
-		plugin.splice( insertionPoint, 0, plugin );
+		plugins.splice( insertionPoint, 0, plugin );
 		plugin[ PLUGIN_REGISTERED ] = true;
 		if ( plugin.init ) {
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -390,7 +390,7 @@ export class TilesRendererBase {
 
 		if ( tile.__active ) {
 
-			this.invokeOnePlugin( plugin => plugin.setTileActive && plugin.setTileActive( tile, false ) );
+			this.setTileActive( tile, false );
 			tile.__active = false;
 
 		}

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -437,7 +437,7 @@ export function toggleTiles( tile, renderer ) {
 
 			if ( tile.__wasSetActive !== setActive ) {
 
-				renderer.invokeOnePlugin( plugin => plugin.setTileActive && plugin.setTileActive( tile, setActive ) );
+				this.setTileActive( tile, setActive );
 
 			}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -437,13 +437,13 @@ export function toggleTiles( tile, renderer ) {
 
 			if ( tile.__wasSetActive !== setActive ) {
 
-				this.invokeOnePlugin( plugin => plugin.setTileActive && plugin.setTileActive( tile, setActive ) );
+				renderer.invokeOnePlugin( plugin => plugin.setTileActive && plugin.setTileActive( tile, setActive ) );
 
 			}
 
 			if ( tile.__wasSetVisible !== setVisible ) {
 
-				this.invokeOnePlugin( plugin => plugin.setTileVisible && plugin.setTileVisible( tile, setVisible ) );
+				renderer.invokeOnePlugin( plugin => plugin.setTileVisible && plugin.setTileVisible( tile, setVisible ) );
 
 			}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -437,13 +437,13 @@ export function toggleTiles( tile, renderer ) {
 
 			if ( tile.__wasSetActive !== setActive ) {
 
-				renderer.setTileActive( tile, setActive );
+				this.invokeOnePlugin( plugin => plugin.setTileActive && plugin.setTileActive( tile, setActive ) );
 
 			}
 
 			if ( tile.__wasSetVisible !== setVisible ) {
 
-				renderer.setTileVisible( tile, setVisible );
+				this.invokeOnePlugin( plugin => plugin.setTileVisible && plugin.setTileVisible( tile, setVisible ) );
 
 			}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -437,7 +437,7 @@ export function toggleTiles( tile, renderer ) {
 
 			if ( tile.__wasSetActive !== setActive ) {
 
-				this.setTileActive( tile, setActive );
+				renderer.setTileActive( tile, setActive );
 
 			}
 

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -574,6 +574,11 @@ Available options are as follows:
 
 	// The material to use for the BatchedMesh. The material of the first tile rendered with be used if not set.
 	material: null,
+
+	// If true then tiles are loaded and unloaded as tiles are set to visible and not visible in order to reduce GPU memory usage.
+	// The original tile scene objects and textures are also not removed when this setting is enabled but can cause frame hiccups
+	// due to the frequent data transfer.
+	dynamicallyUnloadTiles: false
 }
 ```
 

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -576,3 +576,17 @@ Available options are as follows:
 	material: null,
 }
 ```
+
+## UnloadTilesPlugin
+
+_available in the examples directory_
+
+Plugin that unloads geometry, textures, and materials of any given tile when the visibility changes to non-visible to save GPU memory. The model still exists on the CPU until it is completely removed from the cache.
+
+### .estimatedGpuBytes
+
+```js
+estimatedGPUBytes : number
+```
+
+The number of bytes that are actually uploaded to the GPU for rendering compared to `lruCache.cachedBytes` which reports the amount of texture and geometry buffer bytes actually downloaded.

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -575,10 +575,9 @@ Available options are as follows:
 	// The material to use for the BatchedMesh. The material of the first tile rendered with be used if not set.
 	material: null,
 
-	// If true then tiles are loaded and unloaded as tiles are set to visible and not visible in order to reduce GPU memory usage.
-	// The original tile scene objects and textures are also not removed when this setting is enabled but can cause frame hiccups
-	// due to the frequent data transfer.
-	dynamicallyUnloadTiles: false
+	// If true then the original scene geometry is automatically discarded after adding the geometry to the batched mesh to save memory.
+	// This must be set to "false" if being used with plugins such as "UnloadTilesPlugin".
+	discardOriginalContent: true
 }
 ```
 

--- a/src/plugins/three/TileCompressionPlugin.js
+++ b/src/plugins/three/TileCompressionPlugin.js
@@ -126,6 +126,9 @@ export class TileCompressionPlugin {
 			...options,
 		};
 
+		this.name = 'TILES_COMPRESSION_PLUGIN';
+		this.priority = - 100;
+
 	}
 
 	processTileModel( scene, tile ) {

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -818,7 +818,8 @@ export class TilesRenderer extends TilesRendererBase {
 			const parent = cached.scene.parent;
 
 			// dispose of any textures required by the mesh features extension
-			// TODO: this should be handled some other way.
+			// TODO: these are being discarded here to remove the image bitmaps -
+			// can this be handled in another way? Or more generically?
 			cached.scene.traverse( child => {
 
 				if ( child.userData.meshFeatures ) {

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -818,6 +818,7 @@ export class TilesRenderer extends TilesRendererBase {
 			const parent = cached.scene.parent;
 
 			// dispose of any textures required by the mesh features extension
+			// TODO: this should be handled some other way.
 			cached.scene.traverse( child => {
 
 				if ( child.userData.meshFeatures ) {
@@ -886,7 +887,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 	setTileVisible( tile, visible ) {
 
-		const invoked = this.invokeOnePlugin( plugin => plugin !== this && plugin.setTileVisible && plugin.setTileVisible( tile, visible ) );
 		const scene = tile.cached.scene;
 		const visibleTiles = this.visibleTiles;
 		const group = this.group;
@@ -894,7 +894,7 @@ export class TilesRenderer extends TilesRendererBase {
 		// TODO: move "visibleTiles" to TilesRendererBase
 		if ( visible ) {
 
-			if ( ! invoked ) {
+			if ( scene ) {
 
 				group.add( scene );
 				scene.updateMatrixWorld( true );
@@ -905,7 +905,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 		} else {
 
-			if ( ! invoked ) {
+			if ( scene ) {
 
 				group.remove( scene );
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -886,18 +886,29 @@ export class TilesRenderer extends TilesRendererBase {
 
 	setTileVisible( tile, visible ) {
 
+		const invoked = this.invokeOnePlugin( plugin => plugin !== this && plugin.setTileVisible && plugin.setTileVisible( tile, visible ) );
 		const scene = tile.cached.scene;
 		const visibleTiles = this.visibleTiles;
 		const group = this.group;
 		if ( visible ) {
 
-			group.add( scene );
+			if ( ! invoked ) {
+
+				group.add( scene );
+				scene.updateMatrixWorld( true );
+
+			}
+
 			visibleTiles.add( tile );
-			scene.updateMatrixWorld( true );
 
 		} else {
 
-			group.remove( scene );
+			if ( ! invoked ) {
+
+				group.remove( scene );
+
+			}
+
 			visibleTiles.delete( tile );
 
 		}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -890,6 +890,8 @@ export class TilesRenderer extends TilesRendererBase {
 		const scene = tile.cached.scene;
 		const visibleTiles = this.visibleTiles;
 		const group = this.group;
+
+		// TODO: move "visibleTiles" to TilesRendererBase
 		if ( visible ) {
 
 			if ( ! invoked ) {


### PR DESCRIPTION
Fix #873 
Fix #875 

- Add priority support to plugins
- TilesCompression and BatchedMesh plugin will always run first
- Prevent empty groups from being added for each tile when using BatchedMeshPlugin
- Add "UnloadTilesPlugin"
- Add support for "setTileActive" and "setTileVisible" plugin callbacks
- Add names to some plugins that were missing them

**TODO**
- Add "visibleTiles" and "activeTiles" to base tiles renderer class
- Consider removing "setTileActive" callback
- Expose byte counting function for plugin use

**Upcoming PR**
- Make this work with fade tiles
  - Override the setTileVisible to only fire when the tile fades in and out for the first time
- Add to demos, move to core plugins directory