### PR TITLE
feat(PNTSLoader): support NORMAL and NORMAL_OCT16P semantics (#594)

### DIFF
--- a/src/utilities/decodeOctNormal.js
+++ b/src/utilities/decodeOctNormal.js
@@ -1,0 +1,47 @@
+import { Vector2, MathUtils, Vector3 } from 'three';
+
+const f = new Vector2();
+
+/**
+ * Decode an octahedron-encoded normal (as a pair of 8-bit unsigned numbers) into a Vector3.
+ *
+ * Resources:
+ * - https://stackoverflow.com/a/74745666/2704779
+ * - https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/
+ * @param {number} x The unsigned 8-bit X coordinate on the projected octahedron.
+ * @param {number} y The unsigned 8-bit Y coordinate on the projected octahedron.
+ * @param {Vector3} [target] The target vector.
+ */
+export function decodeOctNormal( x, y, target = new Vector3() ) {
+
+	f.set( x, y ).divideScalar( 256 ).multiplyScalar( 2 ).subScalar( 1 );
+
+	target.set( f.x, f.y, 1 - Math.abs( f.x ) - Math.abs( f.y ) );
+
+	const t = MathUtils.clamp( - target.z, 0, 1 );
+
+	if ( target.x >= 0 ) {
+
+		target.setX( target.x - t );
+
+	} else {
+
+		target.setX( target.x + t );
+
+	}
+
+	if ( target.y >= 0 ) {
+
+		target.setY( target.y - t );
+
+	} else {
+
+		target.setY( target.y + t );
+
+	}
+
+	target.normalize();
+
+	return target;
+
+}

--- a/test/decodeOctNormal.test.js
+++ b/test/decodeOctNormal.test.js
@@ -1,0 +1,39 @@
+import { decodeOctNormal } from '../src/utilities/decodeOctNormal';
+
+const PRECISION = 0.005;
+
+describe( 'decodeOctNormal', () => {
+
+	it.each( [
+		// 4 corners of the projected octahedron
+		[ 0, 0, 0, 0, - 1 ],
+		[ 255, 255, 0, 0, - 1 ],
+		[ 0, 255, 0, 0, - 1 ],
+		[ 255, 0, 0, 0, - 1 ],
+
+		// Center of the projected octahedron
+		[ 127, 127, 0, 0, 1 ],
+
+		// Midpoint of left edge of the projected octahedron
+		[ 0, 127, - 1, 0, 0 ],
+
+		// Midpoint of right edge of the projected octahedron
+		[ 255, 127, 1, 0, 0 ],
+
+		// Midpoint of top edge of the projected octahedron
+		[ 127, 255, 0, 1, 0 ],
+
+		// Midpoint of bottom edge of the projected octahedron
+		[ 127, 0, 0, - 1, 0 ],
+	] )( 'should decode (%s, %s) into [%s, %s, %s]', ( encX, encY, x, y, z ) => {
+
+		const result = decodeOctNormal( encX, encY );
+
+		expect( result.length() ).toBeCloseTo( 1, PRECISION );
+		expect( result.x ).toBeCloseTo( x, PRECISION );
+		expect( result.y ).toBeCloseTo( y, PRECISION );
+		expect( result.z ).toBeCloseTo( z, PRECISION );
+
+	} );
+
+} );


### PR DESCRIPTION
This PR adds support for `NORMAL` and `NORMAL_OCT16P` (octahedron-encoded normals) point semantics to the `PNTSLoader`.

Resources:
- <https://knarkowicz.wordpress.com/2014/04/16/octahedron-normal-vector-encoding/>
- <https://stackoverflow.com/a/74745666/2704779>

fix #594 