### PR TITLE
TilesRenderer: Only calculate error for frustums that intersect tiles

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -493,7 +493,6 @@ export class TilesRendererBase {
 
 		}
 
-		// Expected to be set during calculateError()
 		tile.__distanceFromCamera = Infinity;
 		tile.__error = Infinity;
 
@@ -553,15 +552,10 @@ export class TilesRendererBase {
 
 	}
 
-	calculateError( tile ) {
+	getTileVisibility( tile, target ) {
 
-		return 0;
-
-	}
-
-	tileInView( tile ) {
-
-		return true;
+		// retrieve whether the tile is visible, screen space error, and distance to camera
+		// set "inView", "error", "distance"
 
 	}
 

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -1,5 +1,11 @@
 import { LOADED, FAILED, UNLOADED } from './constants.js';
 
+const visTarget = {
+	inView: false,
+	error: Infinity,
+	distance: Infinity,
+};
+
 function isDownloadFinished( value ) {
 
 	return value === LOADED || value === FAILED;
@@ -30,8 +36,10 @@ function resetFrameState( tile, renderer ) {
 		tile.__allChildrenLoaded = false;
 
 		// update tile frustum and error state
-		tile.__inFrustum = renderer.tileInView( tile );
-		renderer.calculateError( tile );
+		renderer.getTileVisibility( tile, visTarget );
+		tile.__inFrustum = visTarget.inView;
+		tile.__error = visTarget.error;
+		tile.__distanceFromCamera = visTarget.distance;
 
 	}
 

--- a/src/plugins/three/LoadRegionPlugin.js
+++ b/src/plugins/three/LoadRegionPlugin.js
@@ -7,7 +7,6 @@ export class LoadRegionPlugin {
 
 		this.name = 'LOAD_REGION_PLUGIN';
 		this.regions = [];
-		this.tileErrors = new Map();
 		this.tiles = null;
 
 	}
@@ -15,14 +14,6 @@ export class LoadRegionPlugin {
 	init( tiles ) {
 
 		this.tiles = tiles;
-
-		this._updateAfterCallback = () => {
-
-			this.tileErrors.clear();
-
-		};
-
-		tiles.addEventListener( 'update-after', this._updateAfterCallback );
 
 	}
 
@@ -59,10 +50,10 @@ export class LoadRegionPlugin {
 
 	}
 
-	tileInView( tile ) {
+	getTileVisibility( tile, target ) {
 
 		const boundingVolume = tile.cached.boundingVolume;
-		const { regions, tileErrors, tiles } = this;
+		const { regions, tiles } = this;
 
 		let visible = false;
 		let maxError = - Infinity;
@@ -78,26 +69,14 @@ export class LoadRegionPlugin {
 
 		}
 
-		if ( visible ) {
-
-			tileErrors.set( tile, maxError );
-
-		}
-
-		return visible;
-
-	}
-
-	calculateError( tile ) {
-
-		return this.tileErrors.has( tile ) ? this.tileErrors.get( tile ) : null;
+		target.inView = visible;
+		target.error = maxError;
 
 	}
 
 	dispose() {
 
 		this.regions = [];
-		this.tiles.removeEventListener( 'update-after', this._updateAfterCallback );
 
 	}
 

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -28,6 +28,10 @@ const INITIAL_FRUSTUM_CULLED = Symbol( 'INITIAL_FRUSTUM_CULLED' );
 const tempMat = new Matrix4();
 const tempVector = new Vector3();
 const tempVector2 = new Vector2();
+const visTarget = {
+	inFrustum: false,
+	error: Infinity,
+};
 
 const X_AXIS = new Vector3( 1, 0, 0 );
 const Y_AXIS = new Vector3( 0, 1, 0 );
@@ -402,7 +406,7 @@ export class TilesRenderer extends TilesRendererBase {
 		if ( cameras.length === 0 ) {
 
 			let found = false;
-			this.invokeAllPlugins( plugin => found = found || Boolean( plugin !== this && plugin.calculateError && plugin.tileInView ) );
+			this.invokeAllPlugins( plugin => found = found || Boolean( plugin !== this && plugin.getTileVisibility ) );
 			if ( found === false ) {
 
 				console.warn( 'TilesRenderer: no cameras defined. Cannot update 3d tiles.' );
@@ -908,86 +912,88 @@ export class TilesRenderer extends TilesRendererBase {
 
 	}
 
-	calculateError( tile ) {
+	getTileVisibility( tile, target ) {
 
 		const cached = tile.cached;
 		const cameras = this.cameras;
 		const cameraInfo = this.cameraInfo;
 		const boundingVolume = cached.boundingVolume;
 
+		let inView = false;
+		let inViewError = - Infinity;
+		let inViewDistance = Infinity;
 		let maxError = - Infinity;
 		let minDistance = Infinity;
 
 		for ( let i = 0, l = cameras.length; i < l; i ++ ) {
 
-			// transform camera position into local frame of the tile bounding box
+			// calculate the camera error
 			const info = cameraInfo[ i ];
 			let error;
+			let distance;
 			if ( info.isOrthographic ) {
 
 				const pixelSize = info.pixelSize;
 				error = tile.geometricError / pixelSize;
+				distance = Infinity;
 
 			} else {
 
-				const distance = boundingVolume.distanceToPoint( info.position );
 				const sseDenominator = info.sseDenominator;
+				distance = boundingVolume.distanceToPoint( info.position );
 				error = tile.geometricError / ( distance * sseDenominator );
-				minDistance = Math.min( minDistance, distance );
 
 			}
-
-			maxError = Math.max( maxError, error );
-
-		}
-
-		this.invokeAllPlugins( plugin => {
-
-			if ( plugin !== this && plugin.calculateError ) {
-
-				maxError = Math.max( maxError, plugin.calculateError( tile ) || 0 );
-
-			}
-
-		} );
-
-		tile.__distanceFromCamera = minDistance;
-		tile.__error = maxError;
-
-	}
-
-	tileInView( tile ) {
-
-		let inView = false;
-		this.invokeAllPlugins( plugin => {
-
-			inView = inView || plugin !== this && plugin.tileInView && plugin.tileInView( tile );
-
-		} );
-
-		if ( inView ) {
-
-			return true;
-
-		}
-
-		const cached = tile.cached;
-		const boundingVolume = cached.boundingVolume;
-		const cameraInfo = this.cameraInfo;
-		for ( let i = 0, l = cameraInfo.length; i < l; i ++ ) {
 
 			// Track which camera frustums this tile is in so we can use it
 			// to ignore the error calculations for cameras that can't see it
 			const frustum = cameraInfo[ i ].frustum;
 			if ( boundingVolume.intersectsFrustum( frustum ) ) {
 
-				return true;
+				inView = true;
+				inViewError = Math.max( inViewError, error );
+				inViewDistance = Math.min( inViewDistance, distance );
 
 			}
 
+			maxError = Math.max( maxError, error );
+			minDistance = Math.min( minDistance, distance );
+
 		}
 
-		return false;
+		// check the plugin visibility
+		this.invokeAllPlugins( plugin => {
+
+			if ( plugin !== this && plugin.getTileVisibility ) {
+
+				plugin.getTileVisibility( tile, visTarget );
+				if ( visTarget.inView ) {
+
+					inView = true;
+					inViewError = Math.max( inViewError, visTarget.error );
+
+				}
+
+				maxError = Math.max( maxError, visTarget.error );
+
+			}
+
+		} );
+
+		// If the tiles are out of view then use the global distance and error calculated
+		if ( inView ) {
+
+			target.inView = true;
+			target.error = inViewError;
+			target.distanceToCamera = inViewDistance;
+
+		} else {
+
+			target.inView = false;
+			target.error = maxError;
+			target.distanceToCamera = minDistance;
+
+		}
 
 	}
 


### PR DESCRIPTION
Fix #1006

**TODO**
- Rename "getTileVisibility" to further differentiate from the "setTileVisible" function.
- Performance test.