### PR TITLE
Add topographic line, cartographic line material

### DIFF
--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -25,6 +25,7 @@ import {
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import Stats from 'three/examples/jsm/libs/stats.module.js';
+import { TopoLinesPlugin } from './src/plugins/topolines/TopoLinesPlugin.js';
 
 let controls, scene, renderer, tiles, transition;
 let statsContainer, stats;
@@ -36,6 +37,7 @@ const params = {
 	enableCacheDisplay: false,
 	enableRendererStats: false,
 	useBatchedMesh: Boolean( new URLSearchParams( window.location.hash.replace( /^#/, '' ) ).get( 'batched' ) ),
+	displayTopoLines: false,
 	errorTarget: 40,
 
 	reload: reinstantiateTiles,
@@ -61,6 +63,7 @@ function reinstantiateTiles() {
 	tiles.registerPlugin( new UpdateOnChangePlugin() );
 	tiles.registerPlugin( new UnloadTilesPlugin() );
 	tiles.registerPlugin( new TilesFadePlugin() );
+	tiles.registerPlugin( new TopoLinesPlugin( { projection: 'ellipsoid' } ) );
 	tiles.registerPlugin( new GLTFExtensionsPlugin( {
 		// Note the DRACO compression files need to be supplied via an explicit source.
 		// We use unpkg here but in practice should be provided by the application.
@@ -156,6 +159,7 @@ function init() {
 	mapsOptions.add( params, 'reload' );
 
 	const exampleOptions = gui.addFolder( 'Example Options' );
+	exampleOptions.add( params, 'displayTopoLines' ).listen();
 	exampleOptions.add( params, 'enableCacheDisplay' );
 	exampleOptions.add( params, 'enableRendererStats' );
 	exampleOptions.add( params, 'errorTarget', 5, 100, 1 ).onChange( () => {
@@ -314,6 +318,10 @@ function animate() {
 	const camera = transition.camera;
 	tiles.setResolutionFromRenderer( camera, renderer );
 	tiles.setCamera( camera );
+
+	const plugin = tiles.getPluginByName( 'TOPO_LINES_PLUGIN' );
+	plugin.topoOpacity = params.displayTopoLines ? 0.5 : 0;
+	plugin.cartoOpacity = params.displayTopoLines ? 0.5 : 0;
 
 	// update tiles
 	camera.updateMatrixWorld();

--- a/example/mars.js
+++ b/example/mars.js
@@ -10,6 +10,7 @@ import {
 	FogExp2,
 } from 'three';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import { TopoLinesPlugin } from './src/plugins/topolines/TopoLinesPlugin.js';
 
 let camera, controls, scene, renderer;
 let groundTiles, skyTiles;
@@ -18,6 +19,7 @@ const params = {
 
 	errorTarget: 12,
 	displayBoxBounds: false,
+	displayTopoLines: false,
 	fog: false,
 
 };
@@ -47,6 +49,7 @@ function init() {
 	controls = new EnvironmentControls( scene, camera, renderer.domElement );
 	controls.minZoomDistance = 2;
 	controls.cameraRadius = 1;
+	controls.enableDamping = true;
 
 	// lights
 	const dirLight = new DirectionalLight( 0xffffff );
@@ -62,6 +65,7 @@ function init() {
 
 	groundTiles = new TilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize_tileset.json' );
 	groundTiles.registerPlugin( new DebugTilesPlugin() );
+	groundTiles.registerPlugin( new TopoLinesPlugin() );
 	groundTiles.fetchOptions.mode = 'cors';
 	groundTiles.lruCache.minSize = 900;
 	groundTiles.lruCache.maxSize = 1300;
@@ -85,6 +89,7 @@ function init() {
 	} );
 
 	gui.add( params, 'displayBoxBounds' );
+	gui.add( params, 'displayTopoLines' );
 	gui.add( params, 'errorTarget', 0, 100 );
 	gui.open();
 
@@ -109,6 +114,8 @@ function render() {
 	groundTiles.errorTarget = params.errorTarget;
 	groundTiles.getPluginByName( 'DEBUG_TILES_PLUGIN' ).displayBoxBounds = params.displayBoxBounds;
 	skyTiles.getPluginByName( 'DEBUG_TILES_PLUGIN' ).displayBoxBounds = params.displayBoxBounds;
+
+	groundTiles.getPluginByName( 'TOPO_LINES_PLUGIN' ).topoOpacity = params.displayTopoLines ? 0.5 : 0;
 
 	groundTiles.setCamera( camera );
 	groundTiles.setResolutionFromRenderer( camera, renderer );

--- a/example/src/plugins/topolines/TopoLineMaterialMixin.js
+++ b/example/src/plugins/topolines/TopoLineMaterialMixin.js
@@ -150,12 +150,6 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 		USE_TOPO_LINES: 1,
 	};
 
-	// material.customProgramCacheKey = () => {
-
-	// 	return JSON.stringify( material.defines );
-
-	// };
-
 	material.onBeforeCompile = shader => {
 
 		addWorldPosition( shader );
@@ -247,14 +241,15 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 
 					// get the height value to use for topo lines
 					vec3 pos;
-					#if USE_ELLIPSOID
+					#if USE_TOPO_ELLIPSOID
 
 
 						pos = getPositionToCartographic( ellipsoid, localPos );
 						pos.xy *= 180.0 / PI;
-						// pos.xy += 180.0;
+						pos.x += 180.0;
 						// pos.xy *= 10.0;
-						pos.xy *= 100.0;
+						pos.xy *= 1000.0;
+						// pos.x += 1e-1;
 						// diffuseColor.rgb = vec3(pos.z * 0.0001, 0, 0);
 
 					#else
@@ -282,9 +277,9 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 					// blend the small and large topo lines
 					vec3 topo = mix( mult1 * topo1, mult0 * topo0, topoAlpha );
 
-					// diffuseColor.rgb = vec3( topo.y * topoOpacity );
-					// diffuseColor.rgb = mix( diffuseColor.rgb, topoColor, topo.y * topoOpacity );
-					diffuseColor.rgb = vec3( topo.z * topoOpacity );
+					// blend with th base color
+					diffuseColor.rgb = mix( diffuseColor.rgb, cartoColor, max( topo.x * cartoOpacity, topo.y * cartoOpacity ) );
+					diffuseColor.rgb = mix( diffuseColor.rgb, topoColor, topo.z * topoOpacity * 0.0 );
 
 				}
 				#endif

--- a/example/src/plugins/topolines/TopoLineMaterialMixin.js
+++ b/example/src/plugins/topolines/TopoLineMaterialMixin.js
@@ -10,7 +10,7 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 		frame: { value: new Matrix4() },
 
 		topoLineColor: { value: new Color() },
-		topoOpacity: { value: 1.0 },
+		topoOpacity: { value: 0.5 },
 		topoLimits: { value: new Vector2( 0, 1e10 ) },
 
 		cartoLineColor: { value: new Color() },
@@ -78,7 +78,7 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 					lineIndex = step( lineIndex, topoStep * 0.5 );
 
 					// calculate the topography lines
-					float thickness = lineIndex == 0.0 ? 1.0 : 2.0;
+					float thickness = lineIndex == 0.0 ? 1.0 : 1.5;
 					float stride = 2.0 * abs( mod( value + halfTopoStep, topoStep ) - halfTopoStep );
 					float topo = smoothstep( yPosDelta * 0.5, yPosDelta * - 0.5, stride - yPosDelta * thickness );
 
@@ -134,7 +134,7 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 					// TODO: tune this - perhaps a different scaling mechanism is needed rather than log so
 					// the distances align more as anticipated
 					float topoBoundary = ( - 2.0 + 0.75 * log10( 0.25 * screenChange ) );
-					float topoAlpha = smoothstep( 1.0, 0.7, mod( topoBoundary, 1.0 ) );
+					float topoAlpha = smoothstep( 1.0, 0.5, mod( topoBoundary, 1.0 ) );
 
 					float topoStep = pow( 10.0, ceil( topoBoundary ) );
 					float topo0 = calculateTopoLines( wPosition.y, yPosDelta, topoStep );

--- a/example/src/plugins/topolines/TopoLineMaterialMixin.js
+++ b/example/src/plugins/topolines/TopoLineMaterialMixin.js
@@ -1,6 +1,6 @@
 // Adjusts the provided material to support fading in and out using a bayer pattern. Providing a "previous"
 
-import { Color, Matrix4, Vector3 } from 'three';
+import { Color, Matrix4, Vector2, Vector3 } from 'three';
 
 // before compile can be used to chain shader adjustments. Returns the added uniforms used for fading.
 export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
@@ -10,7 +10,13 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 		frame: { value: new Matrix4() },
 
 		topoLineColor: { value: new Color() },
+		topoOpacity: { value: 1.0 },
+		topoLimits: { value: new Vector2( 0, 1e10 ) },
+
 		cartoLineColor: { value: new Color() },
+		cartoOpacity: { value: 0.5 },
+		cartoLimits: { value: new Vector2( 0, 1e10 ) },
+
 	};
 
 	material.version = 300;
@@ -51,11 +57,45 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 				uniform mat4 frame;
 
 				uniform vec3 topoLineColor;
+				uniform float topoOpacity;
+
 				uniform vec3 cartoLineColor;
+				uniform float cartoOpacity;
+
+				uniform mat4 projectionMatrix;
 
 				float log10( float v ) {
 
 					return log( v ) / log( 10.0 );
+
+				}
+
+				float calculateTopoLines( float value, float yPosDelta, float topoStep ) {
+
+					float halfTopoStep = topoStep * 0.5;
+					float lineIndex = mod( value, topoStep * 10.0 );
+					lineIndex = abs( lineIndex );
+					lineIndex = step( lineIndex, topoStep * 0.5 );
+
+					// calculate the topography lines
+					float thickness = lineIndex == 0.0 ? 1.0 : 2.0;
+					float stride = 2.0 * abs( mod( value + halfTopoStep, topoStep ) - halfTopoStep );
+					float topo = smoothstep( yPosDelta * 0.5, yPosDelta * - 0.5, stride - yPosDelta * thickness );
+
+					// handle steep surfaces that cover multiple bands
+					float subPixelColor = yPosDelta / topoStep;
+					float subPixelAlpha = smoothstep( 0.4 * topoStep, 0.5 * topoStep, yPosDelta );
+					float fadedTopo = mix( topo, topoStep / yPosDelta * 0.2, subPixelAlpha );
+
+					return lineIndex == 0.0 ? 0.5 * fadedTopo : fadedTopo;
+
+				}
+
+				float fwidth2( float v ) {
+
+					float vdy = dFdy( v );
+					float vdx = dFdx( v );
+					return length( vec2( vdy, vdx ) );
 
 				}
 
@@ -69,6 +109,13 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 					mat4 invFrame = inverse( frame );
 					vec3 localPos = ( invFrame * vec4( wPosition, 1 ) ).xyz;
 
+					// TODO: account for this at a pixel level if possible
+					float distanceFromCamera = ( viewMatrix * vec4( wPosition, 1.0 ) ).z;
+					vec4 p0 = projectionMatrix * vec4( 0, 0, distanceFromCamera, 1 );
+					vec4 p1 = projectionMatrix * vec4( 0, 1.0, distanceFromCamera, 1 );
+					float screenChange = 1.0 / distance( ( p0 / p1.w ).xyz, ( p1 / p1.w ).xyz );
+
+					// get the height value to use for topo lines
 					float height;
 					#if USE_ELLIPSOID
 
@@ -81,49 +128,53 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 					#endif
 
 					// get the change in y
-					float ydy = dFdy( wPosition.y );
-					float ydx = dFdx( wPosition.y );
-					float yPosDelta = max( sqrt( ydy * ydy + ydx * ydx ), 1e-7 );
-
-					// TODO: it may be best to compute the topo step based on the distance to the camera
-					// at the given pixel rather than relying on the per-pixel distances
-					// Maybe we can use the overall wPosition change in screen space?
+					float yPosDelta = max( fwidth2( wPosition.y ), 1e-7 );
 
 					// calculate the topography step for this pixel
-					float topoPow = - 1.0;//ceil( 1.0 + log10( 10.0 * abs( yPosDelta ) ) );
-					float topoStep = pow( 10.0, topoPow );
-					float halfTopoStep = topoStep * 0.5;
+					// TODO: tune this - perhaps a different scaling mechanism is needed rather than log so
+					// the distances align more as anticipated
+					float topoBoundary = ( - 2.0 + 0.75 * log10( 0.25 * screenChange ) );
+					float topoAlpha = smoothstep( 1.0, 0.7, mod( topoBoundary, 1.0 ) );
 
-					float lineIndex = mod( wPosition.y, topoStep * 10.0 );
-					lineIndex -= topoStep;
-					lineIndex = abs( lineIndex );
-					lineIndex = step( lineIndex, topoStep * 0.5 );
+					float topoStep = pow( 10.0, ceil( topoBoundary ) );
+					float topo0 = calculateTopoLines( wPosition.y, yPosDelta, topoStep );
+					float topo1 = calculateTopoLines( wPosition.y, yPosDelta, topoStep * 10.0 );
+					float topo = mix( topo1, topo0, topoAlpha );
+					diffuseColor.rgb = mix( diffuseColor.rgb, topoLineColor, topo * topoOpacity );
 
-					// calculate the topography lines
-					float thickness = lineIndex == 0.0 ? 2.0 : 4.0;
-					float stride = 2.0 * abs( mod( wPosition.y + halfTopoStep, topoStep ) - halfTopoStep );
-					float topo = smoothstep( yPosDelta * thickness, 0.0, stride );
-
-					// handle steep surfaces that cover multiple bands
-					float subPixelColor = yPosDelta / topoStep;
-					float subPixelAlpha = smoothstep( 0.3 * topoStep, 0.4 * topoStep, yPosDelta );
-					float fadedTopo = mix( topo, topoStep / yPosDelta * 0.2, subPixelAlpha );
-
-					diffuseColor.rgb = mix( diffuseColor.rgb, topoLineColor, fadedTopo );
-					// diffuseColor.rgb = vec3( fadedTopo, 0, 0 );
-					// diffuseColor.rgb = vec3( sqrt( topoStep ), 0, 0 );
-					// diffuseColor.rgb = vec3( subPixelAlpha, 0, 0 );
-
+					vec3 pos;
 					#if USE_ELLIPSOID
 
 						// TODO: calculate carto lines
 
 					#else
 
-						// TODO: calculate xyz line
+						pos = localPos;
 
 					#endif
 
+					pos.xz *= 0.1;
+					{
+
+						float xPosDelta = max( fwidth2( pos.x ), 1e-7 );
+						float topoStep = pow( 10.0, ceil( topoBoundary ) );
+						float topo0 = calculateTopoLines( pos.x, xPosDelta, topoStep );
+						float topo1 = calculateTopoLines( pos.x, xPosDelta, topoStep * 10.0 );
+						float topo = mix( topo1, topo0, topoAlpha );
+						diffuseColor.rgb = mix( diffuseColor.rgb, topoLineColor, topo * cartoOpacity );
+
+					}
+
+					{
+
+						float xPosDelta = max( fwidth2( pos.z ), 1e-7 );
+						float topoStep = pow( 10.0, ceil( topoBoundary ) );
+						float topo0 = calculateTopoLines( pos.z, xPosDelta, topoStep );
+						float topo1 = calculateTopoLines( pos.z, xPosDelta, topoStep * 10.0 );
+						float topo = mix( topo1, topo0, topoAlpha );
+						diffuseColor.rgb = mix( diffuseColor.rgb, topoLineColor, topo * cartoOpacity );
+
+					}
 					// TODO: calculate 2d projection lines
 
 				}
@@ -137,7 +188,6 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 }
 
 function addWorldPosition( shader ) {
-
 
 	if ( /varying\s+vec3\s+wPosition/.test( shader.vertexShader ) ) {
 

--- a/example/src/plugins/topolines/TopoLineMaterialMixin.js
+++ b/example/src/plugins/topolines/TopoLineMaterialMixin.js
@@ -39,7 +39,8 @@ const ELLIPSOID_FUNC = /* glsl */`
 		float xMultiplier2, yMultiplier2, zMultiplier2;
 		float xMultiplier3, yMultiplier3, zMultiplier3;
 
-		do {
+		for ( int i = 0; i < 2; i ++ ) {
+		// do {
 
 			lambda -= correction;
 
@@ -67,7 +68,8 @@ const ELLIPSOID_FUNC = /* glsl */`
 			float derivative = - 2.0 * denominator;
 			correction = func / derivative;
 
-		} while ( abs( func ) > EPSILON12 );
+		// } while ( abs( func ) > EPSILON12 );
+		}
 
 		return vec3(
 			pos.x * xMultiplier,
@@ -147,7 +149,7 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 
 	material.defines = {
 		...( material.defines || {} ),
-		USE_ELLIPSOID: 0,
+		USE_ELLIPSOID: 1, //Number( params.ellipsoid.value.length() > 0 ),
 		USE_TOPOLINES: 1,
 		USE_CARTOLINES: 1,
 	};
@@ -252,6 +254,11 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 						// TODO: calculate height relative to surface
 						// TODO: calculate carto lines
 						pos = getPositionToCartographic( ellipsoid, localPos );
+						pos.xy *= 180.0 / PI;
+						// pos.xy += 180.0;
+						// pos.xy *= 10.0;
+						pos.xy *= 100.0;
+						// diffuseColor.rgb = vec3(pos.z * 0.0001, 0, 0);
 
 					#else
 
@@ -278,7 +285,8 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 					// blend the small and large topo lines
 					vec3 topo = mix( mult1 * topo1, mult0 * topo0, topoAlpha );
 
-					diffuseColor.rgb = vec3( topo.z * topoOpacity );
+					// diffuseColor.rgb = vec3( topo.y * topoOpacity );
+					diffuseColor.rgb = mix( diffuseColor.rgb, topoLineColor, topo.y * topoOpacity );
 
 				}
 

--- a/example/src/plugins/topolines/TopoLineMaterialMixin.js
+++ b/example/src/plugins/topolines/TopoLineMaterialMixin.js
@@ -1,0 +1,167 @@
+// Adjusts the provided material to support fading in and out using a bayer pattern. Providing a "previous"
+
+import { Color, Matrix4, Vector3 } from 'three';
+
+// before compile can be used to chain shader adjustments. Returns the added uniforms used for fading.
+export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
+
+	const params = {
+		ellipsoid: { value: new Vector3() },
+		frame: { value: new Matrix4() },
+
+		topoLineColor: { value: new Color() },
+		cartoLineColor: { value: new Color() },
+	};
+
+	material.version = 300;
+
+	material.defines = {
+		...( material.defines || {} ),
+		USE_ELLIPSOID: 0,
+		USE_TOPOLINES: 1,
+		USE_CARTOLINES: 1,
+	};
+
+	material.customProgramCacheKey = () => {
+
+		return Number( ! ! params.ellipsoid ) + '_' + JSON.stringify( material.defines );
+
+	};
+
+	material.onBeforeCompile = shader => {
+
+		addWorldPosition( shader );
+
+		if ( previousOnBeforeCompile ) {
+
+			previousOnBeforeCompile( shader );
+
+		}
+
+		shader.uniforms = {
+			...shader.uniforms,
+			...params,
+		};
+
+		shader.fragmentShader = shader
+			.fragmentShader
+			.replace( /void main\(/, value => /* glsl */`
+
+				uniform vec3 ellipsoid;
+				uniform mat4 frame;
+
+				uniform vec3 topoLineColor;
+				uniform vec3 cartoLineColor;
+
+				float log10( float v ) {
+
+					return log( v ) / log( 10.0 );
+
+				}
+
+				${ value }
+			` )
+			.replace( /#include <color_fragment>/, value => /* glsl */`
+
+				${ value }
+				{
+
+					mat4 invFrame = inverse( frame );
+					vec3 localPos = ( invFrame * vec4( wPosition, 1 ) ).xyz;
+
+					float height;
+					#if USE_ELLIPSOID
+
+						// TODO: calculate height relative to surface
+
+					#else
+
+						height = localPos.y;
+
+					#endif
+
+					// get the change in y
+					float ydy = dFdy( wPosition.y );
+					float ydx = dFdx( wPosition.y );
+					float yPosDelta = max( sqrt( ydy * ydy + ydx * ydx ), 1e-7 );
+
+					// TODO: it may be best to compute the topo step based on the distance to the camera
+					// at the given pixel rather than relying on the per-pixel distances
+					// Maybe we can use the overall wPosition change in screen space?
+
+					// calculate the topography step for this pixel
+					float topoPow = - 1.0;//ceil( 1.0 + log10( 10.0 * abs( yPosDelta ) ) );
+					float topoStep = pow( 10.0, topoPow );
+					float halfTopoStep = topoStep * 0.5;
+
+					float lineIndex = mod( wPosition.y, topoStep * 10.0 );
+					lineIndex -= topoStep;
+					lineIndex = abs( lineIndex );
+					lineIndex = step( lineIndex, topoStep * 0.5 );
+
+					// calculate the topography lines
+					float thickness = lineIndex == 0.0 ? 2.0 : 4.0;
+					float stride = 2.0 * abs( mod( wPosition.y + halfTopoStep, topoStep ) - halfTopoStep );
+					float topo = smoothstep( yPosDelta * thickness, 0.0, stride );
+
+					// handle steep surfaces that cover multiple bands
+					float subPixelColor = yPosDelta / topoStep;
+					float subPixelAlpha = smoothstep( 0.3 * topoStep, 0.4 * topoStep, yPosDelta );
+					float fadedTopo = mix( topo, topoStep / yPosDelta * 0.2, subPixelAlpha );
+
+					diffuseColor.rgb = mix( diffuseColor.rgb, topoLineColor, fadedTopo );
+					// diffuseColor.rgb = vec3( fadedTopo, 0, 0 );
+					// diffuseColor.rgb = vec3( sqrt( topoStep ), 0, 0 );
+					// diffuseColor.rgb = vec3( subPixelAlpha, 0, 0 );
+
+					#if USE_ELLIPSOID
+
+						// TODO: calculate carto lines
+
+					#else
+
+						// TODO: calculate xyz line
+
+					#endif
+
+					// TODO: calculate 2d projection lines
+
+				}
+
+			` );
+
+	};
+
+	return params;
+
+}
+
+function addWorldPosition( shader ) {
+
+
+	if ( /varying\s+vec3\s+wPosition/.test( shader.vertexShader ) ) {
+
+		return;
+
+	}
+
+	shader.vertexShader = /* glsl */`
+			varying vec3 wPosition;
+			${ shader.vertexShader }
+		`
+		.replace(
+			/#include <project_vertex>/,
+			v => /* glsl */`
+				${ v }
+				wPosition = ( modelMatrix * vec4( transformed, 1.0 ) ).xyz;
+			`,
+		);
+
+	shader.fragmentShader = /* glsl */`
+		varying vec3 wPosition;
+		${ shader.fragmentShader }
+	`;
+
+	return shader;
+
+}

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -54,12 +54,26 @@ export class TopoLinesPlugin {
 
 	}
 
+	get thickness() {
+
+		return this.thicknessUniform.value;
+
+	}
+
+	set thickness( v ) {
+
+		this.thicknessUniform.value = v;
+
+	}
+
 	constructor( options = {} ) {
 
 		const isPlanar = 'projection' in options ? options.projection === 'planar' : true;
 
 		const {
 			projection = 'planar',
+
+			thickness = 		window.devicePixelRatio,
 
 			topoColor = 		new Color( 0xffffff ),
 			topoOpacity = 		0.5,
@@ -74,6 +88,8 @@ export class TopoLinesPlugin {
 
 		this.name = 'TOPO_LINES_PLUGIN';
 		this.tiles = null;
+
+		this.thicknessUniform = { value: thickness };
 
 		this.topoColor = new Color().set( topoColor );
 		this.topoOpacityUniform = { value: topoOpacity };
@@ -102,6 +118,8 @@ export class TopoLinesPlugin {
 					const params = wrapTopoLineMaterial( c.material, c.material.onBeforeCompile );
 					params.ellipsoid.value = tiles.ellipsoid.radius;
 					params.frame.value = tiles.group.matrixWorld;
+
+					params.thickness = this.thicknessUniform;
 
 					params.topoColor.value = this.topoColor;
 					params.topoOpacity = this.topoOpacityUniform;

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -1,4 +1,4 @@
-import { wrapTopoLineMaterial } from "./TopoLineMaterialMixin";
+import { wrapTopoLineMaterial } from './TopoLineMaterialMixin.js';
 
 export class TopoLinesPlugin {
 

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -136,7 +136,7 @@ export class TopoLinesPlugin {
 
 				if ( c.material ) {
 
-					const { defines } = c.material.defines;
+					const { defines } = c.material;
 					if ( defines.USE_TOPO_ELLIPSOID !== USE_TOPO_ELLIPSOID ) {
 
 						defines.USE_TOPO_ELLIPSOID = USE_TOPO_ELLIPSOID;

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -61,11 +61,13 @@ export class TopoLinesPlugin {
 
 			topoColor = new Color( 0xffffff ),
 			topoOpacity = 0.5,
-			topoLimits = new Vector2( 0, 1e10 ),
+			topoLimit = new Vector2( 0.1, 1e10 ),
+			topoFadeLimit = new Vector2( 1, 1000 ),
 
 			cartoColor = new Color( 0xffffff ),
-			cartoOpacity = 0.5,
-			cartoLimits = new Vector2( 0, 1e10 ),
+			cartoOpacity = 0.0,
+			cartoLimit = new Vector2( 0.1, 1e10 ),
+			cartoFadeLimit = new Vector2( 0.1, 1e10 ),
 		} = options;
 
 		this.name = 'TOPO_LINES_CONSTRUCTOR';
@@ -73,11 +75,13 @@ export class TopoLinesPlugin {
 
 		this.topoColor = new Color().set( topoColor );
 		this.topoOpacityUniform = { value: topoOpacity };
-		this.topoLimits = new Vector2( ...topoLimits );
+		this.topoLimit = new Vector2( ...topoLimit );
+		this.topoFadeLimit = new Vector2( ...topoFadeLimit );
 
 		this.cartoColor = new Color().set( cartoColor );
 		this.cartoOpacityUniform = { value: cartoOpacity };
-		this.cartoLimits = new Vector2( ...cartoLimits );
+		this.cartoLimit = new Vector2( ...cartoLimit );
+		this.cartoFadeLimit = new Vector2( ...cartoFadeLimit );
 
 		this._projection = projection;
 
@@ -99,11 +103,13 @@ export class TopoLinesPlugin {
 
 					params.topoColor.value = this.topoColor;
 					params.topoOpacity = this.topoOpacityUniform;
-					params.topoLimits.value = this.topoLimits;
+					params.topoLimit.value = this.topoLimit;
+					params.topoFadeLimit.value = this.topoFadeLimit;
 
 					params.cartoColor.value = this.cartoColor;
 					params.cartoOpacity = this.cartoOpacityUniform;
-					params.cartoLimits.value = this.cartoLimits;
+					params.cartoLimit.value = this.cartoLimit;
+					params.cartoFadeLimit.value = this.cartoFadeLimit;
 
 					c.material.defines.USE_TOPO_ELLIPSOID = Number( this.projection === 'ellipsoid' );
 					c.material.needsUpdate = true;

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -44,7 +44,7 @@ export class TopoLinesPlugin {
 
 					if ( c.material ) {
 
-						c.material.defines.USE_ELLIPSOID = Number( v === 'ellipsoid' );
+						c.material.defines.USE_TOPO_ELLIPSOID = Number( v === 'ellipsoid' );
 						c.material.needsUpdate = true;
 
 					}
@@ -68,7 +68,7 @@ export class TopoLinesPlugin {
 
 			cartoColor = new Color( 0xffffff ),
 			cartoOpacity = 0.5,
-			cartoLimits = new Vector2( 0, 1e10 ),
+			cartoLimits = new Vector2( 0, 1e3 ),
 		} = options;
 
 		this.name = 'TOPO_LINES_CONSTRUCTOR';
@@ -108,7 +108,7 @@ export class TopoLinesPlugin {
 					params.cartoOpacity = this.cartoOpacityUniform;
 					params.cartoLimits.value = this.cartoLimits;
 
-					c.material.defines.USE_ELLIPSOID = Number( this.projection === 'ellipsoid' );
+					c.material.defines.USE_TOPO_ELLIPSOID = Number( this.projection === 'ellipsoid' );
 					c.material.needsUpdate = true;
 
 				}

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -56,21 +56,23 @@ export class TopoLinesPlugin {
 
 	constructor( options = {} ) {
 
+		const isPlanar = 'projection' in options ? options.projection === 'planar' : true;
+
 		const {
 			projection = 'planar',
 
-			topoColor = new Color( 0xffffff ),
-			topoOpacity = 0.5,
-			topoLimit = new Vector2( 0.1, 1e10 ),
-			topoFadeLimit = new Vector2( 1, 1000 ),
+			topoColor = 		new Color( 0xffffff ),
+			topoOpacity = 		0.5,
+			topoLimit = 		isPlanar ? new Vector2( 0.1, 1 ) : new Vector2( 1, 1e10 ),
+			topoFadeLimit = 	isPlanar ? new Vector2( 0, 1e10 ) : new Vector2( 0, 1e4 ),
 
-			cartoColor = new Color( 0xffffff ),
-			cartoOpacity = 0.0,
-			cartoLimit = new Vector2( 0.1, 1e10 ),
-			cartoFadeLimit = new Vector2( 0.1, 1e10 ),
+			cartoColor = 		new Color( 0xffffff ),
+			cartoOpacity = 		isPlanar ? 0 : 0.5,
+			cartoLimit = 		new Vector2( 0.1, 1e10 ),
+			cartoFadeLimit = 	isPlanar ? new Vector2( 0, 1e10 ) : new Vector2( 1e4, 1e10 ),
 		} = options;
 
-		this.name = 'TOPO_LINES_CONSTRUCTOR';
+		this.name = 'TOPO_LINES_PLUGIN';
 		this.tiles = null;
 
 		this.topoColor = new Color().set( topoColor );

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -1,14 +1,94 @@
+import { Color, Vector2 } from 'three';
 import { wrapTopoLineMaterial } from './TopoLineMaterialMixin.js';
 
 export class TopoLinesPlugin {
 
-	constructor() {
+	get topoOpacity() {
+
+		return this.topoOpacityUniform.value;
+
+	}
+
+	set topoOpacity( v ) {
+
+		this.topoOpacityUniform.value = v;
+
+	}
+
+	get cartoOpacity() {
+
+		return this.cartoOpacityUniform.value;
+
+	}
+
+	set cartoOpacity( v ) {
+
+		this.cartoOpacityUniform.value = v;
+
+	}
+
+	get projection() {
+
+		return this._projection;
+
+	}
+
+	set projection( v ) {
+
+		if ( v !== this._projection ) {
+
+			this._projection = v;
+			this.tiles.forEachLoadedModel( scene => {
+
+				scene.traverse( c => {
+
+					if ( c.material ) {
+
+						c.material.defines.USE_ELLIPSOID = Number( v === 'ellipsoid' );
+						c.material.needsUpdate = true;
+
+					}
+
+				} );
+
+			} );
+
+		}
+
+	}
+
+	constructor( options = {} ) {
+
+		const {
+			projection = 'planar',
+
+			topoColor = new Color( 0xffffff ),
+			topoOpacity = 0.5,
+			topoLimits = new Vector2( 0, 1e10 ),
+
+			cartoColor = new Color( 0xffffff ),
+			cartoOpacity = 0.5,
+			cartoLimits = new Vector2( 0, 1e10 ),
+		} = options;
 
 		this.name = 'TOPO_LINES_CONSTRUCTOR';
+		this.tiles = null;
+
+		this.topoColor = new Color().set( topoColor );
+		this.topoOpacityUniform = { value: topoOpacity };
+		this.topoLimits = new Vector2( ...topoLimits );
+
+		this.cartoColor = new Color().set( cartoColor );
+		this.cartoOpacityUniform = { value: cartoOpacity };
+		this.cartoLimits = new Vector2( ...cartoLimits );
+
+		this._projection = projection;
 
 	}
 
 	init( tiles ) {
+
+		this.tiles = tiles;
 
 		tiles.addEventListener( 'load-model', ( { scene } ) => {
 
@@ -17,8 +97,19 @@ export class TopoLinesPlugin {
 				if ( c.material ) {
 
 					const params = wrapTopoLineMaterial( c.material, c.material.onBeforeCompile );
-					params.ellipsoid.value.copy( tiles.ellipsoid.radius );
-					params.frame.value.copy( tiles.group.matrixWorld );
+					params.ellipsoid.value = tiles.ellipsoid.radius;
+					params.frame.value = tiles.group.matrixWorld;
+
+					params.topoColor.value = this.topoColor;
+					params.topoOpacity = this.topoOpacityUniform;
+					params.topoLimits.value = this.topoLimits;
+
+					params.cartoColor.value = this.cartoColor;
+					params.cartoOpacity = this.cartoOpacityUniform;
+					params.cartoLimits.value = this.cartoLimits;
+
+					c.material.defines.USE_ELLIPSOID = Number( this.projection === 'ellipsoid' );
+					c.material.needsUpdate = true;
 
 				}
 

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -1,5 +1,5 @@
 import { Color, Vector2 } from 'three';
-import { wrapTopoLineMaterial } from './TopoLineMaterialMixin.js';
+import { wrapTopoLineMaterial } from './wrapTopoLineMaterial.js';
 
 export class TopoLinesPlugin {
 
@@ -63,7 +63,7 @@ export class TopoLinesPlugin {
 
 			topoColor = 		new Color( 0xffffff ),
 			topoOpacity = 		0.5,
-			topoLimit = 		isPlanar ? new Vector2( 0.1, 1 ) : new Vector2( 1, 1e10 ),
+			topoLimit = 		isPlanar ? new Vector2( 0.1, 1e10 ) : new Vector2( 1, 1e10 ),
 			topoFadeLimit = 	isPlanar ? new Vector2( 0, 1e10 ) : new Vector2( 0, 1e4 ),
 
 			cartoColor = 		new Color( 0xffffff ),

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -1,0 +1,29 @@
+import { wrapTopoLineMaterial } from "./TopoLineMaterialMixin";
+
+export class TopoLinesPlugin {
+
+	constructor() {
+
+		this.name = 'TOPO_LINES_CONSTRUCTOR';
+
+	}
+
+	init( tiles ) {
+
+		tiles.addEventListener( 'load-model', ( { scene } ) => {
+
+			scene.traverse( c => {
+
+				if ( c.material ) {
+
+					wrapTopoLineMaterial( c.material, c.material.onBeforeCompile );
+
+				}
+
+			} );
+
+		} );
+
+	}
+
+}

--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -16,7 +16,9 @@ export class TopoLinesPlugin {
 
 				if ( c.material ) {
 
-					wrapTopoLineMaterial( c.material, c.material.onBeforeCompile );
+					const params = wrapTopoLineMaterial( c.material, c.material.onBeforeCompile );
+					params.ellipsoid.value.copy( tiles.ellipsoid.radius );
+					params.frame.value.copy( tiles.group.matrixWorld );
 
 				}
 

--- a/example/src/plugins/topolines/wrapTopoLineMaterial.js
+++ b/example/src/plugins/topolines/wrapTopoLineMaterial.js
@@ -86,27 +86,27 @@ const ELLIPSOID_FUNC = /* glsl */`
 `;
 
 const MATH_FUNC = /* glsl */`
-float log10( float v ) {
+	float log10( float v ) {
 
-	return log( v ) / log( 10.0 );
+		return log( v ) / log( 10.0 );
 
-}
+	}
 
-float fwidth2( float v ) {
+	float fwidth2( float v ) {
 
-	float vdy = dFdy( v );
-	float vdx = dFdx( v );
-	return length( vec2( vdy, vdx ) );
+		float vdy = dFdy( v );
+		float vdx = dFdx( v );
+		return length( vec2( vdy, vdx ) );
 
-}
+	}
 
-vec3 fwidth2( vec3 v ) {
+	vec3 fwidth2( vec3 v ) {
 
-	vec3 vdy = dFdy( v );
-	vec3 vdx = dFdx( v );
-	return sqrt( vdy * vdy + vdx * vdx );
+		vec3 vdy = dFdy( v );
+		vec3 vdx = dFdx( v );
+		return sqrt( vdy * vdy + vdx * vdx );
 
-}
+	}
 `;
 
 // before compile can be used to chain shader adjustments. Returns the added uniforms used for fading.

--- a/example/src/plugins/topolines/wrapTopoLineMaterial.js
+++ b/example/src/plugins/topolines/wrapTopoLineMaterial.js
@@ -126,6 +126,7 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 		cartoLimit: { value: new Vector2( 0, 1e10 ) },
 		cartoFadeLimit: { value: new Vector2( 0, 1e10 ) },
 
+		thickness: { value: 1.0 },
 	};
 
 	material.defines = {
@@ -220,6 +221,7 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 				#if USE_TOPO_LINES
 
 					uniform mat4 frame;
+					uniform float thickness;
 
 					uniform vec3 topoColor;
 					uniform float topoOpacity;
@@ -369,6 +371,9 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 						}
 
 					#endif
+
+					thickness0 *= thickness;
+					thickness1 *= thickness;
 
 					// calculate the topo line value
 					vec3 topo0 = calculateTopoLines( pos, posDelta, step0, thickness0, emphasisStride0 );


### PR DESCRIPTION
Fix #1080 

**After**
- Consider shifting the resolution value to a uniform rather than calculated
- Consider decreasing step size if the terrain has a low rate-of-change (fwidth of perpenticular values)?
- Remaining precision issues
  - Vertex attributes?
  - Use viewPosition in frag shader?
  - It seems performing sin etc operations on the values causes some precision errors. But why is the position okay while other values are not?
- Consider feature for adjusting the number of segments per stride - eg use 9 at the highest level for cartographic
- Add demo
- Ensure the scale of the lines is appropriate for ellipsoid scales - line density looks much higher with steep surfaces. Perhaps we can adjust the apparent distance based on steepness?
