### PR TITLE
TilesRenderer: Add needs-update event

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,25 +308,33 @@ _extends `THREE.EventDispatcher` & [TilesRendererBase](https://github.com/NASA-A
 ### events
 
 ```js
-// fired when a new root or child tile set is loaded
+// Fired when a new root or child tile set is loaded.
 { type: 'load-tile-set', tileSet: Object, url: String }
 
-// fired when a tile model is loaded
+// Fired when a tile model is loaded.
 { type: 'load-model', scene: THREE.Group, tile: Object }
 
-// fired when a tile model is disposed
+// Fired when the content of a model is loaded. Fired along side the
+// above two events.
+{ type: 'load-content', tileSet: Object, url: String }
+
+// Fired when a tile model is disposed.
 { type: 'dispose-model', scene: THREE.Group, tile: Object }
 
-// fired when a tiles visibility changes
+// Fired when the tile set hierarchy is ready for "update to be called
+// again due to new content having loaded or asynchronous processing finished.
+{ type: 'needs-update', tileSet: Object, url: String }
+
+// Fired when a tiles visibility changes.
 { type: 'tile-visibility-change', scene: THREE.Group, tile: Object }
 
-// fired when tiles start loading
+// Fired when tiles start loading.
 { type: 'tiles-load-start' }
 
-// fired when all tiles finish loading
+// Fired when all tiles finish loading.
 { type: 'tiles-load-end' }
 
-// fired when a tile content or the root tile set fails to load
+// Fired when a tile content or the root tile set fails to load.
 { type: 'load-error', tile: Object | null, error: Error, url: string | URL }
 ```
 

--- a/src/plugins/three/TileFlatteningPlugin.js
+++ b/src/plugins/three/TileFlatteningPlugin.js
@@ -210,7 +210,7 @@ export class TileFlatteningPlugin {
 
 		} );
 
-		this.tiles.dispatchEvent( { type: 'force-rerender' } );
+		this.tiles.dispatchEvent( { type: 'needs-render' } );
 
 	}
 

--- a/src/plugins/three/UpdateOnChangePlugin.js
+++ b/src/plugins/three/UpdateOnChangePlugin.js
@@ -35,11 +35,10 @@ export class UpdateOnChangePlugin {
 
 		};
 
-		tiles.addEventListener( 'camera-resolution-change', this._needsUpdateCallback );
-		tiles.addEventListener( 'load-content', this._needsUpdateCallback );
 		tiles.addEventListener( 'needs-update', this._needsUpdateCallback );
 		tiles.addEventListener( 'add-camera', this._onCameraAdd );
 		tiles.addEventListener( 'delete-camera', this._onCameraDelete );
+		tiles.addEventListener( 'camera-resolution-change', this._needsUpdateCallback );
 
 		// register any already-present cameras
 		tiles.cameras.forEach( camera => {

--- a/src/plugins/three/UpdateOnChangePlugin.js
+++ b/src/plugins/three/UpdateOnChangePlugin.js
@@ -37,6 +37,7 @@ export class UpdateOnChangePlugin {
 
 		tiles.addEventListener( 'camera-resolution-change', this._needsUpdateCallback );
 		tiles.addEventListener( 'load-content', this._needsUpdateCallback );
+		tiles.addEventListener( 'needs-update', this._needsUpdateCallback );
 		tiles.addEventListener( 'add-camera', this._onCameraAdd );
 		tiles.addEventListener( 'delete-camera', this._onCameraDelete );
 

--- a/src/plugins/three/fade/TilesFadePlugin.js
+++ b/src/plugins/three/fade/TilesFadePlugin.js
@@ -47,7 +47,7 @@ function onUpdateAfter() {
 	if ( fadingBefore !== 0 && fadingAfter !== 0 ) {
 
 		tiles.dispatchEvent( { type: 'fade-change' } );
-		tiles.dispatchEvent( { type: 'force-rerender' } );
+		tiles.dispatchEvent( { type: 'needs-render' } );
 
 	}
 
@@ -279,14 +279,14 @@ export class TilesFadePlugin {
 		fadeManager.onFadeSetStart = () => {
 
 			tiles.dispatchEvent( { type: 'fade-start' } );
-			tiles.dispatchEvent( { type: 'force-rerender' } );
+			tiles.dispatchEvent( { type: 'needs-render' } );
 
 		};
 
 		fadeManager.onFadeSetComplete = () => {
 
 			tiles.dispatchEvent( { type: 'fade-end' } );
-			tiles.dispatchEvent( { type: 'force-rerender' } );
+			tiles.dispatchEvent( { type: 'needs-render' } );
 
 		};
 

--- a/src/r3f/components/TilesRenderer.jsx
+++ b/src/r3f/components/TilesRenderer.jsx
@@ -214,7 +214,7 @@ export const TilesRenderer = forwardRef( function TilesRenderer( props, ref ) {
 
 		tiles.addEventListener( 'load-tile-set', () => invalidate() );
 		tiles.addEventListener( 'load-content', () => invalidate() );
-		tiles.addEventListener( 'force-rerender', () => invalidate() );
+		tiles.addEventListener( 'needs-render', () => invalidate() );
 		return () => {
 
 			tiles.dispose();

--- a/src/r3f/components/TilesRenderer.jsx
+++ b/src/r3f/components/TilesRenderer.jsx
@@ -215,6 +215,7 @@ export const TilesRenderer = forwardRef( function TilesRenderer( props, ref ) {
 		tiles.addEventListener( 'load-tile-set', () => invalidate() );
 		tiles.addEventListener( 'load-content', () => invalidate() );
 		tiles.addEventListener( 'needs-render', () => invalidate() );
+		tiles.addEventListener( 'needs-update', () => invalidate() );
 		return () => {
 
 			tiles.dispose();

--- a/src/r3f/components/TilesRenderer.jsx
+++ b/src/r3f/components/TilesRenderer.jsx
@@ -212,8 +212,6 @@ export const TilesRenderer = forwardRef( function TilesRenderer( props, ref ) {
 	// create the tile set
 	useEffect( () => {
 
-		tiles.addEventListener( 'load-tile-set', () => invalidate() );
-		tiles.addEventListener( 'load-content', () => invalidate() );
 		tiles.addEventListener( 'needs-render', () => invalidate() );
 		tiles.addEventListener( 'needs-update', () => invalidate() );
 		return () => {

--- a/src/utilities/debounce.js
+++ b/src/utilities/debounce.js
@@ -1,0 +1,19 @@
+export function debounce( callback ) {
+
+	let handle = null;
+	return () => {
+
+		if ( handle === null ) {
+
+			handle = requestAnimationFrame( () => {
+
+				handle = null;
+				callback();
+
+			} );
+
+		}
+
+	};
+
+}


### PR DESCRIPTION
Fix #1081 

Adds a "needs-update" event to listen for delayed hierarchy processing updates.