### PR TITLE
Fix implicit any in types

### DIFF
--- a/src/base/constants.d.ts
+++ b/src/base/constants.d.ts
@@ -1,3 +1,3 @@
-export const WGS84_RADIUS;
-export const WGS84_FLATTENING;
-export const WGS84_HEIGHT;
+export const WGS84_RADIUS: number;
+export const WGS84_FLATTENING: number;
+export const WGS84_HEIGHT: number;

--- a/src/three/math/Ellipsoid.d.ts
+++ b/src/three/math/Ellipsoid.d.ts
@@ -32,6 +32,6 @@ export class Ellipsoid {
 	): Matrix4;
 
 	getEastNorthUpFrame( lat: number, lon: number, target: Matrix4 ): Matrix4;
-	getEastNorthUpAxes( lat: number, lon: number, vecEast: Vector3, vecNorth: Vector3, vecUp: Vector3, point?: Vector3 );
+	getEastNorthUpAxes( lat: number, lon: number, vecEast: Vector3, vecNorth: Vector3, vecUp: Vector3, point?: Vector3 ): void;
 
 }

--- a/src/three/math/EllipsoidRegion.d.ts
+++ b/src/three/math/EllipsoidRegion.d.ts
@@ -17,7 +17,7 @@ export class EllipsoidRegion extends Ellipsoid {
 		heightStart: number, heightEnd: number
 	);
 
-	getBoundingBox( box : Box3, matrix : Matrix4 );
-	getBoundingSphere( sphere : Sphere );
+	getBoundingBox( box : Box3, matrix : Matrix4 ): void;
+	getBoundingSphere( sphere : Sphere ): void;
 
 }

--- a/src/three/math/TileBoundingVolume.d.ts
+++ b/src/three/math/TileBoundingVolume.d.ts
@@ -1,0 +1,5 @@
+export class TileBoundingVolume {
+
+	constructor();
+
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
             "es2015"
         ],
         "moduleResolution": "node",
-        "types": []
+        "types": [],
+		"strict": true
     },
     "files": [
         "src/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         ],
         "moduleResolution": "node",
         "types": [],
-		"strict": true
+        "strict": true
     },
     "files": [
         "src/index.d.ts",


### PR DESCRIPTION
Some of the types in the declaration files are implicitly `any`. This PR fixes those and adds `"strict": "true"` to the `tsconfing.json` to prevent further regressions.