### PR TITLE
feat(implicitTiling): Add support for external buffer

### DIFF
--- a/src/plugins/base/ImplicitTilingPlugin.js
+++ b/src/plugins/base/ImplicitTilingPlugin.js
@@ -47,8 +47,7 @@ export class ImplicitTilingPlugin {
 
 			const loader = new SUBTREELoader( tile );
 			loader.workingPath = tile.__basePath;
-			loader.parse( buffer );
-			return Promise.resolve();
+			return loader.parse( buffer );
 
 		}
 

--- a/src/plugins/base/ImplicitTilingPlugin.js
+++ b/src/plugins/base/ImplicitTilingPlugin.js
@@ -41,11 +41,12 @@ export class ImplicitTilingPlugin {
 
 	}
 
-	parseTile( buffer, parseTile, extension ) {
+	parseTile( buffer, tile, extension ) {
 
 		if ( /^subtree$/i.test( extension ) ) {
 
-			const loader = new SUBTREELoader( parseTile );
+			const loader = new SUBTREELoader( tile );
+			loader.workingPath = tile.__basePath;
 			loader.parse( buffer );
 			return Promise.resolve();
 

--- a/src/plugins/base/SUBTREELoader.js
+++ b/src/plugins/base/SUBTREELoader.js
@@ -845,7 +845,6 @@ export class SUBTREELoader extends LoaderBase {
 	 * @param {Object} tile - The tile object that contains properties:
 	 *   - __level: the subdivision level,
 	 *   - __x, __y, __z: the tile coordinates,
-	 *   - __basePath: the base path for the external resources.
 	 * @param {string} uri - The URI template string with placeholders for the tile (e.g., `{level}`, `{x}`, `{y}`, `{z}`).
 	 * @param {string} bufUri - The buffer file name to append (e.g., "0_1.bin").
 	 * @returns {string} The full external buffer URI.

--- a/src/plugins/base/SUBTREELoader.js
+++ b/src/plugins/base/SUBTREELoader.js
@@ -297,13 +297,14 @@ export class SUBTREELoader extends LoaderBase {
 		for ( let i = 0; i < bufferHeaders.length; i ++ ) {
 
 			const bufferHeader = bufferHeaders[ i ];
-			if ( bufferHeader.isActive ) {
+			//  TODO load external buffer (when isExternal == true)
+			if ( ! bufferHeader.isActive || bufferHeader.isExternal ) {
 
-				bufferResults.push( internalBuffer );
+				bufferResults.push( undefined );
 
 			} else {
 
-				bufferResults.push( undefined );
+				bufferResults.push( internalBuffer );
 
 			}
 
@@ -339,7 +340,7 @@ export class SUBTREELoader extends LoaderBase {
 		for ( let i = 0; i < bufferViewHeaders.length; i ++ ) {
 
 			const bufferViewHeader = bufferViewHeaders[ i ];
-			if ( ! bufferViewHeader.isActive ) {
+			if ( ! bufferViewHeader.isActive || bufferViewHeader.isExternal ) {
 
 				continue;
 
@@ -381,6 +382,7 @@ export class SUBTREELoader extends LoaderBase {
 
 			const bufferHeader = bufferHeaders[ i ];
 			bufferHeader.isActive = false;
+			bufferHeader.isExternal = !! bufferHeader.uri;
 
 		}
 		return bufferHeaders;
@@ -417,6 +419,7 @@ export class SUBTREELoader extends LoaderBase {
 			const bufferViewHeader = bufferViewHeaders[ i ];
 			bufferViewHeader.bufferHeader = bufferHeaders[ bufferViewHeader.buffer ];
 			bufferViewHeader.isActive = false;
+			bufferViewHeader.isExternal = bufferViewHeader.bufferHeader.isExternal;
 
 		}
 		return bufferViewHeaders;

--- a/src/plugins/base/SUBTREELoader.js
+++ b/src/plugins/base/SUBTREELoader.js
@@ -71,6 +71,7 @@ export class SUBTREELoader extends LoaderBase {
 		super();
 		this.tile = tile;
 		this.rootTile = tile.__implicitRoot;	// The implicit root tile
+		this.workingPath = null;
 
 	}
 
@@ -851,17 +852,17 @@ export class SUBTREELoader extends LoaderBase {
 	 */
 	parseImplicitURIBuffer( tile, uri, bufUri ) {
 
-		// Generate the base URI by replacing placeholders
+		// Generate the base tile URI by replacing placeholders
 		const subUri = this.parseImplicitURI( tile, uri );
 
 		// Create a URL object relative to the tile's base path
-		const url = new URL( subUri, tile.__basePath + '/' );
+		const url = new URL( subUri, this.workingPath + '/' );
 
 		// Remove the last path segment
 		url.pathname = url.pathname.substring( 0, url.pathname.lastIndexOf( '/' ) );
 
 		// Construct the final URL with the buffer URI appended
-		return new URL( url.pathname + '/' + bufUri, tile.__basePath + '/' ).toString();
+		return new URL( url.pathname + '/' + bufUri, this.workingPath + '/' ).toString();
 
 
 	}

--- a/src/plugins/base/SUBTREELoader.js
+++ b/src/plugins/base/SUBTREELoader.js
@@ -272,29 +272,31 @@ export class SUBTREELoader extends LoaderBase {
 			// If the buffer is not active, resolve with undefined.
 			if ( ! bufferHeader.isActive ) {
 
-				promises.push( Promise.resolve( undefined ) );
+				promises.push( Promise.resolve( ) );
 
 			} else if ( bufferHeader.isExternal ) {
 
-				// Load external buffer via its URI. Adjust URI.
-				promises.push(
-					fetch( this.parseImplicitURIBuffer( this.tile, this.rootTile.implicitTiling.subtrees.uri, bufferHeader.uri ) )
-						.then( response => {
-
-							if ( ! response.ok ) {
-
-								throw new Error( `Failed to load external buffer from ${bufferHeader.uri}` );
-
-							}
-							return response.arrayBuffer();
-
-						} )
-						.then( arrayBuffer => {
-
-							return new Uint8Array( arrayBuffer );
-
-						} )
+				// Get the absolute URI of the external buffer.
+				const url = this.parseImplicitURIBuffer(
+					this.tile,
+					this.rootTile.implicitTiling.subtrees.uri,
+					bufferHeader.uri
 				);
+
+				const fetchPromise = fetch( url )
+					.then( response => {
+
+						if ( ! response.ok ) {
+
+							throw new Error( `SUBTREELoader: Failed to load external buffer from ${ bufferHeader.uri } with error code ${ response.status }.` );
+
+						}
+						return response.arrayBuffer();
+
+					} )
+					.then( arrayBuffer => new Uint8Array( arrayBuffer ) );
+
+				promises.push( fetchPromise );
 
 			} else {
 

--- a/src/plugins/base/SUBTREELoader.js
+++ b/src/plugins/base/SUBTREELoader.js
@@ -6,8 +6,6 @@ import { LoaderBase } from '../../base/loaders/LoaderBase.js';
 import { readMagicBytes } from '../../utilities/readMagicBytes.js';
 import { arrayToString } from '../../utilities/arrayToString.js';
 
-
-
 function isOctreeSubdivision( tile ) {
 
 	return tile.__implicitRoot.implicitTiling.subdivisionScheme === 'OCTREE';
@@ -20,7 +18,6 @@ function getBoundsDivider( tile ) {
 
 }
 
-
 function getSubtreeCoordinates( tile, parentTile ) {
 
 	if ( ! parentTile ) {
@@ -28,12 +25,10 @@ function getSubtreeCoordinates( tile, parentTile ) {
 		return [ 0, 0, 0 ];
 
 	}
-
 	const x = 2 * parentTile.__x + ( tile.__subtreeIdx % 2 );
 	const y = 2 * parentTile.__y + ( Math.floor( tile.__subtreeIdx / 2 ) % 2 );
 	const z = isOctreeSubdivision( tile ) ?
 		2 * parentTile.__z + ( Math.floor( tile.__subtreeIdx / 4 ) % 2 ) : 0;
-
 	return [ x, y, z ];
 
 }
@@ -46,7 +41,6 @@ class SubtreeTile {
 		this.children = [];
 		this.__level = parentTile.__level + 1;
 		this.__implicitRoot = parentTile.__implicitRoot;
-
 		// Index inside the tree
 		this.__subtreeIdx = childMortonIndex;
 		[ this.__x, this.__y, this.__z ] = getSubtreeCoordinates( this, parentTile );
@@ -59,11 +53,9 @@ class SubtreeTile {
 		copyTile.children = [];
 		copyTile.__level = tile.__level;
 		copyTile.__implicitRoot = tile.__implicitRoot;
-
 		// Index inside the tree
 		copyTile.__subtreeIdx = tile.__subtreeIdx;
 		[ copyTile.__x, copyTile.__y, copyTile.__z ] = [ tile.__x, tile.__y, tile.__z ];
-
 		copyTile.boundingVolume = tile.boundingVolume;
 		copyTile.geometricError = tile.geometricError;
 		return copyTile;
@@ -97,43 +89,33 @@ export class SUBTREELoader extends LoaderBase {
 	 * @param buffer
 	 * @return {Subtree}
 	 */
-
 	parseBuffer( buffer ) {
 
 		const dataView = new DataView( buffer );
 		let offset = 0;
-
 		// 16-byte header
-
 		// 4 bytes
 		const magic = readMagicBytes( dataView );
 		console.assert( magic === 'subt', 'SUBTREELoader: The magic bytes equal "subt".' );
 		offset += 4;
-
 		// 4 bytes
 		const version = dataView.getUint32( offset, true );
 		console.assert( version === 1, 'SUBTREELoader: The version listed in the header is "1".' );
 		offset += 4;
-
 		// From Cesium
 		// Read the bottom 32 bits of the 64-bit byte length.
 		// This is ok for now because:
 		// 1) not all browsers have native 64-bit operations
 		// 2) the data is well under 4GB
-
 		// 8 bytes
 		const jsonLength = dataView.getUint32( offset, true );
 		offset += 8;
-
 		// 8 bytes
 		const byteLength = dataView.getUint32( offset, true );
 		offset += 8;
-
 		const subtreeJson = JSON.parse( arrayToString( new Uint8Array( buffer, offset, jsonLength ) ) );
 		offset += jsonLength;
-
 		const subtreeByte = buffer.slice( offset, offset + byteLength );
-
 		return {
 			version,
 			subtreeJson,
@@ -143,7 +125,7 @@ export class SUBTREELoader extends LoaderBase {
 	}
 
 
-	parse( buffer ) {
+	async parse( buffer ) {
 
 		// todo here : handle json
 		const subtree = this.parseBuffer( buffer );
@@ -152,23 +134,17 @@ export class SUBTREELoader extends LoaderBase {
 		// TODO Handle metadata
 		/*
 		 const subtreeMetadata = subtreeJson.subtreeMetadata;
-		subtree._metadata = subtreeMetadata;
-		 */
-
+		 subtree._metadata = subtreeMetadata;
+		*/
 
 		/*
 			Tile availability indicates which tiles exist within the subtree
-
 			Content availability indicates which tiles have associated content resources
-
 			Child subtree availability indicates what subtrees are reachable from this subtree
-
-		 */
-
+		*/
 
 		// After identifying how availability is stored, put the results in this new array for consistent processing later
 		subtreeJson.contentAvailabilityHeaders = [].concat( subtreeJson.contentAvailability );
-
 		const bufferHeaders = this.preprocessBuffers( subtreeJson.buffers );
 		const bufferViewHeaders = this.preprocessBufferViews(
 			subtreeJson.bufferViews,
@@ -179,17 +155,17 @@ export class SUBTREELoader extends LoaderBase {
 		// This way we can avoid fetching buffers that will not be used.
 		this.markActiveBufferViews( subtreeJson, bufferViewHeaders );
 
-		const buffersU8 = this.requestActiveBuffers(
+		// Await the active buffers. If a buffer is external (isExternal === true),
+		// fetch it from its URI.
+		const buffersU8 = await this.requestActiveBuffers(
 			bufferHeaders,
 			subtree.subtreeByte
 		);
-
 		const bufferViewsU8 = this.parseActiveBufferViews( bufferViewHeaders, buffersU8 );
 		this.parseAvailability( subtree, subtreeJson, bufferViewsU8 );
 		this.expandSubtree( this.tile, subtree );
 
 	}
-
 
 	/**
 	 * Determine which buffer views need to be loaded into memory. This includes:
@@ -212,7 +188,6 @@ export class SUBTREELoader extends LoaderBase {
 
 		let header;
 		const tileAvailabilityHeader = subtreeJson.tileAvailability;
-
 		// Check for bitstream first, which is part of the current schema.
 		// bufferView is the name of the bitstream from an older schema.
 		if ( ! isNaN( tileAvailabilityHeader.bitstream ) ) {
@@ -224,14 +199,12 @@ export class SUBTREELoader extends LoaderBase {
 			header = bufferViewHeaders[ tileAvailabilityHeader.bufferView ];
 
 		}
-
 		if ( header ) {
 
 			header.isActive = true;
 			header.bufferHeader.isActive = true;
 
 		}
-
 		const contentAvailabilityHeaders = subtreeJson.contentAvailabilityHeaders;
 		for ( let i = 0; i < contentAvailabilityHeaders.length; i ++ ) {
 
@@ -273,7 +246,6 @@ export class SUBTREELoader extends LoaderBase {
 
 	}
 
-
 	/**
 	 * Go through the list of buffers and gather all the active ones into
 	 * a dictionary.
@@ -291,25 +263,47 @@ export class SUBTREELoader extends LoaderBase {
 	 * @returns {object} buffersU8 A dictionary of buffer index to a Uint8Array of its contents.
 	 * @private
 	 */
-	requestActiveBuffers( bufferHeaders, internalBuffer ) {
+	async requestActiveBuffers( bufferHeaders, internalBuffer ) {
 
-		const bufferResults = [];
+		const promises = [];
 		for ( let i = 0; i < bufferHeaders.length; i ++ ) {
 
 			const bufferHeader = bufferHeaders[ i ];
-			//  TODO load external buffer (when isExternal == true)
-			if ( ! bufferHeader.isActive || bufferHeader.isExternal ) {
+			// If the buffer is not active, resolve with undefined.
+			if ( ! bufferHeader.isActive ) {
 
-				bufferResults.push( undefined );
+				promises.push( Promise.resolve( undefined ) );
+
+			} else if ( bufferHeader.isExternal ) {
+
+				// Load external buffer via its URI. Adjust URI.
+				promises.push(
+					fetch( this.parseImplicitURIBuffer( this.tile, this.rootTile.implicitTiling.subtrees.uri, bufferHeader.uri ) )
+						.then( response => {
+
+							if ( ! response.ok ) {
+
+								throw new Error( `Failed to load external buffer from ${bufferHeader.uri}` );
+
+							}
+							return response.arrayBuffer();
+
+						} )
+						.then( arrayBuffer => {
+
+							return new Uint8Array( arrayBuffer );
+
+						} )
+				);
 
 			} else {
 
-				bufferResults.push( internalBuffer );
+				promises.push( Promise.resolve( new Uint8Array( internalBuffer ) ) );
 
 			}
 
 		}
-
+		const bufferResults = await Promise.all( promises );
 		const buffersU8 = {};
 		for ( let i = 0; i < bufferResults.length; i ++ ) {
 
@@ -340,7 +334,7 @@ export class SUBTREELoader extends LoaderBase {
 		for ( let i = 0; i < bufferViewHeaders.length; i ++ ) {
 
 			const bufferViewHeader = bufferViewHeaders[ i ];
-			if ( ! bufferViewHeader.isActive || bufferViewHeader.isExternal ) {
+			if ( ! bufferViewHeader.isActive ) {
 
 				continue;
 
@@ -389,10 +383,9 @@ export class SUBTREELoader extends LoaderBase {
 
 	}
 
-
 	/**
-	 * A buffer header is the JSON header from the subtree JSON chunk plus
-	 * the isActive flag and a reference to the header for the underlying buffer
+	 * A buffer view header is the JSON header from the subtree JSON chunk plus
+	 * the isActive flag and a reference to the header for the underlying buffer.
 	 *
 	 * @typedef {object} BufferViewHeader
 	 * @property {BufferHeader} bufferHeader A reference to the header for the underlying buffer
@@ -405,11 +398,11 @@ export class SUBTREELoader extends LoaderBase {
 
 	/**
 	 * Iterate the list of buffer views from the subtree JSON and add the
-	 * isActive flag. Also save a reference to the bufferHeader
+	 * isActive flag. Also save a reference to the bufferHeader.
 	 *
-	 * @param {Object[]} [bufferViewHeaders=[]] The JSON from subtree.bufferViews
-	 * @param {BufferHeader[]} bufferHeaders The preprocessed buffer headers
-	 * @returns {BufferViewHeader[]} The same array of bufferView headers with additional fields
+	 * @param {Object[]} [bufferViewHeaders=[]] The JSON from subtree.bufferViews.
+	 * @param {BufferHeader[]} bufferHeaders The preprocessed buffer headers.
+	 * @returns {BufferViewHeader[]} The same array of bufferView headers with additional fields.
 	 * @private
 	 */
 	preprocessBufferViews( bufferViewHeaders = [], bufferHeaders ) {
@@ -419,6 +412,7 @@ export class SUBTREELoader extends LoaderBase {
 			const bufferViewHeader = bufferViewHeaders[ i ];
 			bufferViewHeader.bufferHeader = bufferHeaders[ bufferViewHeader.buffer ];
 			bufferViewHeader.isActive = false;
+			// Keep the external flag for potential use in requestActiveBuffers
 			bufferViewHeader.isExternal = bufferViewHeader.bufferHeader.isExternal;
 
 		}
@@ -426,33 +420,26 @@ export class SUBTREELoader extends LoaderBase {
 
 	}
 
-
 	/**
-	 * Parse the three availability bitstreams and store them in the subtree
+	 * Parse the three availability bitstreams and store them in the subtree.
 	 *
-	 * @param {Subtree} subtree The subtree to modify
-	 * @param {Object} subtreeJson The subtree JSON
+	 * @param {Subtree} subtree The subtree to modify.
+	 * @param {Object} subtreeJson The subtree JSON.
 	 * @param {Object} bufferViewsU8 A dictionary of buffer view index to a Uint8Array of its contents.
 	 * @private
 	 */
-	parseAvailability(
-		subtree,
-		subtreeJson,
-		bufferViewsU8
-	) {
+	parseAvailability( subtree, subtreeJson, bufferViewsU8 ) {
 
 		const branchingFactor = getBoundsDivider( this.rootTile );
 		const subtreeLevels = this.rootTile.implicitTiling.subtreeLevels;
 		const tileAvailabilityBits =
 			( Math.pow( branchingFactor, subtreeLevels ) - 1 ) / ( branchingFactor - 1 );
 		const childSubtreeBits = Math.pow( branchingFactor, subtreeLevels );
-
 		subtree._tileAvailability = this.parseAvailabilityBitstream(
 			subtreeJson.tileAvailability,
 			bufferViewsU8,
 			tileAvailabilityBits
 		);
-
 		subtree._contentAvailabilityBitstreams = [];
 		for ( let i = 0; i < subtreeJson.contentAvailabilityHeaders.length; i ++ ) {
 
@@ -465,7 +452,6 @@ export class SUBTREELoader extends LoaderBase {
 			subtree._contentAvailabilityBitstreams.push( bitstream );
 
 		}
-
 		subtree._childSubtreeAvailability = this.parseAvailabilityBitstream(
 			subtreeJson.childSubtreeAvailability,
 			bufferViewsU8,
@@ -475,24 +461,13 @@ export class SUBTREELoader extends LoaderBase {
 	}
 
 	/**
-	 * A helper object for storing the two parts of the subtree binary
-	 *
-	 * @typedef {object} ParsedBitstream
-	 * @property {Boolean} constant
-	 * @property {ArrayBuffer} bitstream
-	 * @property {number} lengthBits The length of the availability bitstream in bits
-	 * @private
-	 */
-
-
-	/**
 	 * Given the JSON describing an availability bitstream, turn it into an
 	 * in-memory representation using an object. This handles bitstreams from a bufferView.
 	 *
-	 * @param {Object} availabilityJson A JSON object representing the availability
-	 * @param {Object} bufferViewsU8 A dictionary of bufferView index to its Uint8Array contents.
-	 * @param {number} lengthBits The length of the availability bitstream in bits
-	 * @returns {ParsedBitstream}
+	 * @param {Object} availabilityJson A JSON object representing the availability.
+	 * @param {Object} bufferViewsU8 A dictionary of buffer view index to its Uint8Array contents.
+	 * @param {number} lengthBits The length of the availability bitstream in bits.
+	 * @returns {object}
 	 * @private
 	 */
 	parseAvailabilityBitstream(
@@ -512,7 +487,6 @@ export class SUBTREELoader extends LoaderBase {
 		let bufferView;
 		// Check for bitstream first, which is part of the current schema.
 		// bufferView is the name of the bitstream from an older schema.
-
 		if ( ! isNaN( availabilityJson.bitstream ) ) {
 
 			bufferView = bufferViewsU8[ availabilityJson.bitstream ];
@@ -529,45 +503,40 @@ export class SUBTREELoader extends LoaderBase {
 
 	}
 
-
 	/**
 	 * Expand a single subtree tile. This transcodes the subtree into
 	 * a tree of {@link SubtreeTile}. The root of this tree is stored in
 	 * the placeholder tile's children array. This method also creates
 	 * tiles for the child subtrees to be lazily expanded as needed.
 	 *
-	 * @param {Object | SubtreeTile} subtreeRoot The first node of the subtree
-	 * @param {Subtree} subtree The parsed subtree
+	 * @param {Object | SubtreeTile} subtreeRoot The first node of the subtree.
+	 * @param {Subtree} subtree The parsed subtree.
 	 * @private
 	 */
 	expandSubtree( subtreeRoot, subtree ) {
 
 		// TODO If multiple contents were supported then this tile could contain both renderable and un renderable content.
 		const contentTile = SubtreeTile.copy( subtreeRoot );
-
 		// If the subtree root tile has content, then create a placeholder child with cloned parameters
 		// Todo Multiple contents not handled, keep the first content found
 		for ( let i = 0; subtree && i < subtree._contentAvailabilityBitstreams.length; i ++ ) {
 
 			if ( subtree && this.getBit( subtree._contentAvailabilityBitstreams[ i ], 0 ) ) {
 
-				// Create a child holding the content uri, this child is similar to its parent and doesn't have any children
+				// Create a child holding the content uri, this child is similar to its parent and doesn't have any children.
 				contentTile.content = { uri: this.parseImplicitURI( subtreeRoot, this.rootTile.content.uri ) };
 				break;
 
 			}
 
 		}
-
 		subtreeRoot.children.push( contentTile );
-
-		// Creating each leaf inside the current subtree
+		// Creating each leaf inside the current subtree.
 		const bottomRow = this.transcodeSubtreeTiles(
 			contentTile,
 			subtree
 		);
-
-		// For each child subtree, create a tile containing the uri of the next subtree to fetch
+		// For each child subtree, create a tile containing the uri of the next subtree to fetch.
 		const childSubtrees = this.listChildSubtrees( subtree, bottomRow );
 		for ( let i = 0; i < childSubtrees.length; i ++ ) {
 
@@ -579,7 +548,7 @@ export class SUBTREELoader extends LoaderBase {
 				null,
 				subtreeLocator.childMortonIndex
 			);
-			// Assign subtree uri as content
+			// Assign subtree uri as content.
 			subtreeTile.content = { uri: this.parseImplicitURI( subtreeTile, this.rootTile.implicitTiling.subtrees.uri ) };
 			leafTile.children.push( subtreeTile );
 
@@ -589,46 +558,39 @@ export class SUBTREELoader extends LoaderBase {
 
 	/**
 	 * Transcode the implicitly defined tiles within this subtree and generate
-	 * explicit {@link SubtreeTile} objects. This function only transcode tiles,
+	 * explicit {@link SubtreeTile} objects. This function only transcodes tiles,
 	 * child subtrees are handled separately.
 	 *
-	 * @param {Object | SubtreeTile} subtreeRoot The root of the current subtree
-	 * @param {Subtree} subtree The subtree to get availability information
-	 * @returns {Array} The bottom row of transcoded tiles. This is helpful for processing child subtrees
+	 * @param {Object | SubtreeTile} subtreeRoot The root of the current subtree.
+	 * @param {Subtree} subtree The subtree to get availability information.
+	 * @returns {Array} The bottom row of transcoded tiles. This is helpful for processing child subtrees.
 	 * @private
 	 */
 	transcodeSubtreeTiles( subtreeRoot, subtree ) {
 
 		// Sliding window over the levels of the tree.
-		// Each row is branchingFactor * length of previous row
+		// Each row is branchingFactor * length of previous row.
 		// Tiles within a row are ordered by Morton index.
 		let parentRow = [ subtreeRoot ];
 		let currentRow = [];
-
 		for ( let level = 1; level < this.rootTile.implicitTiling.subtreeLevels; level ++ ) {
 
 			const branchingFactor = getBoundsDivider( this.rootTile );
 			const levelOffset = ( Math.pow( branchingFactor, level ) - 1 ) / ( branchingFactor - 1 );
 			const numberOfChildren = branchingFactor * parentRow.length;
-			for (
-				let childMortonIndex = 0;
-				childMortonIndex < numberOfChildren;
-				childMortonIndex ++
-			) {
+			for ( let childMortonIndex = 0; childMortonIndex < numberOfChildren; childMortonIndex ++ ) {
 
 				const childBitIndex = levelOffset + childMortonIndex;
 				const parentMortonIndex = childMortonIndex >> Math.log2( branchingFactor );
 				const parentTile = parentRow[ parentMortonIndex ];
-
-				// Check if tile is available
+				// Check if tile is available.
 				if ( ! this.getBit( subtree._tileAvailability, childBitIndex ) ) {
 
 					currentRow.push( undefined );
 					continue;
 
 				}
-
-				// Create a tile and add it as a child
+				// Create a tile and add it as a child.
 				const childTile = this.deriveChildTile(
 					subtree,
 					parentTile,
@@ -654,10 +616,10 @@ export class SUBTREELoader extends LoaderBase {
 	 * This creates a real tile for rendering.
 	 * </p>
 	 *
-	 * @param {Subtree} subtree The subtree the child tile belongs to
-	 * @param {Object | SubtreeTile} parentTile The parent of the new child tile
+	 * @param {Subtree} subtree The subtree the child tile belongs to.
+	 * @param {Object | SubtreeTile} parentTile The parent of the new child tile.
 	 * @param {number} childBitIndex The index of the child tile within the tile's availability information.
-	 * @param {number} childMortonIndex The morton index of the child tile relative to its parent
+	 * @param {number} childMortonIndex The morton index of the child tile relative to its parent.
 	 * @returns {SubtreeTile} The new child tile.
 	 * @private
 	 */
@@ -671,8 +633,7 @@ export class SUBTREELoader extends LoaderBase {
 		const subtreeTile = new SubtreeTile( parentTile, childMortonIndex );
 		subtreeTile.boundingVolume = this.getTileBoundingVolume( subtreeTile );
 		subtreeTile.geometricError = this.getGeometricError( subtreeTile );
-
-		// Todo Multiple contents not handled, keep the first found content
+		// Todo Multiple contents not handled, keep the first found content.
 		for ( let i = 0; subtree && i < subtree._contentAvailabilityBitstreams.length; i ++ ) {
 
 			if ( subtree && this.getBit( subtree._contentAvailabilityBitstreams[ i ], childBitIndex ) ) {
@@ -687,14 +648,13 @@ export class SUBTREELoader extends LoaderBase {
 
 	}
 
-
 	/**
 	 * Get a bit from the bitstream as a Boolean. If the bitstream
 	 * is a constant, the constant value is returned instead.
 	 *
 	 * @param {ParsedBitstream} object
 	 * @param {number} index The integer index of the bit.
-	 * @returns {boolean} The value of the bit
+	 * @returns {boolean} The value of the bit.
 	 * @private
 	 */
 	getBit( object, index ) {
@@ -722,7 +682,7 @@ export class SUBTREELoader extends LoaderBase {
 	 * the actual bounding volumes should not be computed progressively by subdividing a non-root tile volume.
 	 * Instead, the exact bounding volumes are computed directly for a given level.
 	 * @param {Object | SubtreeTile} tile
-	 * @return {Object} object containing the bounding volume
+	 * @return {Object} object containing the bounding volume.
 	 */
 	getTileBoundingVolume( tile ) {
 
@@ -740,7 +700,6 @@ export class SUBTREELoader extends LoaderBase {
 			region[ 2 ] = minX + sizeX * ( tile.__x + 1 );	//east
 			region[ 1 ] = minY + sizeY * tile.__y;	//south
 			region[ 3 ] = minY + sizeY * ( tile.__y + 1 );	//north
-
 			for ( let k = 0; k < 4; k ++ ) {
 
 				const coord = region[ k ];
@@ -755,49 +714,39 @@ export class SUBTREELoader extends LoaderBase {
 				}
 
 			}
-
 			//Also divide the height in the case of octree.
 			if ( isOctreeSubdivision( tile ) ) {
 
 				const minZ = region[ 4 ];
 				const maxZ = region[ 5 ];
-
 				const sizeZ = ( maxZ - minZ ) / Math.pow( 2, tile.__level );
-
 				region[ 4 ] = minZ + sizeZ * tile.__z;	//minimum height
-				region[ 5 ] = minZ + sizeZ * ( tile.__z + 1 );	// maximum height
+				region[ 5 ] = minZ + sizeZ * ( tile.__z + 1 );	//maximum height
 
 			}
-
 			boundingVolume.region = region;
 
 		}
-
 		if ( this.rootTile.boundingVolume.box ) {
 
 			// 0-2: center of the box
 			// 3-5: x axis direction and half length
 			// 6-8: y axis direction and half length
 			// 9-11: z axis direction and half length
-
 			const box = [ ...this.rootTile.boundingVolume.box ];
 			const cellSteps = 2 ** tile.__level - 1;
 			const scale = Math.pow( 2, - tile.__level );
 			const axisNumber = isOctreeSubdivision( tile ) ? 3 : 2;
-
-
 			for ( let i = 0; i < axisNumber; i ++ ) {
 
 				// scale the bounds axes
 				box[ 3 + i * 3 + 0 ] *= scale;
 				box[ 3 + i * 3 + 1 ] *= scale;
 				box[ 3 + i * 3 + 2 ] *= scale;
-
 				// axis vector
 				const x = box[ 3 + i * 3 + 0 ];
 				const y = box[ 3 + i * 3 + 1 ];
 				const z = box[ 3 + i * 3 + 2 ];
-
 				// adjust the center by the x, y and z axes
 				const axisOffset = i === 0 ? tile.__x : ( i === 1 ? tile.__y : tile.__z );
 				box[ 0 ] += 2 * x * ( - 0.5 * cellSteps + axisOffset );
@@ -805,17 +754,15 @@ export class SUBTREELoader extends LoaderBase {
 				box[ 2 ] += 2 * z * ( - 0.5 * cellSteps + axisOffset );
 
 			}
-
 			boundingVolume.box = box;
 
 		}
-
 		return boundingVolume;
 
 	}
 
 	/**
-	 * Each child’s geometricError is half of its parent’s geometricError
+	 * Each child’s geometricError is half of its parent’s geometricError.
 	 * @param {Object | SubtreeTile} tile
 	 * @return {number}
 	 */
@@ -825,12 +772,11 @@ export class SUBTREELoader extends LoaderBase {
 
 	}
 
-
 	/**
-	 * Determine what child subtrees exist and return a list of information
+	 * Determine what child subtrees exist and return a list of information.
 	 *
-	 * @param {Object} subtree The subtree for looking up availability
-	 * @param {Array} bottomRow The bottom row of tiles in a transcoded subtree
+	 * @param {Object} subtree The subtree for looking up availability.
+	 * @param {Array} bottomRow The bottom row of tiles in a transcoded subtree.
 	 * @returns {[]} A list of identifiers for the child subtrees.
 	 * @private
 	 */
@@ -864,8 +810,19 @@ export class SUBTREELoader extends LoaderBase {
 		return results;
 
 	}
-
-
+	/**
+	 * Replaces placeholder tokens in a URI template with the corresponding tile properties.
+	 *
+	 * The URI template should contain the tokens:
+	 * - `{level}` for the tile's subdivision level.
+	 * - `{x}` for the tile's x-coordinate.
+	 * - `{y}` for the tile's y-coordinate.
+	 * - `{z}` for the tile's z-coordinate.
+	 *
+	 * @param {Object} tile - The tile object containing properties __level, __x, __y, and __z.
+	 * @param {string} uri - The URI template string with placeholders.
+	 * @returns {string} The URI with placeholders replaced by the tile's properties.
+	 */
 	parseImplicitURI( tile, uri ) {
 
 		uri = uri.replace( '{level}', tile.__level );
@@ -873,6 +830,37 @@ export class SUBTREELoader extends LoaderBase {
 		uri = uri.replace( '{y}', tile.__y );
 		uri = uri.replace( '{z}', tile.__z );
 		return uri;
+
+	}
+
+	/**
+	 * Generates the full external buffer URI for a tile by combining an implicit URI with a buffer URI.
+	 *
+	 * First, it parses the implicit URI using the tile properties and the provided template. Then, it creates a new URL
+	 * relative to the tile's base path, removes the last path segment, and appends the buffer URI.
+	 *
+	 * @param {Object} tile - The tile object that contains properties:
+	 *   - __level: the subdivision level,
+	 *   - __x, __y, __z: the tile coordinates,
+	 *   - __basePath: the base path for the external resources.
+	 * @param {string} uri - The URI template string with placeholders for the tile (e.g., `{level}`, `{x}`, `{y}`, `{z}`).
+	 * @param {string} bufUri - The buffer file name to append (e.g., "0_1.bin").
+	 * @returns {string} The full external buffer URI.
+	 */
+	parseImplicitURIBuffer( tile, uri, bufUri ) {
+
+		// Generate the base URI by replacing placeholders
+		const subUri = this.parseImplicitURI( tile, uri );
+
+		// Create a URL object relative to the tile's base path
+		const url = new URL( subUri, tile.__basePath + '/' );
+
+		// Remove the last path segment
+		url.pathname = url.pathname.substring( 0, url.pathname.lastIndexOf( '/' ) );
+
+		// Construct the final URL with the buffer URI appended
+		return new URL( url.pathname + '/' + bufUri, tile.__basePath + '/' ).toString();
+
 
 	}
 


### PR DESCRIPTION
Fix #844
Fix #1032

**SUPPORT** correctly the external buffer presents in the subtree.
The support of an external buffer (.bin) is not done yet https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/608#issuecomment-2283364305 .

@gkjohnson it doesn't seem that hard to implement BUT I don't really know how the manage the cache once the buffer has been uploaded.

In Cesium:
The presence of an external buffer is checked here:
https://github.com/CesiumGS/cesium/blob/466f780f3a50d6edd17b1f27e1cde5f86ce10128/packages/engine/Source/Scene/ImplicitSubtree.js#L700

And loaded here
https://github.com/CesiumGS/cesium/blob/466f780f3a50d6edd17b1f27e1cde5f86ce10128/packages/engine/Source/Scene/ImplicitSubtree.js#L719

How could we do something similar to cache the incoming buffer ?

