### PR TITLE
DebugTilesPlugin: add the displayParentBounds option (#730)

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -72,6 +72,7 @@ const params = {
 
 	up: hashUrl ? '+Z' : '+Y',
 	enableDebug: true,
+	displayParentBounds: false,
 	displayBoxBounds: false,
 	displaySphereBounds: false,
 	displayRegionBounds: false,
@@ -273,6 +274,7 @@ function init() {
 
 	const debug = gui.addFolder( 'Debug Options' );
 	debug.add( params, 'enableDebug' );
+	debug.add( params, 'displayParentBounds' );
 	debug.add( params, 'displayBoxBounds' );
 	debug.add( params, 'displaySphereBounds' );
 	debug.add( params, 'displayRegionBounds' );
@@ -489,6 +491,7 @@ function animate() {
 	const plugin = tiles.getPluginByName( 'DEBUG_TILES_PLUGIN' );
 	plugin.enabled = params.enableDebug;
 	plugin.displayBoxBounds = params.displayBoxBounds;
+	plugin.displayParentBounds = params.displayParentBounds;
 	plugin.displaySphereBounds = params.displaySphereBounds;
 	plugin.displayRegionBounds = params.displayRegionBounds;
 	plugin.colorMode = parseFloat( params.colorMode );

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -488,3 +488,28 @@ export function toggleTiles( tile, renderer ) {
 	}
 
 }
+
+/**
+ * Traverses the ancestry of the tile up to the root tile.
+ */
+export function traverseAncestors( tile, callback = null ) {
+
+	let current = tile;
+
+	while ( current ) {
+
+		const depth = current.__depth;
+		const parent = current.parent;
+
+		if ( callback ) {
+
+			callback( current, parent, depth );
+
+		}
+
+		current = parent;
+
+	}
+
+
+}

--- a/src/plugins/three/DebugTilesPlugin.js
+++ b/src/plugins/three/DebugTilesPlugin.js
@@ -698,6 +698,7 @@ export class DebugTilesPlugin {
 			tiles.removeEventListener( 'load-model', this._onLoadModelCB );
 			tiles.removeEventListener( 'dispose-model', this._onDisposeModelCB );
 			tiles.removeEventListener( 'update-after', this._onUpdateAfterCB );
+			tiles.removeEventListener( 'tile-visibility-change', this._onTileVisibilityChangeCB );
 
 			// reset all materials
 			this.colorMode = NONE;

--- a/src/plugins/three/objects/EllipsoidRegionHelper.js
+++ b/src/plugins/three/objects/EllipsoidRegionHelper.js
@@ -45,7 +45,7 @@ function toGroupGeometry( geometry ) {
 
 }
 
-function getRegionGeometry( ellipsoidRegion ) {
+function getRegionGeometry( ellipsoidRegion, { computeNormals = false } = {} ) {
 
 	// retrieve the relevant fields
 	const {
@@ -81,8 +81,12 @@ function getRegionGeometry( ellipsoidRegion ) {
 
 	}
 
-	// compute the vertex normals so we can get the edge normals
-	geometry.computeVertexNormals();
+	if ( computeNormals ) {
+
+		// compute the vertex normals so we can get the edge normals
+		geometry.computeVertexNormals();
+
+	}
 
 	// compute the top and bottom cap normals
 	for ( let i = 0, l = refPosition.count; i < l; i ++ ) {
@@ -159,7 +163,7 @@ export class EllipsoidRegionHelper extends Mesh {
 		this.geometry.dispose();
 
 		// retrieve the relevant fields
-		const geometry = getRegionGeometry( this.ellipsoidRegion );
+		const geometry = getRegionGeometry( this.ellipsoidRegion, { computeNormals: true } );
 		const { lonStart, lonEnd } = this;
 
 		// exclude the side tris if the region wraps around

--- a/test/traverseFunctions.test.js
+++ b/test/traverseFunctions.test.js
@@ -1,4 +1,4 @@
-import { traverseSet } from '../src/base/traverseFunctions.js';
+import { traverseAncestors, traverseSet } from '../src/base/traverseFunctions.js';
 
 describe( 'traverseSet', () => {
 
@@ -95,6 +95,33 @@ describe( 'traverseSet', () => {
 
 		expect( visited ).toHaveLength( 7 );
 		expect( visited ).toEqual( [ 'root', 'a', 'd', 'e', 'f', 'b', 'c' ] );
+
+	} );
+
+} );
+
+describe( 'traverseAncestors', () => {
+
+	function makeTile( name, parent = undefined ) {
+
+		return { name, parent };
+
+	}
+
+	it( 'visit all ancestry chain', () => {
+
+		const root = makeTile( 'root' );
+
+		const lod1 = makeTile( '1', root );
+		const lod2 = makeTile( '2', lod1 );
+		const lod3 = makeTile( '3', lod2 );
+		const lod4 = makeTile( '4', lod3 );
+
+		const visited = [];
+
+		traverseAncestors( lod4, tile => visited.push( tile.name ) );
+
+		expect( visited ).toEqual( [ '4', '3', '2', '1', 'root' ] );
 
 	} );
 


### PR DESCRIPTION
This PR fixes #730.

Adds the `.displayParentBounds` property to display the bounds of tiles between the root tile and the first visible tile.

The helpers for the intermediate bounds use ~a thicker line and~ semi-transparent materials to help distinguishing them from the "leaf" tiles.

![image](https://github.com/user-attachments/assets/f6c27f28-1b9a-4149-a944-5921061d2b23)

~Note: not all GPUs support thick lines (see the [comment in the three.js doc](https://threejs.org/docs/index.html?q=box3help#api/en/materials/LineBasicMaterial.linewidth)), so on some platforms the line will remain 1-pixel thick. The alternative would be to use different materials, but that would increase complexity and maintenance.~

This uses a reference counting mechanism as suggested in #730.
