### PR TITLE
gltf-plugin: null check for subclasses of PropertySetAccessor

### DIFF
--- a/src/plugins/three/gltf/metadata/classes/PropertyAttributeAccessor.js
+++ b/src/plugins/three/gltf/metadata/classes/PropertyAttributeAccessor.js
@@ -8,7 +8,7 @@ class PropertyAttributeClassProperty extends ClassProperty {
 
 		super( enums, classProperty, attributeProperty );
 
-		this.attribute = attributeProperty.attribute;
+		this.attribute = attributeProperty?.attribute;
 
 	}
 

--- a/src/plugins/three/gltf/metadata/classes/PropertyAttributeAccessor.js
+++ b/src/plugins/three/gltf/metadata/classes/PropertyAttributeAccessor.js
@@ -8,7 +8,7 @@ class PropertyAttributeClassProperty extends ClassProperty {
 
 		super( enums, classProperty, attributeProperty );
 
-		this.attribute = attributeProperty?.attribute;
+		this.attribute = attributeProperty?.attribute ?? null;
 
 	}
 

--- a/src/plugins/three/gltf/metadata/classes/PropertyTableAccessor.js
+++ b/src/plugins/three/gltf/metadata/classes/PropertyTableAccessor.js
@@ -15,7 +15,7 @@ class PropertyTableClassProperty extends ClassProperty {
 
 		super( enums, classProperty, tableProperty );
 
-		this.values = tableProperty?.values;
+		this.values = tableProperty?.values ?? null;
 		this.valueLength = typeToComponentCount( this.type );
 		this.arrayOffsets = getField( tableProperty, 'arrayOffsets', null );
 		this.stringOffsets = getField( tableProperty, 'stringOffsets', null );

--- a/src/plugins/three/gltf/metadata/classes/PropertyTableAccessor.js
+++ b/src/plugins/three/gltf/metadata/classes/PropertyTableAccessor.js
@@ -15,7 +15,7 @@ class PropertyTableClassProperty extends ClassProperty {
 
 		super( enums, classProperty, tableProperty );
 
-		this.values = tableProperty.values;
+		this.values = tableProperty?.values;
 		this.valueLength = typeToComponentCount( this.type );
 		this.arrayOffsets = getField( tableProperty, 'arrayOffsets', null );
 		this.stringOffsets = getField( tableProperty, 'stringOffsets', null );


### PR DESCRIPTION
Not all of the properties of a class in schema will appear in it‘s instances.