### PR TITLE
Add TypeScript definition for setLatLonToYUp

### DIFF
--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -41,6 +41,8 @@ export class TilesRenderer<TEventMap extends TilesRendererEventMap = TilesRender
 	setResolution( camera : Camera, resolution : Vector2 ) : boolean;
 	setResolutionFromRenderer( camera : Camera, renderer : WebGLRenderer ) : boolean;
 
+	setLatLonToYUp( lat: number, lon: number ) : void;
+
 	forEachLoadedModel( callback : ( scene : Object3D, tile : Tile ) => void ) : void;
 
 	/**


### PR DESCRIPTION
Note that at: https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/4c51400763c3689f26cb4efaf4e301e964265471/src/three/TilesRenderer.js#L957 it is mentioned that this function will be deprecated in the future.