### PR TITLE
Add missing headers to subtree fetch

### DIFF
--- a/src/plugins/base/ImplicitTilingPlugin.js
+++ b/src/plugins/base/ImplicitTilingPlugin.js
@@ -47,6 +47,7 @@ export class ImplicitTilingPlugin {
 
 			const loader = new SUBTREELoader( tile );
 			loader.workingPath = tile.__basePath;
+			loader.fetchOptions = this.tiles.fetchOptions
 			return loader.parse( buffer );
 
 		}

--- a/src/plugins/base/SUBTREELoader.js
+++ b/src/plugins/base/SUBTREELoader.js
@@ -284,7 +284,7 @@ export class SUBTREELoader extends LoaderBase {
 					bufferHeader.uri
 				);
 
-				const fetchPromise = fetch( url )
+				const fetchPromise = fetch( url, this.fetchOptions )
 					.then( response => {
 
 						if ( ! response.ok ) {


### PR DESCRIPTION
### Changes
Just grabs the fetchOptions from the tiles renderer and gives it to the subtree loader so it can be used for fetching subtree files.