### PR TITLE
TilesRenderer: Only mark previously used tiles as unused

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -246,6 +246,13 @@ export class TilesRendererBase {
 
 	}
 
+	markTileUsed( tile ) {
+
+		this.usedSet.add( tile );
+		this.lruCache.add( tile );
+
+	}
+
 	// Public API
 	update() {
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -135,6 +135,7 @@ export class TilesRendererBase {
 		parseQueue.maxJobs = 1;
 		parseQueue.priorityCallback = priorityCallback;
 
+		this.usedSet = new Set();
 		this.lruCache = lruCache;
 		this.downloadQueue = downloadQueue;
 		this.parseQueue = parseQueue;
@@ -248,8 +249,7 @@ export class TilesRendererBase {
 	// Public API
 	update() {
 
-		const stats = this.stats;
-		const lruCache = this.lruCache;
+		const { lruCache, usedSet, stats, root } = this;
 		if ( this.rootLoadingState === UNLOADED ) {
 
 			this.rootLoadingState = LOADING;
@@ -264,19 +264,20 @@ export class TilesRendererBase {
 
 		}
 
-		if ( ! this.root ) {
+		if ( ! root ) {
 
 			return;
 
 		}
-
-		const root = this.root;
 
 		stats.inFrustum = 0;
 		stats.used = 0;
 		stats.active = 0;
 		stats.visible = 0;
 		this.frameCount ++;
+
+		usedSet.forEach( tile => lruCache.markUnused( tile ) );
+		usedSet.clear();
 
 		markUsedTiles( root, this );
 		markUsedSetLeaves( root, this );

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -102,8 +102,7 @@ function markUsed( tile, renderer ) {
 	}
 
 	tile.__used = true;
-	renderer.lruCache.markUsed( tile );
-	renderer.usedSet.add( tile );
+	tile.markTileUsed( tile );
 	renderer.stats.used ++;
 
 	if ( tile.__inFrustum === true ) {

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -103,6 +103,7 @@ function markUsed( tile, renderer ) {
 
 	tile.__used = true;
 	renderer.lruCache.markUsed( tile );
+	renderer.usedSet.add( tile );
 	renderer.stats.used ++;
 
 	if ( tile.__inFrustum === true ) {

--- a/src/plugins/three/UnloadTilesPlugin.js
+++ b/src/plugins/three/UnloadTilesPlugin.js
@@ -98,6 +98,7 @@ export class UnloadTilesPlugin {
 
 				lruCache.add( tile, unloadCallback );
 				lruCache.markUsed( tile );
+				tiles.usedSet.add( tile );
 				deferCallbacks.cancel( tile );
 
 			} else {

--- a/src/plugins/three/UnloadTilesPlugin.js
+++ b/src/plugins/three/UnloadTilesPlugin.js
@@ -97,8 +97,7 @@ export class UnloadTilesPlugin {
 			if ( visible ) {
 
 				lruCache.add( tile, unloadCallback );
-				lruCache.markUsed( tile );
-				tiles.usedSet.add( tile );
+				tiles.markTileUsed( tile );
 				deferCallbacks.cancel( tile );
 
 			} else {

--- a/src/plugins/three/fade/TilesFadePlugin.js
+++ b/src/plugins/three/fade/TilesFadePlugin.js
@@ -126,8 +126,7 @@ function onUpdateAfter() {
 		// prevent faded tiles from being unloaded
 		const scene = tile.cached.scene;
 		const isFadingOut = fadeManager.isFadingOut( tile );
-		lruCache.markUsed( tile );
-		tiles.usedSet.add( tile );
+		tiles.markTileUsed( tile );
 		if ( scene ) {
 
 			fadeMaterialManager.setFade( scene, fadeIn, fadeOut );

--- a/src/plugins/three/fade/TilesFadePlugin.js
+++ b/src/plugins/three/fade/TilesFadePlugin.js
@@ -34,7 +34,7 @@ function onUpdateAfter() {
 	const fadingBefore = this._fadingBefore;
 	const prevCameraTransforms = this._prevCameraTransforms;
 	const { tiles, maximumFadeOutTiles, batchedMesh } = this;
-	const { lruCache, cameras } = tiles;
+	const { cameras } = tiles;
 
 	// reset the active tiles flag
 	tiles.displayActiveTiles = displayActiveTiles;

--- a/src/plugins/three/fade/TilesFadePlugin.js
+++ b/src/plugins/three/fade/TilesFadePlugin.js
@@ -127,6 +127,7 @@ function onUpdateAfter() {
 		const scene = tile.cached.scene;
 		const isFadingOut = fadeManager.isFadingOut( tile );
 		lruCache.markUsed( tile );
+		tiles.usedSet.add( tile );
 		if ( scene ) {
 
 			fadeMaterialManager.setFade( scene, fadeIn, fadeOut );

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -337,7 +337,7 @@ export class TilesRenderer extends TilesRendererBase {
 			.then( () => {
 
 				// cache the gltf tile set rotation matrix
-				const { asset, extensions } = this.rootTileSet;
+				const { asset, extensions = {} } = this.rootTileSet;
 				const upAxis = asset && asset.gltfUpAxis || 'y';
 				switch ( upAxis.toLowerCase() ) {
 

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -49,7 +49,6 @@ class LRUCache {
 		this.itemList = [];
 		this.usedSet = new Set();
 		this.callbacks = new Map();
-		this.markUnusedQueued = false;
 		this.unloadingHandle = - 1;
 		this.cachedBytes = 0;
 		this.bytesMap = new Map();
@@ -77,12 +76,6 @@ class LRUCache {
 	}
 
 	add( item, removeCb ) {
-
-		if ( this.markUnusedQueued ) {
-
-			this.markAllUnused();
-
-		}
 
 		const itemSet = this.itemSet;
 		if ( itemSet.has( item ) ) {
@@ -194,12 +187,6 @@ class LRUCache {
 
 	markUsed( item ) {
 
-		if ( this.markUnusedQueued ) {
-
-			this.markAllUnused();
-
-		}
-
 		const itemSet = this.itemSet;
 		const usedSet = this.usedSet;
 		if ( itemSet.has( item ) && ! usedSet.has( item ) ) {
@@ -220,7 +207,6 @@ class LRUCache {
 	markAllUnused() {
 
 		this.usedSet.clear();
-		this.markUnusedQueued = false;
 		if ( this.unloadingHandle !== - 1 ) {
 
 			cancelAnimationFrame( this.unloadingHandle );
@@ -385,12 +371,6 @@ class LRUCache {
 
 				this.scheduled = false;
 				this.unloadUnusedContent();
-
-				if ( this.autoMarkUnused ) {
-
-					this.markUnusedQueued = true;
-
-				}
 
 			} );
 

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -207,12 +207,6 @@ class LRUCache {
 	markAllUnused() {
 
 		this.usedSet.clear();
-		if ( this.unloadingHandle !== - 1 ) {
-
-			cancelAnimationFrame( this.unloadingHandle );
-			this.unloadingHandle = - 1;
-
-		}
 
 	}
 
@@ -363,6 +357,8 @@ class LRUCache {
 	}
 
 	scheduleUnload() {
+
+		cancelAnimationFrame( this.unloadingHandle );
 
 		if ( ! this.scheduled ) {
 

--- a/src/utilities/LRUCache.js
+++ b/src/utilities/LRUCache.js
@@ -213,12 +213,7 @@ class LRUCache {
 
 	markUnused( item ) {
 
-		const usedSet = this.usedSet;
-		if ( usedSet.has( item ) ) {
-
-			usedSet.delete( item );
-
-		}
+		this.usedSet.delete( item );
 
 	}
 


### PR DESCRIPTION
Fix #684

**TODO**
- Make a single function that will make both tiles as "used" in both places (the lru cache and the previous update tracking) so plugins etc do not have to manage both.