### PR TITLE
Fix incorrect isMatrixType matching for metadata schema

### DIFF
--- a/src/plugins/three/gltf/metadata/utilities/ClassPropertyHelpers.js
+++ b/src/plugins/three/gltf/metadata/utilities/ClassPropertyHelpers.js
@@ -38,7 +38,7 @@ export function isVectorType( type ) {
 // check if the class property type is a matrix type
 export function isMatrixType( type ) {
 
-	return /^MATRIX/.test( type );
+	return /^MAT/.test( type );
 
 }
 


### PR DESCRIPTION
This PR fixes the issue where requesting properties of matrix type on structural metadata tables returned scalar values. This was due to an incorrect regexp for matrix type matching.