### PR TITLE
refactor(controls): add missing properties in declaration files

### DIFF
--- a/src/three/controls/EnvironmentControls.d.ts
+++ b/src/three/controls/EnvironmentControls.d.ts
@@ -11,8 +11,22 @@ export class EnvironmentControls extends EventDispatcher<EnvironmentControlsEven
 
 	readonly isEnvironmentControls: true;
 
-	get enabled(): boolean;
-	set enabled( v: boolean );
+	enabled: boolean;
+	cameraRadius: number;
+	rotationSpeed: number;
+	minAltitude: number;
+	maxAltitude: number;
+	minDistance: number;
+	maxDistance: number;
+	minZoom: number;
+	maxZoom: number;
+	zoomSpeed: number;
+	adjustHeight: boolean;
+	enableDamping: boolean;
+	dampingFactor: number;
+	useFallbackPlane: boolean;
+
+	pivotPoint: Vector3;
 
 	constructor(
 		scene?: Object3D,

--- a/src/three/controls/GlobeControls.d.ts
+++ b/src/three/controls/GlobeControls.d.ts
@@ -6,6 +6,9 @@ export class GlobeControls extends EnvironmentControls {
 
 	readonly isGlobeControls: true;
 
+	nearMargin: number;
+	farMargin: number;
+
 	get ellipsoid(): Ellipsoid;
 	get tilesGroup(): Group;
 


### PR DESCRIPTION
@gkjohnson It's not very clear in the .js files which fields are internal and other are meant to be exposed as public APIs, so I'm not 100% sure. I looked into the various examples for fields that were used as a starting point.