### PR TITLE
Fix DebugTilesPlugin updates with matrixAutoUpdate = false

### DIFF
--- a/src/plugins/three/DebugTilesPlugin.js
+++ b/src/plugins/three/DebugTilesPlugin.js
@@ -762,7 +762,9 @@ export class DebugTilesPlugin {
 			if ( boxHelperGroup ) {
 
 				boxGroup.add( boxHelperGroup );
+				boxGroup.updateMatrixWorld( true );
 				boxHelperGroup.updateMatrixWorld( true );
+				boxHelperGroup.children[ 0 ].updateMatrix();
 
 				this._updateHelperMaterial( tile, boxHelperGroup.children[ 0 ].material );
 
@@ -771,6 +773,7 @@ export class DebugTilesPlugin {
 			if ( sphereHelper ) {
 
 				sphereGroup.add( sphereHelper );
+				sphereGroup.updateMatrixWorld( true );
 				sphereHelper.updateMatrixWorld( true );
 
 				this._updateHelperMaterial( tile, sphereHelper.material );
@@ -780,7 +783,9 @@ export class DebugTilesPlugin {
 			if ( regionHelper ) {
 
 				regionGroup.add( regionHelper );
+				regionGroup.updateMatrixWorld( true );
 				regionHelper.updateMatrixWorld( true );
+				regionHelper.updateMatrix();
 
 				this._updateHelperMaterial( tile, regionHelper.material );
 


### PR DESCRIPTION
Specifically, if the global default `Object3D.DEFAULT_MATRIX_AUTO_UPDATE` is disabled, debug objects from the `DebugTilesPlugin` do not update correctly. All that was missing was a `matrixWorld` update on the main container, and matrix updates on the helpers themselves (where applicable). 

There are several other places in this library that fail when matrixAutoUpdate is disabled, but they're relatively easy to fix application-side with the event callbacks already in place, but that wasn't feasible here. I may make some PR's for that in the future just to provide some bugfixes for applications that have matrix auto updates disabled for performance reasons.

I do not have tilesets that allow testing of boundingSphere and boundingRegion, so I just emulated the work I did for boundingBoxes - validation on those would be helpful.