### PR TITLE
TilesRenderer: remove loadIndex in favor of abort signal

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -691,45 +691,6 @@ export class TilesRendererBase {
 		tile.__loadAbort = controller;
 		tile.__loadingState = LOADING;
 
-		const errorCallback = e => {
-
-			// if it has been unloaded then the tile has been disposed
-			if ( tile.__loadIndex !== loadIndex ) {
-
-				return;
-
-			}
-
-			if ( e.name !== 'AbortError' ) {
-
-				parseQueue.remove( tile );
-				downloadQueue.remove( tile );
-
-				if ( tile.__loadingState === PARSING ) {
-
-					stats.parsing --;
-
-				} else if ( tile.__loadingState === LOADING ) {
-
-					stats.downloading --;
-
-				}
-
-				stats.failed ++;
-
-				console.error( `TilesRenderer : Failed to load tile at url "${ tile.content.uri }".` );
-				console.error( e );
-				tile.__loadingState = FAILED;
-				lruCache.setLoaded( tile, true );
-
-			} else {
-
-				lruCache.remove( tile );
-
-			}
-
-		};
-
 		// queue the download and parse
 		return downloadQueue.add( tile, downloadTile => {
 
@@ -833,7 +794,44 @@ export class TilesRendererBase {
 				}
 
 			} )
-			.catch( errorCallback );
+			.catch( e => {
+
+				// if it has been unloaded then the tile has been disposed
+				if ( tile.__loadIndex !== loadIndex ) {
+
+					return;
+
+				}
+
+				if ( e.name !== 'AbortError' ) {
+
+					parseQueue.remove( tile );
+					downloadQueue.remove( tile );
+
+					if ( tile.__loadingState === PARSING ) {
+
+						stats.parsing --;
+
+					} else if ( tile.__loadingState === LOADING ) {
+
+						stats.downloading --;
+
+					}
+
+					stats.failed ++;
+
+					console.error( `TilesRenderer : Failed to load tile at url "${ tile.content.uri }".` );
+					console.error( e );
+					tile.__loadingState = FAILED;
+					lruCache.setLoaded( tile, true );
+
+				} else {
+
+					lruCache.remove( tile );
+
+				}
+
+			} );
 
 	}
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -480,7 +480,6 @@ export class TilesRendererBase {
 		tile.__active = false;
 
 		tile.__loadingState = UNLOADED;
-		tile.__loadIndex = 0;
 
 		tile.__loadAbort = null;
 
@@ -666,7 +665,6 @@ export class TilesRendererBase {
 			}
 
 			t.__loadingState = UNLOADED;
-			t.__loadIndex ++;
 
 			parseQueue.remove( t );
 			downloadQueue.remove( t );
@@ -680,10 +678,7 @@ export class TilesRendererBase {
 
 		}
 
-		// Track a new load index so we avoid the condition where this load is stopped and
-		// another begins soon after so we don't parse twice.
-		tile.__loadIndex ++;
-		const loadIndex = tile.__loadIndex;
+		// track an abort controller and pass-through the below conditions if aborted
 		const controller = new AbortController();
 		const signal = controller.signal;
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -749,7 +749,7 @@ export class TilesRendererBase {
 
 					} else {
 
-						return this.invokeOnePlugin( plugin => plugin.parseTile && plugin.parseTile( content, parseTile, extension, uri ) );
+						return this.invokeOnePlugin( plugin => plugin.parseTile && plugin.parseTile( content, parseTile, extension, uri, signal ) );
 
 					}
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -694,7 +694,7 @@ export class TilesRendererBase {
 		// queue the download and parse
 		return downloadQueue.add( tile, downloadTile => {
 
-			if ( downloadTile.__loadIndex !== loadIndex ) {
+			if ( signal.aborted ) {
 
 				return Promise.resolve();
 
@@ -705,7 +705,7 @@ export class TilesRendererBase {
 		} )
 			.then( res => {
 
-				if ( tile.__loadIndex !== loadIndex ) {
+				if ( signal.aborted ) {
 
 					return;
 
@@ -725,7 +725,7 @@ export class TilesRendererBase {
 			.then( content => {
 
 				// if it has been unloaded then the tile has been disposed
-				if ( tile.__loadIndex !== loadIndex ) {
+				if ( signal.aborted ) {
 
 					return;
 
@@ -739,7 +739,7 @@ export class TilesRendererBase {
 				return parseQueue.add( tile, parseTile => {
 
 					// if it has been unloaded then the tile has been disposed
-					if ( parseTile.__loadIndex !== loadIndex ) {
+					if ( signal.aborted ) {
 
 						return Promise.resolve();
 
@@ -764,7 +764,7 @@ export class TilesRendererBase {
 			.then( () => {
 
 				// if it has been unloaded then the tile has been disposed
-				if ( tile.__loadIndex !== loadIndex ) {
+				if ( signal.aborted ) {
 
 					return;
 
@@ -797,7 +797,7 @@ export class TilesRendererBase {
 			.catch( e => {
 
 				// if it has been unloaded then the tile has been disposed
-				if ( tile.__loadIndex !== loadIndex ) {
+				if ( signal.aborted ) {
 
 					return;
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -546,7 +546,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 		tile.cached = {
 
-			_loadIndex: 0,
 			transform,
 			transformInverse,
 
@@ -571,18 +570,15 @@ export class TilesRenderer extends TilesRendererBase {
 
 	}
 
-	async parseTile( buffer, tile, extension, uri ) {
+	async parseTile( buffer, tile, extension, uri, abortSignal ) {
 
 		const cached = tile.cached;
-		cached._loadIndex ++;
-
 		const uriSplits = uri.split( /[\\/]/g );
 		uriSplits.pop();
 		const workingPath = uriSplits.join( '/' );
 		const fetchOptions = this.fetchOptions;
 
 		const manager = this.manager;
-		const loadIndex = cached._loadIndex;
 		let promise = null;
 
 		const cachedTransform = cached.transform;
@@ -697,7 +693,7 @@ export class TilesRenderer extends TilesRendererBase {
 		} );
 
 		// exit early if a new request has already started
-		if ( cached._loadIndex !== loadIndex ) {
+		if ( abortSignal.aborted ) {
 
 			return;
 
@@ -858,8 +854,6 @@ export class TilesRenderer extends TilesRendererBase {
 			cached.metadata = null;
 
 		}
-
-		cached._loadIndex ++;
 
 	}
 


### PR DESCRIPTION
Fix #422 

**TODO**
- Consider removing `__loadAbort` field
- Test