### PR TITLE
TS - Extend from base Loader classes in loaders, three.js loaders

### DIFF
--- a/src/base/loaders/B3DMLoaderBase.d.ts
+++ b/src/base/loaders/B3DMLoaderBase.d.ts
@@ -1,5 +1,6 @@
 import { BatchTable } from '../../utilities/BatchTable.js';
 import { FeatureTable } from '../../utilities/FeatureTable.js';
+import { LoaderBase } from './LoaderBase.js';
 
 export interface B3DMBaseResult {
 
@@ -10,9 +11,7 @@ export interface B3DMBaseResult {
 
 }
 
-export class B3DMLoaderBase {
-
-	load( url : string ) : Promise< B3DMBaseResult >;
-	parse( buffer : ArrayBuffer ) : B3DMBaseResult;
+export class B3DMLoaderBase<Result = B3DMBaseResult, ParseResult = Result>
+	extends LoaderBase<Result, ParseResult> {
 
 }

--- a/src/base/loaders/CMPTLoaderBase.d.ts
+++ b/src/base/loaders/CMPTLoaderBase.d.ts
@@ -1,3 +1,5 @@
+import { LoaderBase } from './LoaderBase.js';
+
 interface TileInfo {
 
 	type : string;
@@ -13,10 +15,7 @@ export interface CMPTBaseResult {
 
 }
 
-export class CMPTLoaderBase {
-
-	workingPath : string;
-	load( url : string ) : Promise< CMPTBaseResult >;
-	parse( buffer : ArrayBuffer ) : CMPTBaseResult;
+export class CMPTLoaderBase<Result = CMPTBaseResult, ParseResult = Result>
+	extends LoaderBase<Result, ParseResult> {
 
 }

--- a/src/base/loaders/I3DMLoaderBase.d.ts
+++ b/src/base/loaders/I3DMLoaderBase.d.ts
@@ -1,5 +1,6 @@
 import { BatchTable } from '../../utilities/BatchTable.js';
 import { FeatureTable } from '../../utilities/FeatureTable.js';
+import { LoaderBase } from './LoaderBase.js';
 
 export interface I3DMBaseResult {
 
@@ -10,12 +11,7 @@ export interface I3DMBaseResult {
 
 }
 
-export class I3DMLoaderBase {
-
-	workingPath : string;
-
-	resolveExternalURL( url : string ) : string;
-	load( url : string ) : Promise< I3DMBaseResult >;
-	parse( buffer : ArrayBuffer ) : Promise< I3DMBaseResult >;
+export class I3DMLoaderBase<Result = I3DMBaseResult, ParseResult = Result>
+	extends LoaderBase<Result, ParseResult> {
 
 }

--- a/src/base/loaders/LoaderBase.d.ts
+++ b/src/base/loaders/LoaderBase.d.ts
@@ -1,10 +1,10 @@
-export class LoaderBase {
+export class LoaderBase<Result = any, ParseResult = Promise< Result >> {
 
 	fetchOptions: any;
 	workingPath: string;
-	load( url: string ): Promise< any >;
+	load( url: string ): Promise< Result >;
 	resolveExternalURL( url: string ): string;
 	workingPathForURL( url: string ): string
-	parse( buffer: ArrayBuffer ): Promise< any >;
+	parse( buffer: ArrayBuffer ): ParseResult;
 
 }

--- a/src/base/loaders/PNTSLoaderBase.d.ts
+++ b/src/base/loaders/PNTSLoaderBase.d.ts
@@ -1,5 +1,6 @@
 import { BatchTable } from '../../utilities/BatchTable.js';
 import { FeatureTable } from '../../utilities/FeatureTable.js';
+import { LoaderBase } from './LoaderBase.js';
 
 export interface PNTSBaseResult {
 
@@ -9,9 +10,7 @@ export interface PNTSBaseResult {
 
 }
 
-export class PNTSLoaderBase {
-
-	load( url : string ) : Promise< PNTSBaseResult >;
-	parse( buffer : ArrayBuffer ) : Promise< PNTSBaseResult >;
+export class PNTSLoaderBase<Result = PNTSBaseResult, ParseResult = Result>
+	extends LoaderBase<Result, ParseResult> {
 
 }

--- a/src/three/loaders/B3DMLoader.d.ts
+++ b/src/three/loaders/B3DMLoader.d.ts
@@ -1,4 +1,4 @@
-import { B3DMBaseResult } from '../../base/loaders/B3DMLoaderBase.js';
+import { B3DMBaseResult, B3DMLoaderBase } from '../../base/loaders/B3DMLoaderBase.js';
 import { BatchTable } from '../../utilities/BatchTable.js';
 import { FeatureTable } from '../../utilities/FeatureTable.js';
 import { LoadingManager, Group } from 'three';
@@ -17,10 +17,9 @@ export interface B3DMResult extends GLTF, B3DMBaseResult {
 
 }
 
-export class B3DMLoader {
+export class B3DMLoader<Result extends B3DMResult = B3DMResult, ParseResult = Promise<Result>>
+	extends B3DMLoaderBase<Result, ParseResult> {
 
 	constructor( manager : LoadingManager );
-	load( url : string ) : Promise< B3DMResult >;
-	parse( buffer : ArrayBuffer ) : Promise < B3DMResult >;
 
 }

--- a/src/three/loaders/CMPTLoader.d.ts
+++ b/src/three/loaders/CMPTLoader.d.ts
@@ -2,6 +2,7 @@ import { B3DMBaseResult } from '../../base/loaders/B3DMLoaderBase.js';
 import { I3DMBaseResult } from '../../base/loaders/I3DMLoaderBase.js';
 import { PNTSBaseResult } from '../../base/loaders/PNTSLoaderBase.js';
 import { Group, LoadingManager } from 'three';
+import { CMPTLoaderBase } from '../../base/loaders/CMPTLoaderBase.js';
 
 export interface CMPTResult {
 
@@ -10,10 +11,9 @@ export interface CMPTResult {
 
 }
 
-export class CMPTLoader {
+export class CMPTLoader<Result extends CMPTResult = CMPTResult, ParseResult = Promise<Result>>
+	extends CMPTLoaderBase<Result, ParseResult> {
 
 	constructor( manager : LoadingManager );
-	load( url : string ) : Promise< CMPTResult >;
-	parse( buffer : ArrayBuffer ) : Promise< CMPTResult >;
 
 }

--- a/src/three/loaders/I3DMLoader.d.ts
+++ b/src/three/loaders/I3DMLoader.d.ts
@@ -1,4 +1,4 @@
-import { I3DMBaseResult } from '../../base/loaders/I3DMLoaderBase.js';
+import { I3DMBaseResult, I3DMLoaderBase } from '../../base/loaders/I3DMLoaderBase.js';
 import { BatchTable } from '../../utilities/BatchTable.js';
 import { FeatureTable } from '../../utilities/FeatureTable.js';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -17,10 +17,9 @@ export interface I3DMResult extends GLTF, I3DMBaseResult {
 
 }
 
-export class I3DMLoader {
+export class I3DMLoader<Result extends I3DMResult = I3DMResult, ParseResult = Promise<Result>>
+	extends I3DMLoaderBase<Result, ParseResult> {
 
 	constructor( manager : LoadingManager );
-	load( url : string ) : Promise< I3DMResult >;
-	parse( buffer : ArrayBuffer ) : Promise< I3DMResult >;
 
 }

--- a/src/three/loaders/PNTSLoader.d.ts
+++ b/src/three/loaders/PNTSLoader.d.ts
@@ -16,10 +16,9 @@ export interface PNTSResult extends PNTSBaseResult {
 
 }
 
-export class PNTSLoader extends PNTSLoaderBase {
+export class PNTSLoader<Result extends PNTSResult = PNTSResult, ParseResult = Promise<Result>>
+	extends PNTSLoaderBase<Result, ParseResult> {
 
 	constructor( manager : LoadingManager );
-	load( url : string ) : Promise< PNTSResult >;
-	parse( buffer : ArrayBuffer ) : Promise< PNTSResult >;
 
 }


### PR DESCRIPTION
Hi, 
The loaders in typescript don't extend from the LoaderBase, but they do in javascript, as a result some properties like workingPath were not accessible from the three.js loader like `B3DMLoader` in typescript. 

In this, updated the classes to extend from the correct base class, and added generic types for return types of `load` and `parse` functions which seem to be the only properties that changed.

Since it was a very quick change, didn't create an issue first, let me know if its okay. 