### PR TITLE
Plugins: Add support for Deep Zoom Image format

### DIFF
--- a/example/deepZoom.html
+++ b/example/deepZoom.html
@@ -4,7 +4,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 		<meta charset="utf-8"/>
 
-		<title>Dither Fade Tiles</title>
+		<title>Deep Zoom Images</title>
 
 		<style>
 			* {
@@ -35,7 +35,7 @@
 			}
 
 			#info, #info a {
-				color: #234;
+				color: #ccc;
 			}
 
 			#info a {
@@ -45,7 +45,7 @@
     </head>
     <body>
 		<div id="info">
-			Demonstration of tiles using a dither fade to change, smoothing out the transition.
+			Demonstration of rendering <a href="https://learn.microsoft.com/en-us/previous-versions/windows/silverlight/dotnet-windows-silverlight/cc645077(v=vs.95)">Deep Zoom Images</a> for high resolution data.
 		</div>
         <script src="./deepZoom.js" type="module"></script>
     </body>

--- a/example/deepZoom.html
+++ b/example/deepZoom.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+		<meta charset="utf-8"/>
+
+		<title>Dither Fade Tiles</title>
+
+		<style>
+			* {
+				margin: 0;
+				padding: 0;
+			}
+
+			html {
+				overflow: hidden;
+				font-family: Arial, Helvetica, sans-serif;
+				user-select: none;
+			}
+
+			canvas {
+				image-rendering: pixelated;
+				outline: none;
+			}
+
+			#info {
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				text-align: center;
+				padding: 5px;
+				pointer-events: none;
+				line-height: 1.5em;
+			}
+
+			#info, #info a {
+				color: #234;
+			}
+
+			#info a {
+				pointer-events: all;
+			}
+        </style>
+    </head>
+    <body>
+		<div id="info">
+			Demonstration of tiles using a dither fade to change, smoothing out the transition.
+		</div>
+        <script src="./deepZoom.js" type="module"></script>
+    </body>
+</html>

--- a/example/deepZoom.html
+++ b/example/deepZoom.html
@@ -46,6 +46,8 @@
     <body>
 		<div id="info">
 			Demonstration of rendering <a href="https://learn.microsoft.com/en-us/previous-versions/windows/silverlight/dotnet-windows-silverlight/cc645077(v=vs.95)">Deep Zoom Images</a> for high resolution data.
+			<br/>
+			Example courtesy of <a href="https://openseadragon.github.io/">OpenSeadragon Project</a>.
 		</div>
         <script src="./deepZoom.js" type="module"></script>
     </body>

--- a/example/deepZoom.js
+++ b/example/deepZoom.js
@@ -3,24 +3,21 @@ import {
 	WebGLRenderer,
 	PerspectiveCamera,
 	OrthographicCamera,
-	Group,
 } from 'three';
-import { TileCompressionPlugin, DebugTilesPlugin } from '3d-tiles-renderer/plugins';
 import { EnvironmentControls, TilesRenderer, CameraTransitionManager } from '3d-tiles-renderer';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import { DeepZoomImagesPlugin } from '../src/plugins/three/DeepZoomImagesPlugin';
+import { TilesFadePlugin } from '../src/plugins';
 
 let controls, scene, renderer;
-let tiles, tilesParent, transition;
+let tiles, transition;
 
 const params = {
 
-	reinstantiateTiles,
-	errorTarget: 12,
+	errorTarget: 1,
 	renderScale: 1,
 
 	orthographic: false,
-	transitionDuration: 0.25,
 
 };
 
@@ -33,7 +30,7 @@ function init() {
 	renderer = new WebGLRenderer( { antialias: true } );
 	renderer.setPixelRatio( window.devicePixelRatio );
 	renderer.setSize( window.innerWidth, window.innerHeight );
-	renderer.setClearColor( 0xd8cec0 );
+	renderer.setClearColor( 0x111111 );
 
 	document.body.appendChild( renderer.domElement );
 
@@ -42,26 +39,39 @@ function init() {
 
 	// set up cameras and ortho / perspective transition
 	transition = new CameraTransitionManager(
-		new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.25, 4000 ),
+		new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.001, 10000 ),
 		new OrthographicCamera( - 1, 1, 1, - 1, 0, 4000 ),
 	);
-	transition.camera.position.set( 2, 4, 2 );
+	transition.camera.position.set( 0, 0, 150 );
 	transition.camera.lookAt( 0, 0, 0 );
 	transition.autoSync = false;
+	transition.addEventListener( 'camera-change', ( { camera, prevCamera } ) => {
+
+		tiles.deleteCamera( prevCamera );
+		tiles.setCamera( camera );
+		controls.setCamera( camera );
+
+	} );
+
+	// tiles
+	tiles = new TilesRenderer( 'https://openseadragon.github.io/example-images/duomo/duomo.dzi' );
+	tiles.registerPlugin( new DeepZoomImagesPlugin( { center: true } ) );
+	tiles.fetchOptions.mode = 'cors';
+	tiles.lruCache.minSize = 900;
+	tiles.lruCache.maxSize = 1300;
+	tiles.errorTarget = 1;
+	tiles.setCamera( transition.camera );
+	scene.add( tiles.group );
 
 	// controls
 	controls = new EnvironmentControls( scene, transition.camera, renderer.domElement );
 	controls.minZoomDistance = 2;
-	controls.minDistance = 0;
+	controls.minDistance = 0.01;
+	controls.maxDistance = 1000;
 	controls.cameraRadius = 0;
-
-	// tiles parent group
-	tilesParent = new Group();
-	tilesParent.rotation.set( - Math.PI / 2, 0, 0 );
-	scene.add( tilesParent );
-
-	// init tiles
-	reinstantiateTiles();
+	controls.enableDamping = true;
+	controls.fallbackPlane.normal.set( 0, 0, 1 );
+	controls.up.set( 0, 0, 1 );
 
 	// events
 	onWindowResize();
@@ -69,8 +79,7 @@ function init() {
 
 	// gui initialization
 	const gui = new GUI();
-	const cameraFolder = gui.addFolder( 'camera' );
-	cameraFolder.add( params, 'orthographic' ).onChange( v => {
+	gui.add( params, 'orthographic' ).onChange( v => {
 
 		transition.fixedPoint.copy( controls.pivotPoint );
 
@@ -81,38 +90,11 @@ function init() {
 		transition.toggle();
 
 	} );
-	cameraFolder.add( params, 'transitionDuration', 0, 1.5 );
 
-	const fadeFolder = gui.addFolder( 'fade' );
-	fadeFolder.add( params, 'errorTarget', 0, 1000 );
-	fadeFolder.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
+	gui.add( params, 'errorTarget', 0, 100 );
+	gui.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
 
 	gui.open();
-
-}
-
-function reinstantiateTiles() {
-
-	if ( tiles ) {
-
-		tiles.dispose();
-		tiles.group.removeFromParent();
-
-	}
-
-	// tiles = new TilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize_tileset.json' );
-	tiles = new TilesRenderer( 'https://openseadragon.github.io/example-images/highsmith/highsmith.dzi' );
-	tiles.registerPlugin( new DeepZoomImagesPlugin() );
-	tiles.registerPlugin( new TileCompressionPlugin() );
-	tiles.registerPlugin( new DebugTilesPlugin( { displayBoxBounds: true } ) );
-	tiles.fetchOptions.mode = 'cors';
-	tiles.lruCache.minSize = 900;
-	tiles.lruCache.maxSize = 1300;
-	tiles.errorTarget = 12;
-	tiles.setCamera( transition.camera );
-	tilesParent.add( tiles.group );
-
-	window.TILES = tiles;
 
 }
 
@@ -140,8 +122,6 @@ function render() {
 
 	controls.enabled = ! transition.animating;
 	controls.update();
-
-	transition.duration = 1000 * params.transitionDuration;
 	transition.update();
 
 	const camera = transition.camera;

--- a/example/deepZoom.js
+++ b/example/deepZoom.js
@@ -5,9 +5,8 @@ import {
 	OrthographicCamera,
 } from 'three';
 import { EnvironmentControls, TilesRenderer, CameraTransitionManager } from '3d-tiles-renderer';
+import { DeepZoomImagePlugin } from '3d-tiles-renderer/plugins';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { DeepZoomImagesPlugin } from '../src/plugins/three/DeepZoomImagesPlugin';
-import { TilesFadePlugin } from '../src/plugins';
 
 let controls, scene, renderer;
 let tiles, transition;
@@ -55,7 +54,7 @@ function init() {
 
 	// tiles
 	tiles = new TilesRenderer( 'https://openseadragon.github.io/example-images/duomo/duomo.dzi' );
-	tiles.registerPlugin( new DeepZoomImagesPlugin( { center: true } ) );
+	tiles.registerPlugin( new DeepZoomImagePlugin( { center: true } ) );
 	tiles.fetchOptions.mode = 'cors';
 	tiles.lruCache.minSize = 900;
 	tiles.lruCache.maxSize = 1300;

--- a/example/deepZoom.js
+++ b/example/deepZoom.js
@@ -1,0 +1,154 @@
+import {
+	Scene,
+	WebGLRenderer,
+	PerspectiveCamera,
+	OrthographicCamera,
+	Group,
+} from 'three';
+import { TilesFadePlugin } from '3d-tiles-renderer/plugins';
+import { EnvironmentControls, TilesRenderer, CameraTransitionManager } from '3d-tiles-renderer';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import { DeepZoomImagesPlugin } from '../src/plugins/three/DeepZoomImagesPlugin';
+
+let controls, scene, renderer;
+let tiles, tilesParent, transition;
+
+const params = {
+
+	reinstantiateTiles,
+	errorTarget: 12,
+	renderScale: 1,
+
+	orthographic: false,
+	transitionDuration: 0.25,
+
+};
+
+init();
+render();
+
+function init() {
+
+	// renderer
+	renderer = new WebGLRenderer( { antialias: true } );
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.setClearColor( 0xd8cec0 );
+
+	document.body.appendChild( renderer.domElement );
+
+	// scene
+	scene = new Scene();
+
+	// set up cameras and ortho / perspective transition
+	transition = new CameraTransitionManager(
+		new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.25, 4000 ),
+		new OrthographicCamera( - 1, 1, 1, - 1, 0, 4000 ),
+	);
+	transition.camera.position.set( 20, 10, 20 );
+	transition.camera.lookAt( 0, 0, 0 );
+	transition.autoSync = false;
+
+	// controls
+	controls = new EnvironmentControls( scene, transition.camera, renderer.domElement );
+	controls.minZoomDistance = 2;
+	controls.cameraRadius = 1;
+
+	// tiles parent group
+	tilesParent = new Group();
+	tilesParent.rotation.set( Math.PI / 2, 0, 0 );
+	scene.add( tilesParent );
+
+	// init tiles
+	reinstantiateTiles();
+
+	// events
+	onWindowResize();
+	window.addEventListener( 'resize', onWindowResize, false );
+
+	// gui initialization
+	const gui = new GUI();
+	const cameraFolder = gui.addFolder( 'camera' );
+	cameraFolder.add( params, 'orthographic' ).onChange( v => {
+
+		transition.fixedPoint.copy( controls.pivotPoint );
+
+		// adjust the camera before the transition begins
+		transition.syncCameras();
+		controls.adjustCamera( transition.perspectiveCamera );
+		controls.adjustCamera( transition.orthographicCamera );
+		transition.toggle();
+
+	} );
+	cameraFolder.add( params, 'transitionDuration', 0, 1.5 );
+
+	const fadeFolder = gui.addFolder( 'fade' );
+	fadeFolder.add( params, 'errorTarget', 0, 1000 );
+	fadeFolder.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
+
+	gui.open();
+
+}
+
+function reinstantiateTiles() {
+
+	if ( tiles ) {
+
+		tiles.dispose();
+		tiles.group.removeFromParent();
+
+	}
+
+	// tiles = new TilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize_tileset.json' );
+	tiles = new TilesRenderer( 'https://openseadragon.github.io/example-images/highsmith/highsmith.dzi' );
+	tiles.registerPlugin( new DeepZoomImagesPlugin() );
+	tiles.fetchOptions.mode = 'cors';
+	tiles.lruCache.minSize = 900;
+	tiles.lruCache.maxSize = 1300;
+	tiles.errorTarget = 12;
+	tiles.setCamera( transition.camera );
+	tilesParent.add( tiles.group );
+
+	window.TILES = tiles;
+
+}
+
+function onWindowResize() {
+
+	const { perspectiveCamera, orthographicCamera } = transition;
+	const aspect = window.innerWidth / window.innerHeight;
+
+	orthographicCamera.bottom = - 40;
+	orthographicCamera.top = 40;
+	orthographicCamera.left = - 40 * aspect;
+	orthographicCamera.right = 40 * aspect;
+	orthographicCamera.updateProjectionMatrix();
+
+	perspectiveCamera.aspect = aspect;
+	perspectiveCamera.updateProjectionMatrix();
+
+	renderer.setSize( window.innerWidth, window.innerHeight );
+
+}
+
+function render() {
+
+	requestAnimationFrame( render );
+
+	controls.enabled = ! transition.animating;
+	controls.update();
+
+	transition.duration = 1000 * params.transitionDuration;
+	transition.update();
+
+	const camera = transition.camera;
+	camera.updateMatrixWorld();
+
+	tiles.errorTarget = params.errorTarget;
+	tiles.setCamera( camera );
+	tiles.setResolutionFromRenderer( camera, renderer );
+	tiles.update();
+
+	renderer.render( scene, camera );
+
+}

--- a/example/deepZoom.js
+++ b/example/deepZoom.js
@@ -5,7 +5,7 @@ import {
 	OrthographicCamera,
 	Group,
 } from 'three';
-import { TilesFadePlugin } from '3d-tiles-renderer/plugins';
+import { TileCompressionPlugin, DebugTilesPlugin } from '3d-tiles-renderer/plugins';
 import { EnvironmentControls, TilesRenderer, CameraTransitionManager } from '3d-tiles-renderer';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import { DeepZoomImagesPlugin } from '../src/plugins/three/DeepZoomImagesPlugin';
@@ -45,18 +45,19 @@ function init() {
 		new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.25, 4000 ),
 		new OrthographicCamera( - 1, 1, 1, - 1, 0, 4000 ),
 	);
-	transition.camera.position.set( 20, 10, 20 );
+	transition.camera.position.set( 2, 4, 2 );
 	transition.camera.lookAt( 0, 0, 0 );
 	transition.autoSync = false;
 
 	// controls
 	controls = new EnvironmentControls( scene, transition.camera, renderer.domElement );
 	controls.minZoomDistance = 2;
-	controls.cameraRadius = 1;
+	controls.minDistance = 0;
+	controls.cameraRadius = 0;
 
 	// tiles parent group
 	tilesParent = new Group();
-	tilesParent.rotation.set( Math.PI / 2, 0, 0 );
+	tilesParent.rotation.set( - Math.PI / 2, 0, 0 );
 	scene.add( tilesParent );
 
 	// init tiles
@@ -102,6 +103,8 @@ function reinstantiateTiles() {
 	// tiles = new TilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize_tileset.json' );
 	tiles = new TilesRenderer( 'https://openseadragon.github.io/example-images/highsmith/highsmith.dzi' );
 	tiles.registerPlugin( new DeepZoomImagesPlugin() );
+	tiles.registerPlugin( new TileCompressionPlugin() );
+	tiles.registerPlugin( new DebugTilesPlugin( { displayBoxBounds: true } ) );
 	tiles.fetchOptions.mode = 'cors';
 	tiles.lruCache.minSize = 900;
 	tiles.lruCache.maxSize = 1300;

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -259,7 +259,7 @@ export class TilesRendererBase {
 			this.invokeAllPlugins( plugin => processedUrl = plugin.preprocessURL ? plugin.preprocessURL( processedUrl, null ) : processedUrl );
 
 			this.rootLoadingState = LOADING;
-			this.invokeOnePlugin( plugin => plugin.loadRootTileSet && plugin.loadRootTileSet() )
+			this.invokeOnePlugin( plugin => plugin.loadRootTileSet && plugin.loadRootTileSet( processedUrl ) )
 				.then( root => {
 
 					this.rootLoadingState = LOADED;

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -406,7 +406,7 @@ export class TilesRendererBase {
 
 	}
 
-	parseTile( buffer, tile, extension ) {
+	parseTile( buffer, tile, extension, abortSignal ) {
 
 		return null;
 

--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -406,7 +406,7 @@ export class TilesRendererBase {
 
 	}
 
-	parseTile( buffer, tile, extension, abortSignal ) {
+	parseTile( buffer, tile, extension, uri, abortSignal ) {
 
 		return null;
 

--- a/src/plugins/README.md
+++ b/src/plugins/README.md
@@ -626,3 +626,26 @@ Available options are as follows:
 	discardOriginalContent: true
 }
 ```
+
+## DeepZoomImagePlugin
+
+Plugin to add support for the [DeepZoomImage format](https://learn.microsoft.com/en-us/previous-versions/windows/silverlight/dotnet-windows-silverlight/cc645077(v=vs.95)?redirectedfrom=MSDN). Only a single embedded "Image" is supported. The DeepZoomImage xml file should be passed in as the TilesRenderer url.
+
+### .constructor
+
+```js
+constructor( options : Object )
+```
+
+Available options are as follows:
+
+```js
+{
+	// Whether to shift the DZI tiles so the image is centered at the origin rather than
+	// at the top left corner
+	center: false,
+
+	// The scale of a pixel in the image
+	pixelSize: 0.01,
+}
+```

--- a/src/plugins/index.d.ts
+++ b/src/plugins/index.d.ts
@@ -10,6 +10,9 @@ export { TilesFadePlugin } from './three/fade/TilesFadePlugin';
 export { BatchedTilesPlugin } from './three/batched/BatchedTilesPlugin';
 export * from './three/DebugTilesPlugin';
 
+// other formats
+export { DeepZoomImagePlugin } from './three/DeepZoomImagePlugin';
+
 // common plugins
 export { ImplicitTilingPlugin } from './base/ImplicitTilingPlugin';
 

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -10,6 +10,9 @@ export { TilesFadePlugin } from './three/fade/TilesFadePlugin.js';
 export { BatchedTilesPlugin } from './three/batched/BatchedTilesPlugin.js';
 export * from './three/DebugTilesPlugin.js';
 
+// other formats
+export { DeepZoomImagePlugin } from './three/DeepZoomImagePlugin.js';
+
 // common plugins
 export { ImplicitTilingPlugin } from './base/ImplicitTilingPlugin.js';
 

--- a/src/plugins/three/CesiumIonAuthPlugin.js
+++ b/src/plugins/three/CesiumIonAuthPlugin.js
@@ -34,12 +34,12 @@ export class CesiumIonAuthPlugin {
 
 	}
 
-	loadRootTileSet() {
+	loadRootTileSet( ...args ) {
 
 		// ensure we have an up-to-date token and root url, then trigger the internal
 		// root tile set load function
 		return this._refreshToken()
-			.then( () => this.tiles.loadRootTileSet() );
+			.then( () => this.tiles.loadRootTileSet( ...args ) );
 
 	}
 

--- a/src/plugins/three/DeepZoomImagePlugin.d.ts
+++ b/src/plugins/three/DeepZoomImagePlugin.d.ts
@@ -1,0 +1,8 @@
+export class DeepZoomImagePlugin {
+
+	constructor( options: {
+		center?: boolean,
+		pixelSize?: number,
+	} );
+
+}

--- a/src/plugins/three/DeepZoomImagePlugin.js
+++ b/src/plugins/three/DeepZoomImagePlugin.js
@@ -1,6 +1,6 @@
 import { Mesh, MeshBasicMaterial, PlaneGeometry, SRGBColorSpace, Texture } from 'three';
 
-export class DeepZoomImagesPlugin {
+export class DeepZoomImagePlugin {
 
 	constructor( options = {} ) {
 

--- a/src/plugins/three/DeepZoomImagesPlugin.js
+++ b/src/plugins/three/DeepZoomImagesPlugin.js
@@ -24,13 +24,11 @@ export class DeepZoomImagesPlugin {
 
 	}
 
-	parseToMesh( buffer, tile, extension, uri, abortSignal ) {
-
-		// TODO: need a function to insert before loaders via parseGeometry _or_ consider adding via loading manager?
+	async parseToMesh( buffer, tile, extension, uri, abortSignal ) {
 
 		// Construct texture
 		const blob = new Blob( [ buffer ] );
-		const imageBitmap = createImageBitmap( blob, {
+		const imageBitmap = await createImageBitmap( blob, {
 			premultiplyAlpha: 'none',
 			colorSpaceConversion: 'none',
 		} );
@@ -43,11 +41,10 @@ export class DeepZoomImagesPlugin {
 			x, y, z,	// center
 			sx,,,		// x vector
 			, sy,,		// y vector
-			,, sz,		// z vector
 		] = tile.boundingVolume.box;
 
 		mesh.position.set( x, y, z );
-		mesh.scale.set( 2 * sx, 2 * sy, 2 * sz );
+		mesh.scale.set( 2 * sx, 2 * sy, 1 );
 
 		return mesh;
 
@@ -85,7 +82,8 @@ export class DeepZoomImagesPlugin {
 				const offsetX = centered ? width / 2 : 0;
 				const offsetY = centered ? height / 2 : 0;
 
-				const [ stem ] = url.split( /\..+$/g );
+				const [ stem ] = url.split( /\.[^.]+$/g );
+
 				const tileset = {
 					asset: {
 						version: '1.1'
@@ -97,6 +95,9 @@ export class DeepZoomImagesPlugin {
 				return tileset;
 
 				function expand( level, x, y ) {
+
+					// TODO: we need to scale the these tiles based on the level so the scale of the image
+					// is overall the same
 
 					const levelWidth = Math.ceil( Math.pow( width, - ( levels - level ) ) );
 					const levelHeight = Math.ceil( Math.pow( height, - ( levels - level ) ) );
@@ -154,7 +155,7 @@ export class DeepZoomImagesPlugin {
 						geometricError: Math.max( width / levelWidth, height / levelHeight ) - 1,
 						refine: 'REPLACE',
 						content: {
-							uri: `${ stem }/${ level }/${ x }_${ y }.${ format }`,
+							uri: `${ stem }_files/${ level }/${ x }_${ y }.${ format }`,
 						},
 						children: [],
 					};

--- a/src/plugins/three/DeepZoomImagesPlugin.js
+++ b/src/plugins/three/DeepZoomImagesPlugin.js
@@ -99,8 +99,8 @@ export class DeepZoomImagesPlugin {
 					// TODO: we need to scale the these tiles based on the level so the scale of the image
 					// is overall the same
 
-					const levelWidth = Math.ceil( Math.pow( width, - ( levels - level ) ) );
-					const levelHeight = Math.ceil( Math.pow( height, - ( levels - level ) ) );
+					const levelWidth = Math.ceil( width * Math.pow( 2, - ( levels - level ) ) );
+					const levelHeight = Math.ceil( height * Math.pow( 2, - ( levels - level ) ) );
 
 					let tileX = tileSize * x - overlap;
 					let tileY = tileSize * y - overlap;
@@ -142,17 +142,25 @@ export class DeepZoomImagesPlugin {
 
 					}
 
+					const centerX = tileX - offsetX + tileWidth / 2;
+					const centerY = tileY - offsetY + tileHeight / 2;
+
+					const ratioX = width / levelWidth;
+					const ratioY = height / levelHeight;
+
+					// TODO: make sure the geometric error is calculated correctly
+
 					// Generate the root node
 					const node = {
 						boundingVolume: {
 							box: [
-								tileX - offsetX + tileWidth / 2, tileY - offsetY + tileHeight / 2, 0,
-								tileWidth / 2, 0.0, 0.0,
-								0.0, tileHeight / 2, 0.0,
+								ratioX * pixelSize * centerX, ratioY * pixelSize * centerY, 0,
+								ratioX * pixelSize * tileWidth / 2, 0.0, 0.0,
+								0.0, ratioY * pixelSize * tileHeight / 2, 0.0,
 								0.0, 0.0, 0.0,
 							].map( n => n * pixelSize ),
 						},
-						geometricError: Math.max( width / levelWidth, height / levelHeight ) - 1,
+						geometricError: pixelSize * ( Math.max( width / levelWidth, height / levelHeight ) - 1 ),
 						refine: 'REPLACE',
 						content: {
 							uri: `${ stem }_files/${ level }/${ x }_${ y }.${ format }`,

--- a/src/plugins/three/DeepZoomImagesPlugin.js
+++ b/src/plugins/three/DeepZoomImagesPlugin.js
@@ -6,10 +6,15 @@ export class DeepZoomImagesPlugin {
 
 		const {
 			pixelSize = 0.01,
+			centered = false,
 		} = options;
 
+		this.name = 'DZI_TILES_PLUGIN';
+		this.priority = - 10;
 		this.tiles = null;
+
 		this.pixelSize = pixelSize;
+		this.centered = centered;
 
 	}
 
@@ -19,10 +24,11 @@ export class DeepZoomImagesPlugin {
 
 	}
 
-	parseTile( buffer, tile, extension, abortSignal ) {
+	parseToMesh( buffer, tile, extension, uri, abortSignal ) {
 
 		// TODO: need a function to insert before loaders via parseGeometry _or_ consider adding via loading manager?
 
+		// Construct texture
 		const blob = new Blob( [ buffer ] );
 		const imageBitmap = createImageBitmap( blob, {
 			premultiplyAlpha: 'none',
@@ -31,6 +37,7 @@ export class DeepZoomImagesPlugin {
 		const texture = new Texture( imageBitmap );
 		texture.needsUpdate = true;
 
+		// Construct mesh
 		const mesh = new Mesh( new PlaneGeometry(), new MeshBasicMaterial( { map: texture } ) );
 		const [
 			x, y, z,	// center
@@ -40,7 +47,7 @@ export class DeepZoomImagesPlugin {
 		] = tile.boundingVolume.box;
 
 		mesh.position.set( x, y, z );
-		mesh.scale.set( sx, sy, sz );
+		mesh.scale.set( 2 * sx, 2 * sy, 2 * sz );
 
 		return mesh;
 
@@ -48,59 +55,133 @@ export class DeepZoomImagesPlugin {
 
 	loadRootTileSet( url ) {
 
-		return this
-			.tiles
+		const { pixelSize, centered, tiles } = this;
+
+		return tiles
 			.invokeOnePlugin( plugin => plugin.fetchData && plugin.fetchData( url, this.fetchOptions ) )
 			.then( res => res.text() )
 			.then( text => {
 
 				const xml = new DOMParser().parseFromString( text, 'text/xml' );
-				if ( image.querySelector( 'DisplayRects' ) || xml.querySelector( 'Collection' ) ) {
+				if ( xml.querySelector( 'DisplayRects' ) || xml.querySelector( 'Collection' ) ) {
 
-					throw new Error();
+					throw new Error( 'DeepZoomImagesPlugin: DisplayRect and Collection DZI files not supported.' );
 
 				}
 
+				// Elements
 				const image = xml.querySelector( 'Image' );
 				const size = image.querySelector( 'Size' );
 
+				// Image properties
 				const tileSize = parseInt( image.getAttribute( 'TileSize' ) );
 				const overlap = parseInt( image.getAttribute( 'Overlap' ) );
 				const format = image.getAttribute( 'Format' );
 				const width = parseInt( size.getAttribute( 'Width' ) );
 				const height = parseInt( size.getAttribute( 'Height' ) );
+				const levels = Math.ceil( Math.log2( Math.max( width, height ) ) );
 
-				const tokens = url.split( /[/\\]/g );
-				tokens.pop();
-				const stem = tokens.join( '/' );
+				// offset for the image so it's centered
+				const offsetX = centered ? width / 2 : 0;
+				const offsetY = centered ? height / 2 : 0;
 
-				// TODO: this probably can't be done with implicit tiles since it doesn't align like a proper octree. Ie you
-				// may not split into 4 on the first layer or two with a wide image
-
-				return {
+				const [ stem ] = url.split( /\..+$/g );
+				const tileset = {
 					asset: {
 						version: '1.1'
 					},
-					geometricError: 1024.0,
-					root: {
+					geometricError: 1e5,
+					root: expand( 0, 0, 0 ),
+				};
+
+				return tileset;
+
+				function expand( level, x, y ) {
+
+					const levelWidth = Math.ceil( Math.pow( width, - ( levels - level ) ) );
+					const levelHeight = Math.ceil( Math.pow( height, - ( levels - level ) ) );
+
+					let tileX = tileSize * x - overlap;
+					let tileY = tileSize * y - overlap;
+					let tileWidth = tileSize + overlap * 2;
+					let tileHeight = tileSize + overlap * 2;
+
+					// adjust the starting position of the tile to the edge of the image
+					if ( tileX < 0 ) {
+
+						tileWidth += tileX;
+						tileX = 0;
+
+					}
+
+					if ( tileY < 0 ) {
+
+						tileHeight += tileY;
+						tileY = 0;
+
+					}
+
+					// clamp the dimensions to the edge of the image
+					if ( tileX + tileWidth > levelWidth ) {
+
+						tileWidth -= tileX + tileWidth - levelWidth;
+
+					}
+
+					if ( tileY + tileHeight > levelHeight ) {
+
+						tileHeight -= tileY + tileHeight - levelHeight;
+
+					}
+
+					// If this section doesn't cover an image then discard it
+					if ( tileHeight <= 0 || tileWidth <= 0 ) {
+
+						return null;
+
+					}
+
+					// Generate the root node
+					const node = {
 						boundingVolume: {
-							box: [ 0.5, 0.5, 0.00625, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.00625 ]
+							box: [
+								tileX - offsetX + tileWidth / 2, tileY - offsetY + tileHeight / 2, 0,
+								tileWidth / 2, 0.0, 0.0,
+								0.0, tileHeight / 2, 0.0,
+								0.0, 0.0, 0.0,
+							].map( n => n * pixelSize ),
 						},
-						geometricError: Math.max( width / tileSize, height / tileSize ),
+						geometricError: Math.max( width / levelWidth, height / levelHeight ) - 1,
 						refine: 'REPLACE',
 						content: {
-							uri: `${ stem }/{level}/{x}_{y}.${ format }`,
+							uri: `${ stem }/${ level }/${ x }_${ y }.${ format }`,
 						},
-						implicitTiling: {
-							subdivisionScheme: 'QUADTREE',
-							subtreeLevels: Math.ceil( Math.max( width / tileSize, height / tileSize ) ),
-							availableLevels: 6,
-							subtrees: {
-								uri: 'subtrees/{level}.{x}.{y}.subtree'
+						children: [],
+					};
+
+					// Generate the children
+					if ( level < levels ) {
+
+						for ( let cx = 0; cx < 2; cx ++ ) {
+
+							for ( let cy = 0; cy < 2; cy ++ ) {
+
+								const child = expand( level + 1, 2 * x + cx, 2 * y + cy );
+								if ( child ) {
+
+									node.children.push( child );
+
+								}
+
 							}
+
 						}
+
 					}
-				};
+
+					return node;
+
+				}
 
 			} );
 

--- a/src/plugins/three/DeepZoomImagesPlugin.js
+++ b/src/plugins/three/DeepZoomImagesPlugin.js
@@ -1,0 +1,109 @@
+import { Mesh, MeshBasicMaterial, PlaneGeometry, Texture } from 'three';
+
+export class DeepZoomImagesPlugin {
+
+	constructor( options = {} ) {
+
+		const {
+			pixelSize = 0.01,
+		} = options;
+
+		this.tiles = null;
+		this.pixelSize = pixelSize;
+
+	}
+
+	init( tiles ) {
+
+		this.tiles = tiles;
+
+	}
+
+	parseTile( buffer, tile, extension, abortSignal ) {
+
+		// TODO: need a function to insert before loaders via parseGeometry _or_ consider adding via loading manager?
+
+		const blob = new Blob( [ buffer ] );
+		const imageBitmap = createImageBitmap( blob, {
+			premultiplyAlpha: 'none',
+			colorSpaceConversion: 'none',
+		} );
+		const texture = new Texture( imageBitmap );
+		texture.needsUpdate = true;
+
+		const mesh = new Mesh( new PlaneGeometry(), new MeshBasicMaterial( { map: texture } ) );
+		const [
+			x, y, z,	// center
+			sx,,,		// x vector
+			, sy,,		// y vector
+			,, sz,		// z vector
+		] = tile.boundingVolume.box;
+
+		mesh.position.set( x, y, z );
+		mesh.scale.set( sx, sy, sz );
+
+		return mesh;
+
+	}
+
+	loadRootTileSet( url ) {
+
+		return this
+			.tiles
+			.invokeOnePlugin( plugin => plugin.fetchData && plugin.fetchData( url, this.fetchOptions ) )
+			.then( res => res.text() )
+			.then( text => {
+
+				const xml = new DOMParser().parseFromString( text, 'text/xml' );
+				if ( image.querySelector( 'DisplayRects' ) || xml.querySelector( 'Collection' ) ) {
+
+					throw new Error();
+
+				}
+
+				const image = xml.querySelector( 'Image' );
+				const size = image.querySelector( 'Size' );
+
+				const tileSize = parseInt( image.getAttribute( 'TileSize' ) );
+				const overlap = parseInt( image.getAttribute( 'Overlap' ) );
+				const format = image.getAttribute( 'Format' );
+				const width = parseInt( size.getAttribute( 'Width' ) );
+				const height = parseInt( size.getAttribute( 'Height' ) );
+
+				const tokens = url.split( /[/\\]/g );
+				tokens.pop();
+				const stem = tokens.join( '/' );
+
+				// TODO: this probably can't be done with implicit tiles since it doesn't align like a proper octree. Ie you
+				// may not split into 4 on the first layer or two with a wide image
+
+				return {
+					asset: {
+						version: '1.1'
+					},
+					geometricError: 1024.0,
+					root: {
+						boundingVolume: {
+							box: [ 0.5, 0.5, 0.00625, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.00625 ]
+						},
+						geometricError: Math.max( width / tileSize, height / tileSize ),
+						refine: 'REPLACE',
+						content: {
+							uri: `${ stem }/{level}/{x}_{y}.${ format }`,
+						},
+						implicitTiling: {
+							subdivisionScheme: 'QUADTREE',
+							subtreeLevels: Math.ceil( Math.max( width / tileSize, height / tileSize ) ),
+							availableLevels: 6,
+							subtrees: {
+								uri: 'subtrees/{level}.{x}.{y}.subtree'
+							}
+						}
+					}
+				};
+
+			} );
+
+	}
+
+}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -676,10 +676,19 @@ export class TilesRenderer extends TilesRendererBase {
 
 			}
 
-			default:
-				console.warn( `TilesRenderer: Content type "${ fileType }" not supported.` );
-				promise = Promise.resolve( null );
+			default: {
+
+				promise = this.invokeAllPlugins( plugin => plugin.parseToMesh && plugin.parseToMesh( buffer, tile, extension, uri, abortSignal ) );
+
+				if ( promise === null ) {
+
+					console.warn( `TilesRenderer: Content type "${ fileType }" not supported.` );
+					promise = Promise.resolve( null );
+
+				}
 				break;
+
+			}
 
 		}
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -681,13 +681,6 @@ export class TilesRenderer extends TilesRendererBase {
 			default: {
 
 				promise = this.invokeOnePlugin( plugin => plugin.parseToMesh && plugin.parseToMesh( buffer, tile, extension, uri, abortSignal ) );
-
-				if ( promise === null ) {
-
-					console.warn( `TilesRenderer: Content type "${ fileType }" not supported.` );
-					promise = Promise.resolve( null );
-
-				}
 				break;
 
 			}
@@ -696,6 +689,11 @@ export class TilesRenderer extends TilesRendererBase {
 
 		// wait for the tile to load
 		const result = await promise;
+		if ( result === null ) {
+
+			throw new Error( `TilesRenderer: Content type "${ fileType }" not supported.` );
+
+		}
 
 		// get the scene data
 		let scene;
@@ -935,7 +933,6 @@ export class TilesRenderer extends TilesRendererBase {
 				const distance = boundingVolume.distanceToPoint( info.position );
 				const sseDenominator = info.sseDenominator;
 				error = tile.geometricError / ( distance * sseDenominator );
-
 				minDistance = Math.min( minDistance, distance );
 
 			}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -329,10 +329,10 @@ export class TilesRenderer extends TilesRendererBase {
 	loadRootTileSet( ...args ) {
 
 		return super.loadRootTileSet( ...args )
-			.then( () => {
+			.then( root => {
 
 				// cache the gltf tile set rotation matrix
-				const { asset, extensions = {} } = this.rootTileSet;
+				const { asset, extensions = {} } = root;
 				const upAxis = asset && asset.gltfUpAxis || 'y';
 				switch ( upAxis.toLowerCase() ) {
 
@@ -365,6 +365,8 @@ export class TilesRenderer extends TilesRendererBase {
 				}
 
 				this.dispatchEvent( { type: 'load-content' } );
+
+				return root;
 
 			} );
 
@@ -678,7 +680,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 			default: {
 
-				promise = this.invokeAllPlugins( plugin => plugin.parseToMesh && plugin.parseToMesh( buffer, tile, extension, uri, abortSignal ) );
+				promise = this.invokeOnePlugin( plugin => plugin.parseToMesh && plugin.parseToMesh( buffer, tile, extension, uri, abortSignal ) );
 
 				if ( promise === null ) {
 


### PR DESCRIPTION
Related to #943

Related to #480 - enabling LoDs to be skipped can help the transitions load faster.
