### PR TITLE
DebugTilesPlugin: optimize performance and make it toggleable

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -71,6 +71,7 @@ const params = {
 	resolutionScale: 1.0,
 
 	up: hashUrl ? '+Z' : '+Y',
+	enableDebug: true,
 	displayBoxBounds: false,
 	displaySphereBounds: false,
 	displayRegionBounds: false,
@@ -271,6 +272,7 @@ function init() {
 	tileOptions.open();
 
 	const debug = gui.addFolder( 'Debug Options' );
+	debug.add( params, 'enableDebug' );
 	debug.add( params, 'displayBoxBounds' );
 	debug.add( params, 'displaySphereBounds' );
 	debug.add( params, 'displayRegionBounds' );
@@ -485,6 +487,7 @@ function animate() {
 
 	// update plugin
 	const plugin = tiles.getPluginByName( 'DEBUG_TILES_PLUGIN' );
+	plugin.enabled = params.enableDebug;
 	plugin.displayBoxBounds = params.displayBoxBounds;
 	plugin.displaySphereBounds = params.displaySphereBounds;
 	plugin.displayRegionBounds = params.displayRegionBounds;

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -134,32 +134,57 @@ function canTraverse( tile, renderer ) {
 
 }
 
-// Helper function for recursively traversing a tile set. If `beforeCb` returns `true` then the
+// Helper function for traversing a tile set. If `beforeCb` returns `true` then the
 // traversal will end early.
-export function traverseSet( tile, beforeCb = null, afterCb = null, parent = null, depth = 0 ) {
+export function traverseSet( tile, beforeCb = null, afterCb = null ) {
 
-	if ( beforeCb && beforeCb( tile, parent, depth ) ) {
+	const stack = [];
+
+	// A stack-based, depth-first traversal, storing
+	// triplets (tile, parent, depth) in the stack array.
+
+	stack.push( tile );
+	stack.push( null );
+	stack.push( 0 );
+
+	while ( stack.length > 0 ) {
+
+		const depth = stack.pop();
+		const parent = stack.pop();
+		const tile = stack.pop();
+
+		if ( beforeCb && beforeCb( tile, parent, depth ) ) {
+
+			if ( afterCb ) {
+
+				afterCb( tile, parent, depth );
+
+			}
+
+			return;
+
+		}
+
+		const children = tile.children;
+
+		// Children might be undefined if the tile has not been preprocessed yet
+		if ( children ) {
+
+			for ( let i = children.length - 1; i >= 0; i -- ) {
+
+				stack.push( children[ i ] );
+				stack.push( tile );
+				stack.push( depth + 1 );
+
+			}
+
+		}
 
 		if ( afterCb ) {
 
 			afterCb( tile, parent, depth );
 
 		}
-
-		return;
-
-	}
-
-	const children = tile.children;
-	for ( let i = 0, l = children.length; i < l; i ++ ) {
-
-		traverseSet( children[ i ], beforeCb, afterCb, tile, depth + 1 );
-
-	}
-
-	if ( afterCb ) {
-
-		afterCb( tile, parent, depth );
 
 	}
 

--- a/src/plugins/three/DebugTilesPlugin.d.ts
+++ b/src/plugins/three/DebugTilesPlugin.d.ts
@@ -14,6 +14,8 @@ export const RANDOM_NODE_COLOR: ColorMode;
 export const CUSTOM_COLOR: ColorMode;
 export class DebugTilesPlugin {
 
+	enabled: boolean;
+
 	displayBoxBounds : boolean;
 	displaySphereBounds : boolean;
 	displayRegionBounds : boolean;

--- a/src/plugins/three/DebugTilesPlugin.js
+++ b/src/plugins/three/DebugTilesPlugin.js
@@ -1,6 +1,7 @@
 import { Box3Helper, Group, MeshStandardMaterial, PointsMaterial, Sphere, Color } from 'three';
 import { SphereHelper } from './objects/SphereHelper.js';
 import { EllipsoidRegionLineHelper } from './objects/EllipsoidRegionHelper.js';
+import { traverseSet } from '../../base/traverseFunctions.js';
 
 const ORIGINAL_MATERIAL = Symbol( 'ORIGINAL_MATERIAL' );
 const HAS_RANDOM_COLOR = Symbol( 'HAS_RANDOM_COLOR' );
@@ -216,15 +217,11 @@ export class DebugTilesPlugin {
 
 		// initialize the extreme values of the hierarchy
 		let maxDepth = - 1;
-		this.tiles.traverse( tile => {
-
-			maxDepth = Math.max( maxDepth, tile.__depth );
-
-		} );
-
 		let maxError = - 1;
-		this.tiles.traverse( tile => {
 
+		traverseSet( this.tiles.root, null, ( tile, parent, depth ) => {
+
+			maxDepth = Math.max( maxDepth, depth );
 			maxError = Math.max( maxError, tile.geometricError );
 
 		} );

--- a/test/traverseFunctions.test.js
+++ b/test/traverseFunctions.test.js
@@ -1,0 +1,101 @@
+import { traverseSet } from '../src/base/traverseFunctions.js';
+
+describe( 'traverseSet', () => {
+
+	function makeTile( name, ...children ) {
+
+		return { name, children };
+
+	}
+
+	it( 'should visit all tiles in depth-first order', () => {
+
+		/**
+		 *             root
+		 *          /   |   \
+		 *         a    b    c
+		 *       / | \      /
+		 *      d  e  f    g
+		 *               / | \
+		 *              h  i  j
+		 */
+
+
+		const h = makeTile( 'h' );
+		const i = makeTile( 'i' );
+		const j = makeTile( 'j' );
+
+		const d = makeTile( 'd' );
+		const e = makeTile( 'e' );
+		const f = makeTile( 'f' );
+
+		const b = makeTile( 'b' );
+		const a = makeTile( 'a', d, e, f );
+
+		const g = makeTile( 'g', h, i, j );
+
+		const c = makeTile( 'c', g );
+
+		const root = makeTile( 'root', a, b, c );
+
+
+		const visited = [];
+
+		traverseSet( root, null, ( tile, parent, depth ) => visited.push( `${tile.name}-${depth}-${parent?.name ?? 'none'}` ) );
+
+		expect( visited ).toHaveLength( 11 );
+		expect( visited ).toEqual( [ 'root-0-none', 'a-1-root', 'd-2-a', 'e-2-a', 'f-2-a', 'b-1-root', 'c-1-root', 'g-2-c', 'h-3-g', 'i-3-g', 'j-3-g' ] );
+
+	} );
+
+	it( 'should exit traversal if beforeCb returns true', () => {
+
+		/**
+		 *             root
+		 *          /   |   \
+		 *         a    b    c
+		 *       / | \      /
+		 *      d  e  f    g
+		 *               / | \
+		 *              h  i  j
+		 */
+
+
+		const h = makeTile( 'h' );
+		const i = makeTile( 'i' );
+		const j = makeTile( 'j' );
+
+		const d = makeTile( 'd' );
+		const e = makeTile( 'e' );
+		const f = makeTile( 'f' );
+
+		const b = makeTile( 'b' );
+		const a = makeTile( 'a', d, e, f );
+
+		const g = makeTile( 'g', h, i, j );
+
+		const c = makeTile( 'c', g );
+
+		const root = makeTile( 'root', a, b, c );
+
+
+		const visited = [];
+
+		const beforeCb = ( tile ) => {
+
+			if ( tile.name === 'c' ) {
+
+				return true;
+
+			}
+
+		};
+
+		traverseSet( root, beforeCb, t => visited.push( t.name ) );
+
+		expect( visited ).toHaveLength( 7 );
+		expect( visited ).toEqual( [ 'root', 'a', 'd', 'e', 'f', 'b', 'c' ] );
+
+	} );
+
+} );


### PR DESCRIPTION
This PR optimizes the `DebugTilesPlugin` by reducing its overhead, an makes it toggleable.

fix #647 

## Tree traversal optimizations

This PR optimizes (some) tree traversals by using a stack-based approach, rather than a recursive approach, that reduces overhead of recursion.

`traverseSet()` is modified from a recursive approach to a stack-based approach. ~`toggleTiles()` now uses this version.~

Note: other functions in `traverseFunctions.js` might also benefit from using this approach, but the migration is not as easy as for `toggleTiles()`, as the recursion logic is entangled with the callback logic.

## Disable/Enable the `DebugTilesPlugin` dynamically

Add the `enabled` property on the plugin. When toggled on, the plugin initializes its state from the current tile hierarchy. When toggled off, the existing helpers are removed, and all event listeners do nothing (except for `'dispose-model'`).