### PR TITLE
feat(TilesRenderer): add the load-model-start event (#906)

### DIFF
--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -12,6 +12,7 @@ export interface TilesRendererEventMap {
 	'tiles-load-start': {};
 	'tiles-load-end': {};
 	'load-content': {};
+	'load-model-start': { tile: Tile };
 	'load-model': { scene: Object3D; tile: Tile };
 	'dispose-model': { scene: Object3D; tile: Tile };
 	'tile-visibility-change': { scene: Object3D; tile: Tile; visible: boolean };

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -573,6 +573,12 @@ export class TilesRenderer extends TilesRendererBase {
 
 	async parseTile( buffer, tile, extension, uri ) {
 
+		// dispatch an event indicating that this model has started loading
+		this.dispatchEvent( {
+			type: 'load-model-start',
+			tile,
+		} );
+
 		const cached = tile.cached;
 		cached._loadIndex ++;
 


### PR DESCRIPTION
This PR adds the load-model-start event that is triggered at the very beginning of parseTile(), and is the symetrical equivalent of load-model.


