### PR TITLE
style(.eslintrc.json): disable the no-undef rule for typescript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,7 @@
 		"parser": "@typescript-eslint/parser",
 		"plugins": [ "@typescript-eslint" ],
 		"rules": {
+			"no-undef": "off",
 			"no-unused-vars": [ "error", { "args": "none" } ],
 			"indent": [ "error", "tab" ],
 			"no-dupe-class-members": "off",


### PR DESCRIPTION
This rule conflicts with TypeScript's own typechecker in some cases, for example the RequestInit DOM type.

This rule should be [disabled for TypeScript files](https://eslint.org/docs/latest/rules/no-undef#handled_by_typescript):
> It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check.