### PR TITLE
GlobeControls: make adjusting camera clipping planes optional

### DIFF
--- a/src/three/controls/GlobeControls.d.ts
+++ b/src/three/controls/GlobeControls.d.ts
@@ -9,6 +9,8 @@ export class GlobeControls extends EnvironmentControls {
 	nearMargin: number;
 	farMargin: number;
 
+	adjustCameraAutomatically: boolean;
+
 	get ellipsoid(): Ellipsoid;
 	get tilesGroup(): Group;
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -57,6 +57,7 @@ export class GlobeControls extends EnvironmentControls {
 		this.farMargin = 0;
 		this.useFallbackPlane = false;
 		this.reorientOnDrag = false;
+		this.adjustCameraAutomatically = true;
 
 		this.globeInertia = new Quaternion();
 		this.globeInertiaFactor = 0;
@@ -189,8 +190,10 @@ export class GlobeControls extends EnvironmentControls {
 		// fire basic controls update
 		super.update( deltaTime );
 
-		// update the camera planes and the ortho camera position
-		this.adjustCamera( camera );
+		if (this.adjustCameraAutomatically) {
+			// update the camera planes and the ortho camera position
+			this.adjustCamera( camera );
+		}
 
 	}
 


### PR DESCRIPTION
Whenever you want to display a globe tileset and additional objects around it, you might want to disable automatic adjustment of camera clipping planes by `GlobeControls`, so that objects far above the globe's surface can be seen.