### PR TITLE
Improve R3F Tiles

### DIFF
--- a/src/plugins/three/images/ImageFormatPlugin.js
+++ b/src/plugins/three/images/ImageFormatPlugin.js
@@ -184,7 +184,6 @@ export class ImageFormatPlugin {
 
 		tileset.root[ UV_BOUNDS ] = [ 0, 0, 1, 1 ];
 
-		this._tilesNeedUpdate = true;
 		this.tiles.preprocessTileSet( tileset, baseUrl );
 		return tileset;
 
@@ -311,7 +310,7 @@ export class ImageFormatPlugin {
 
 		}
 
-		return false;
+		return null;
 
 	}
 

--- a/src/plugins/three/images/ImageFormatPlugin.js
+++ b/src/plugins/three/images/ImageFormatPlugin.js
@@ -184,6 +184,7 @@ export class ImageFormatPlugin {
 
 		tileset.root[ UV_BOUNDS ] = [ 0, 0, 1, 1 ];
 
+		this._tilesNeedUpdate = true;
 		this.tiles.preprocessTileSet( tileset, baseUrl );
 		return tileset;
 

--- a/src/r3f/components/TilesRenderer.jsx
+++ b/src/r3f/components/TilesRenderer.jsx
@@ -4,7 +4,6 @@ import { Vector3 } from 'three';
 import { TilesRenderer as TilesRendererImpl } from '../../three/TilesRenderer.js';
 import { useDeepOptions, useShallowOptions } from '../utilities/useOptions.js';
 import { useObjectDep } from '../utilities/useObjectDep.js';
-import { useForceUpdate } from '../utilities/useForceUpdate.js';
 import { useApplyRefs } from '../utilities/useApplyRefs.js';
 
 // context for accessing the tile set
@@ -129,26 +128,34 @@ export const TilesPlugin = forwardRef( function TilesPlugin( props, ref ) {
 export const TilesRenderer = forwardRef( function TilesRenderer( props, ref ) {
 
 	const { url, group = {}, enabled = true, children, ...options } = props;
-	const [ tiles, setTiles ] = useState( null );
 	const [ camera, gl, invalidate ] = useThree( state => [ state.camera, state.gl, state.invalidate ] );
-	const [ forceUpdateIndex, forceUpdate ] = useForceUpdate();
+
+	const tiles = useMemo( () => {
+
+		return new TilesRendererImpl( url );
+
+	}, [ url ] );
 
 	// create the tile set
 	useEffect( () => {
 
-		const tiles = new TilesRendererImpl( url );
-		tiles.addEventListener( 'load-tile-set', () => invalidate() );
+		tiles.addEventListener( 'load-tile-set', () => {
+
+			console.log('LOADED')
+			invalidate();
+
+		} );
 		tiles.addEventListener( 'load-content', () => invalidate() );
 		tiles.addEventListener( 'force-rerender', () => invalidate() );
-		setTiles( tiles );
 
+		window.TILES = tiles;
 		return () => {
 
 			tiles.dispose();
 
 		};
 
-	}, [ url, invalidate ] );
+	}, [ tiles, invalidate ] );
 
 	// update the resolution for the camera
 	useFrame( () => {
@@ -189,17 +196,9 @@ export const TilesRenderer = forwardRef( function TilesRenderer( props, ref ) {
 	// assign options recursively
 	useDeepOptions( tiles, options );
 
-	// because options modify tiles settings non-reactively we force an update and
-	// pass the update index into the tiles context to force children to update
-	useEffect( () => {
-
-		forceUpdate();
-
-	}, [ tiles, useObjectDep( options ) ] ); // eslint-disable-line
-
 	return <>
 		{ tiles ? <primitive object={ tiles.group } { ...group } /> : null }
-		<TilesRendererContext.Provider value={ tiles } key={ forceUpdateIndex }>
+		<TilesRendererContext.Provider value={ tiles }>
 			<TileSetRoot>
 				{ children }
 			</TileSetRoot>

--- a/src/r3f/components/TilesRenderer.jsx
+++ b/src/r3f/components/TilesRenderer.jsx
@@ -143,7 +143,7 @@ export const TilesRenderer = forwardRef( function TilesRenderer( props, ref ) {
 		tiles.addEventListener( 'load-content', () => invalidate() );
 		tiles.addEventListener( 'force-rerender', () => invalidate() );
 		return () => {
-			
+
 			tiles.dispose();
 
 		};

--- a/src/r3f/components/TilesRenderer.jsx
+++ b/src/r3f/components/TilesRenderer.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useRef, forwardRef, useMemo } from 'react';
+import { createContext, useContext, useEffect, useRef, forwardRef, useMemo } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
 import { Vector3 } from 'three';
 import { TilesRenderer as TilesRendererImpl } from '../../three/TilesRenderer.js';
@@ -139,18 +139,11 @@ export const TilesRenderer = forwardRef( function TilesRenderer( props, ref ) {
 	// create the tile set
 	useEffect( () => {
 
-		tiles.addEventListener( 'load-tile-set', () => {
-
-			console.log('LOADED')
-			invalidate();
-
-		} );
+		tiles.addEventListener( 'load-tile-set', () => invalidate() );
 		tiles.addEventListener( 'load-content', () => invalidate() );
 		tiles.addEventListener( 'force-rerender', () => invalidate() );
-
-		window.TILES = tiles;
 		return () => {
-
+			
 			tiles.dispose();
 
 		};
@@ -197,7 +190,7 @@ export const TilesRenderer = forwardRef( function TilesRenderer( props, ref ) {
 	useDeepOptions( tiles, options );
 
 	return <>
-		{ tiles ? <primitive object={ tiles.group } { ...group } /> : null }
+		<primitive object={ tiles.group } { ...group } />
 		<TilesRendererContext.Provider value={ tiles }>
 			<TileSetRoot>
 				{ children }

--- a/src/r3f/utilities/useForceUpdate.js
+++ b/src/r3f/utilities/useForceUpdate.js
@@ -1,8 +1,0 @@
-import { useState } from 'react';
-
-export function useForceUpdate() {
-
-	const [ value, setValue ] = useState( 0 );
-	return [ value, () => setValue( value + 1 ) ];
-
-}


### PR DESCRIPTION
Fix #993 

- Avoid recreating all children and plugins when tile options change
- ImageFormatsPlugins: Do not preclude update

**TODO**
- Understand why "force update" was originally needed (see #822) (possibly for moon?)