### PR TITLE
Export `TilesRendererEventMap`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 // three.js
-export { TilesRenderer } from './three/TilesRenderer';
+export { TilesRenderer, TilesRendererEventMap } from './three/TilesRenderer';
 export { TilesGroup } from './three/TilesGroup';
 export { B3DMLoader, B3DMScene } from './three/loaders/B3DMLoader';
 export { I3DMLoader, I3DMScene } from './three/loaders/I3DMLoader';


### PR DESCRIPTION
Just need `TilesRendererEventMap` exported so it can be referenced correctly.

**Why**

TS doesn't like when I try to create a custom `forwardRef` component based on `TilesRenderer`.

```ts
import type { TilesRenderer as TilesRendererImpl } from "3d-tiles-renderer";
import { TilesRenderer } from "3d-tiles-renderer/r3f";

export const Map3DTiles = forwardRef<TilesRendererImpl, Map3DTilesProps>( (customProps, fRef) => {
  const [tilesRenderer, setTilesRenderer] = useState<TilesRendererImpl | null>(null);

  useImperativeHandle(fRef, () => tilesRenderer as TilesRendererImpl);

  return <TilesRenderer ref={setTilesRenderer} />
});
```

> The inferred type of 'Map3DTiles' cannot be named without a reference to '../../../node_modules/3d-tiles-renderer/src/three/TilesRenderer'. This is likely not portable. A type annotation is necessary.ts(2742)

But if the TS compiler can access the default generic `TilesRendererEventMap`, then it is happy without any further changes.