### PR TITLE
CameraTransition: Add support for rotation transition

### DIFF
--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -139,6 +139,24 @@ function init() {
 
 		// sync the camera positions and then adjust the camera views
 		transition.syncCameras();
+
+		// If transitioning to ortho view then use a top-down perspective
+		if ( v ) {
+
+			const invMat = tiles.group.matrixWorld.clone().invert();
+			const p = transition.fixedPoint.clone().applyMatrix4( invMat );
+
+			const { lat, lon } = tiles.ellipsoid.getPositionToCartographic( p, {} );
+			const { orthographicCamera } = transition;
+			tiles.ellipsoid.getRotationMatrixFromAzElRoll( lat, lon, 0, 0, 0, orthographicCamera.matrixWorld );
+			orthographicCamera.matrixWorld.premultiply( tiles.group.matrixWorld );
+			orthographicCamera.matrixWorld.decompose( orthographicCamera.position, orthographicCamera.quaternion, orthographicCamera.scale );
+
+			tiles.ellipsoid.getCartographicToPosition( lat, lon, 1000, orthographicCamera.position ).applyMatrix4( tiles.group.matrixWorld );
+			orthographicCamera.updateMatrixWorld();
+
+		}
+
 		controls.adjustCamera( transition.perspectiveCamera );
 		controls.adjustCamera( transition.orthographicCamera );
 

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -32,6 +32,7 @@ let statsContainer, stats;
 const params = {
 
 	orthographic: false,
+	topDownOrtho: false,
 
 	enableCacheDisplay: false,
 	enableRendererStats: false,
@@ -144,7 +145,7 @@ function init() {
 			transition.syncCameras();
 
 			// If transitioning to ortho view then use a top-down perspective
-			if ( v ) {
+			if ( v && params.topDownOrtho ) {
 
 				const invMat = tiles.group.matrixWorld.clone().invert();
 				const p = transition.fixedPoint.clone().applyMatrix4( invMat );
@@ -166,6 +167,8 @@ function init() {
 		transition.toggle();
 
 	} );
+	gui.add( params, 'topDownOrtho' );
+
 
 	const mapsOptions = gui.addFolder( 'Google Photorealistic Tiles' );
 	mapsOptions.add( params, 'useBatchedMesh' ).listen();

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -137,28 +137,33 @@ function init() {
 
 		controls.getPivotPoint( transition.fixedPoint );
 
-		// sync the camera positions and then adjust the camera views
-		transition.syncCameras();
+		// don't update the cameras if they are already being animated
+		if ( ! transition.animating ) {
 
-		// If transitioning to ortho view then use a top-down perspective
-		if ( v ) {
+			// sync the camera positions and then adjust the camera views
+			transition.syncCameras();
 
-			const invMat = tiles.group.matrixWorld.clone().invert();
-			const p = transition.fixedPoint.clone().applyMatrix4( invMat );
+			// If transitioning to ortho view then use a top-down perspective
+			if ( v ) {
 
-			const { lat, lon } = tiles.ellipsoid.getPositionToCartographic( p, {} );
-			const { orthographicCamera } = transition;
-			tiles.ellipsoid.getRotationMatrixFromAzElRoll( lat, lon, 0, 0, 0, orthographicCamera.matrixWorld );
-			orthographicCamera.matrixWorld.premultiply( tiles.group.matrixWorld );
-			orthographicCamera.matrixWorld.decompose( orthographicCamera.position, orthographicCamera.quaternion, orthographicCamera.scale );
+				const invMat = tiles.group.matrixWorld.clone().invert();
+				const p = transition.fixedPoint.clone().applyMatrix4( invMat );
 
-			tiles.ellipsoid.getCartographicToPosition( lat, lon, 1000, orthographicCamera.position ).applyMatrix4( tiles.group.matrixWorld );
-			orthographicCamera.updateMatrixWorld();
+				const { lat, lon } = tiles.ellipsoid.getPositionToCartographic( p, {} );
+				const { orthographicCamera } = transition;
+				tiles.ellipsoid.getRotationMatrixFromAzElRoll( lat, lon, 0, 0, 0, orthographicCamera.matrixWorld );
+				orthographicCamera.matrixWorld.premultiply( tiles.group.matrixWorld );
+				orthographicCamera.matrixWorld.decompose( orthographicCamera.position, orthographicCamera.quaternion, orthographicCamera.scale );
+
+				tiles.ellipsoid.getCartographicToPosition( lat, lon, 1000, orthographicCamera.position ).applyMatrix4( tiles.group.matrixWorld );
+				orthographicCamera.updateMatrixWorld();
+
+			}
+
+			controls.adjustCamera( transition.perspectiveCamera );
+			controls.adjustCamera( transition.orthographicCamera );
 
 		}
-
-		controls.adjustCamera( transition.perspectiveCamera );
-		controls.adjustCamera( transition.orthographicCamera );
 
 		transition.toggle();
 

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -151,11 +151,9 @@ function init() {
 
 				const { lat, lon } = tiles.ellipsoid.getPositionToCartographic( p, {} );
 				const { orthographicCamera } = transition;
-				tiles.ellipsoid.getRotationMatrixFromAzElRoll( lat, lon, 0, 0, 0, orthographicCamera.matrixWorld );
+				tiles.ellipsoid.getFrame( lat, lon, 0, 0, 0, 1000, orthographicCamera.matrixWorld );
 				orthographicCamera.matrixWorld.premultiply( tiles.group.matrixWorld );
 				orthographicCamera.matrixWorld.decompose( orthographicCamera.position, orthographicCamera.quaternion, orthographicCamera.scale );
-
-				tiles.ellipsoid.getCartographicToPosition( lat, lon, 1000, orthographicCamera.position ).applyMatrix4( tiles.group.matrixWorld );
 				orthographicCamera.updateMatrixWorld();
 
 			}

--- a/src/three/controls/CameraTransitionManager.js
+++ b/src/three/controls/CameraTransitionManager.js
@@ -3,7 +3,6 @@ import { Clock, EventDispatcher, MathUtils, Matrix4, OrthographicCamera, Perspec
 const _forward = new Vector3();
 const _vec = new Vector3();
 const _orthographicCamera = new OrthographicCamera();
-const _targetPos = new Vector3();
 const _targetOffset = new Vector3();
 const _perspOffset = new Vector3();
 const _orthoOffset = new Vector3();
@@ -289,11 +288,7 @@ export class CameraTransitionManager extends EventDispatcher {
 		// calculate the target distance and fov to position the camera at
 		const targetFov = MathUtils.lerp( perspectiveCamera.fov, 1, alpha );
 		const targetDistance = projectionHeight * 0.5 / Math.tan( MathUtils.DEG2RAD * targetFov * 0.5 );
-		const targetPos = _targetPos.lerpVectors( perspectiveCamera.position, _orthographicCamera.position, alpha );
 		
-		// shift the camera back by the appropriate amount to emulate the camera pullback effect
-		targetPos.addScaledVector( _forward, Math.abs( _vec.subVectors( targetPos, fixedPoint ).dot( _forward ) ) - targetDistance );
-
 		// calculate the offset from the fixed point
 		const orthoOffset = _orthoOffset.copy( _orthographicCamera.position ).sub( fixedPoint ).applyQuaternion( _quat.copy( _orthographicCamera.quaternion ).invert() );
 		const perspOffset = _perspOffset.copy( perspectiveCamera.position ).sub( fixedPoint ).applyQuaternion( _quat.copy( perspectiveCamera.quaternion ).invert() );

--- a/src/three/controls/CameraTransitionManager.js
+++ b/src/three/controls/CameraTransitionManager.js
@@ -83,6 +83,8 @@ export class CameraTransitionManager extends EventDispatcher {
 		this._target = this._target === 1 ? 0 : 1;
 		this._clock.getDelta();
 
+		this.dispatchEvent( { type: 'toggle' } );
+
 	}
 
 	update() {
@@ -296,13 +298,9 @@ export class CameraTransitionManager extends EventDispatcher {
 		const perspOffset = _perspOffset.copy( perspectiveCamera.position ).sub( fixedPoint ).applyQuaternion( perspectiveCamera.quaternion.clone().invert() );
 		const targetOffset = _targetOffset.lerpVectors( perspOffset, orthoOffset, alpha );
 		targetOffset.z -= Math.abs( targetOffset.z ) - targetDistance;
-		targetOffset.applyQuaternion( perspectiveCamera.quaternion );
+		targetOffset.applyQuaternion( targetQuat );
 
-		// TODO: rotate the offset vector correctly
-
-
-
-
+		// TODO: fix this to not use "targetPos"
 		// calculate the near and far plane positions
 		const distToPersp = _vec.subVectors( perspectiveCamera.position, targetPos ).dot( _forward );
 		const distToOrtho = _vec.subVectors( _orthographicCamera.position, targetPos ).dot( _forward );

--- a/src/three/controls/CameraTransitionManager.js
+++ b/src/three/controls/CameraTransitionManager.js
@@ -1,4 +1,4 @@
-import { Clock, EventDispatcher, MathUtils, Matrix4, OrthographicCamera, PerspectiveCamera, Quaternion, Vector3 } from 'three';
+import { Clock, EventDispatcher, MathUtils, OrthographicCamera, PerspectiveCamera, Quaternion, Vector3 } from 'three';
 
 const _forward = new Vector3();
 const _vec = new Vector3();
@@ -288,7 +288,7 @@ export class CameraTransitionManager extends EventDispatcher {
 		// calculate the target distance and fov to position the camera at
 		const targetFov = MathUtils.lerp( perspectiveCamera.fov, 1, alpha );
 		const targetDistance = projectionHeight * 0.5 / Math.tan( MathUtils.DEG2RAD * targetFov * 0.5 );
-		
+
 		// calculate the offset from the fixed point
 		const orthoOffset = _orthoOffset.copy( _orthographicCamera.position ).sub( fixedPoint ).applyQuaternion( _quat.copy( _orthographicCamera.quaternion ).invert() );
 		const perspOffset = _perspOffset.copy( perspectiveCamera.position ).sub( fixedPoint ).applyQuaternion( _quat.copy( perspectiveCamera.quaternion ).invert() );

--- a/src/three/math/Ellipsoid.d.ts
+++ b/src/three/math/Ellipsoid.d.ts
@@ -26,6 +26,11 @@ export class Ellipsoid {
 		target: Matrix4, frame: Frames,
 	): Matrix4;
 
+	getFrame(
+		lat: number, lon: number, az: number, el: number, roll: number, height: number,
+		target: Matrix4, frame: Frames,
+	): Matrix4;
+
 	getEastNorthUpFrame( lat: number, lon: number, target: Matrix4 ): Matrix4;
 	getEastNorthUpAxes( lat: number, lon: number, vecEast: Vector3, vecNorth: Vector3, vecUp: Vector3, point?: Vector3 );
 

--- a/src/three/math/Ellipsoid.js
+++ b/src/three/math/Ellipsoid.js
@@ -137,6 +137,15 @@ export class Ellipsoid {
 
 	}
 
+	getFrame( lat, lon, az, el, roll, height, target, frame = ENU_FRAME ) {
+
+		this.getRotationMatrixFromAzElRoll( lat, lon, az, el, roll, target, frame );
+		this.getCartographicToPosition( lat, lon, height, _pos );
+		target.setPosition( _pos );
+		return target;
+
+	}
+
 	getCartographicToPosition( lat, lon, height, target ) {
 
 		// From Cesium function Ellipsoid.cartographicToCartesian


### PR DESCRIPTION
Fix #831

**TODO**
- ~Remove the need for a separate "targetPos" variable~
- ~Make it simpler to extract the ortho position with height~
- Add option for example to transition to predetermined viewpoint
  - shift perspective camera down slightly
  - consider just rotating the ortho camera orientation so it's facing the same direction
- ~Test and fix mid-transition toggle logic (right now it jumps)~
- Add option for the transition camera transform can be applied when interrupting the transition