### PR TITLE
Track the number of tiles loading since loading had finished previously

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,14 +392,6 @@ If true then the `raycast` functions of the loaded tile objects are overriden to
 
 If you would like to manage raycasting against tiles yourself this behavior can be disabled if needed by setting `optizeRaycast` to false.
 
-### .preprocessURL
-
-```js
-preprocessURL = null : ( uri : string | URL ) => string | URL;
-```
-
-Function to preprocess the url for each individual tile geometry or child tile set to be loaded. If null then the url is used directly.
-
 ### .lruCache
 
 ```js
@@ -445,6 +437,14 @@ manager : LoadingManager
 ```
 
 The manager used when loading tile geometry.
+
+### .loadProgress
+
+```js
+readOnly loadProgress : Number
+```
+
+Returns the total load progress between `[0, 1]`. Progress is measured since the last set of loading tiles completed.
 
 ### .constructor
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -108,7 +108,7 @@ export class TilesRendererBase {
 		this.fetchOptions = {};
 		this.plugins = [];
 		this.queuedTiles = [];
-		this.cachedSinceReset = new Set();
+		this.cachedSinceLoadComplete = new Set();
 
 		const lruCache = new LRUCache();
 		lruCache.unloadPriorityCallback = lruPriorityCallback;
@@ -126,7 +126,7 @@ export class TilesRendererBase {
 		this.downloadQueue = downloadQueue;
 		this.parseQueue = parseQueue;
 		this.stats = {
-			inCacheSinceReset: 0,
+			inCacheSinceLoad: 0,
 			inCache: 0,
 			parsing: 0,
 			downloading: 0,
@@ -644,10 +644,10 @@ export class TilesRendererBase {
 
 			// Decrement stats
 			stats.inCache --;
-			if ( this.cachedSinceReset.has( tile ) ) {
+			if ( this.cachedSinceLoadComplete.has( tile ) ) {
 
-				this.cachedSinceReset.delete( tile );
-				stats.inCacheSinceReset --;
+				this.cachedSinceLoadComplete.delete( tile );
+				stats.inCacheSinceLoad --;
 
 			}
 
@@ -675,8 +675,8 @@ export class TilesRendererBase {
 
 		}
 
-		this.cachedSinceReset.add( tile );
-		stats.inCacheSinceReset ++;
+		this.cachedSinceLoadComplete.add( tile );
+		stats.inCacheSinceLoad ++;
 		stats.inCache ++;
 		stats.downloading ++;
 		tile.__loadingState = LOADING;
@@ -825,8 +825,8 @@ export class TilesRendererBase {
 
 				if ( stats.parsing === 0 && stats.downloading === 0 ) {
 
-					this.cachedSinceReset.clear();
-					stats.inCacheSinceReset = 0;
+					this.cachedSinceLoadComplete.clear();
+					stats.inCacheSinceLoad = 0;
 
 				}
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -87,15 +87,12 @@ export class TilesRendererBase {
 
 	}
 
-	set loadSiblings( v ) {
+	get loadPercent() {
 
-		console.warn( 'TilesRenderer: "loadSiblings" option has been removed.' );
-
-	}
-
-	set stopAtEmptyTiles( v ) {
-
-		console.warn( 'TilesRenderer: "stopAtEmptyTiles" option has been removed.' );
+		const stats = this.stats;
+		const loading = stats.downloading + stats.parsing;
+		const total = stats.inCacheSinceLoad;
+		return total === 0 ? 1.0 : 1.0 - loading / total;
 
 	}
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -87,7 +87,7 @@ export class TilesRendererBase {
 
 	}
 
-	get loadPercent() {
+	get loadProgress() {
 
 		const stats = this.stats;
 		const loading = stats.downloading + stats.parsing;


### PR DESCRIPTION
Fix #906

**TODO**
- ~Rename `inCacheBeforeReset` - `inCacheSinceLoad`?~
- Consider exposing convenience members / function - `loadProgress` / `loadProgressSinceCompletion`, `getLoadProgress( sinceLoad = true )` 