### PR TITLE
Fixed a bug that caused shift+click not to work

### DIFF
--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -214,31 +214,9 @@ export class EnvironmentControls extends EventDispatcher {
 		this.pointerTracker.domElement = domElement;
 		domElement.style.touchAction = 'none';
 
-		let shiftClicked = false;
-
 		const contextMenuCallback = e => {
 
 			e.preventDefault();
-
-		};
-
-		const keydownCallback = e => {
-
-			if ( e.key === 'Shift' ) {
-
-				shiftClicked = true;
-
-			}
-
-		};
-
-		const keyupCallback = e => {
-
-			if ( e.key === 'Shift' ) {
-
-				shiftClicked = false;
-
-			}
 
 		};
 
@@ -304,7 +282,7 @@ export class EnvironmentControls extends EventDispatcher {
 				if (
 					pointerTracker.getPointerCount() === 2 ||
 					pointerTracker.isRightClicked() ||
-					pointerTracker.isLeftClicked() && shiftClicked
+					pointerTracker.isLeftClicked() && e.shiftKey
 				) {
 
 					this.setState( pointerTracker.isPointerTouch() ? WAITING : ROTATE );
@@ -487,8 +465,6 @@ export class EnvironmentControls extends EventDispatcher {
 
 			const { pointerTracker } = this;
 
-			shiftClicked = false;
-
 			if ( e.buttons !== pointerTracker.getPointerButtons() ) {
 
 				pointerTracker.deletePointer( e );
@@ -499,8 +475,6 @@ export class EnvironmentControls extends EventDispatcher {
 		};
 
 		domElement.addEventListener( 'contextmenu', contextMenuCallback );
-		domElement.addEventListener( 'keydown', keydownCallback );
-		domElement.addEventListener( 'keyup', keyupCallback );
 		domElement.addEventListener( 'pointerdown', pointerdownCallback );
 		domElement.addEventListener( 'pointermove', pointermoveCallback );
 		domElement.addEventListener( 'pointerup', pointerupCallback );
@@ -510,8 +484,6 @@ export class EnvironmentControls extends EventDispatcher {
 		this._detachCallback = () => {
 
 			domElement.removeEventListener( 'contextmenu', contextMenuCallback );
-			domElement.removeEventListener( 'keydown', keydownCallback );
-			domElement.removeEventListener( 'keyup', keyupCallback );
 			domElement.removeEventListener( 'pointerdown', pointerdownCallback );
 			domElement.removeEventListener( 'pointermove', pointermoveCallback );
 			domElement.removeEventListener( 'pointerup', pointerupCallback );


### PR DESCRIPTION
Fixed https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/1023

The reason why the current solution doesn't work is because the `pointerdown` event handler calls `preventDefault()` which makes the canvas element cannot be focused, however the keydown event relies on the canvas element to be focused.

Instead of listening to the `keydown` and `keyup` events on the canvas element in order to handle the shift + click gesture, we can simply detect whether the shift key is pressed using [MouseEvent.shiftKey](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/shiftKey) property.

This fix should allow end users to use shift key to control the tilt and rotation of the globe.