### PR TITLE
Allow plugins to set inView to false in calculateTileViewError

### DIFF
--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -970,9 +970,9 @@ export class TilesRenderer extends TilesRendererBase {
 			if ( plugin !== this && plugin.calculateTileViewError ) {
 
 				plugin.calculateTileViewError( tile, viewErrorTarget );
-				if ( viewErrorTarget.inView ) {
+				if ( viewErrorTarget.inView || viewErrorTarget.inView === false) {
 
-					inView = true;
+					inView = viewErrorTarget.inView;
 					inViewError = Math.max( inViewError, viewErrorTarget.error );
 
 				}

--- a/src/three/TilesRenderer.js
+++ b/src/three/TilesRenderer.js
@@ -970,7 +970,8 @@ export class TilesRenderer extends TilesRendererBase {
 			if ( plugin !== this && plugin.calculateTileViewError ) {
 
 				plugin.calculateTileViewError( tile, viewErrorTarget );
-				if ( viewErrorTarget.inView || viewErrorTarget.inView === false) {
+				// allow false to pass
+				if ( viewErrorTarget.inView || viewErrorTarget.inView === false ) {
 
 					inView = viewErrorTarget.inView;
 					inViewError = Math.max( inViewError, viewErrorTarget.error );


### PR DESCRIPTION
Based on [this](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/master/src/three/TilesRenderer.js#L973C5-L978C6):
```
if ( viewErrorTarget.inView ) {

	inView = true;
	inViewError = Math.max( inViewError, viewErrorTarget.error );

}
```

It's not possible for any plugin to set `inView` to false if it was previously set to `true` by the camera frustum check in the base `calculateTileViewError` function in `TilesRenderer`. 

It's not clear to me how the example for the `LoadRegionPlugin` actually works because of this flaw, is it running on older code? https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/master/example/loadRegion.js

When running locally, `LoadRegionPlugin` does not work, nor does my own plugin that serves a similar function, _until_ I make the change from this PR, then they both work.
