### PR TITLE
Examples: Add a demo for flattening plugin

### DIFF
--- a/example/r3f/plugins/TileFlatteningPlugin.jsx
+++ b/example/r3f/plugins/TileFlatteningPlugin.jsx
@@ -1,0 +1,76 @@
+import { forwardRef, useContext, useEffect, useState } from 'react';
+import { TilesPlugin, TilesPluginContext, TilesRendererContext } from '3d-tiles-renderer/r3f';
+import { TileFlatteningPlugin as TilesFlatteningPluginImpl } from '3d-tiles-renderer/plugins';
+import { Box3, Vector3 } from 'three';
+
+// Helper class for adding a flattening shape to the scene
+export function TileFlatteningShape( props ) {
+
+	// Get the plugins and tiles
+	const plugin = useContext( TilesPluginContext );
+	const tiles = useContext( TilesRendererContext );
+
+	const {
+		children,
+		debug = false,
+		relativeToEllipsoid = false,
+		threshold = Infinity,
+		direction = null,
+	} = props;
+
+	const [ group, setGroup ] = useState( null );
+
+	// Add the provided shape to the tile set
+	useEffect( () => {
+
+		if ( tiles === null || group === null || plugin === null ) {
+
+			return;
+
+		}
+
+		// Calculate the direction to flatten on
+		const _direction = new Vector3();
+		if ( direction ) {
+
+			_direction.copy( direction );
+
+		} else if ( relativeToEllipsoid ) {
+
+			const box = new Box3();
+			box.setFromObject( group );
+			box.getCenter( _direction );
+			tiles.ellipsoid.getPositionToNormal( _direction, _direction ).multiplyScalar( - 1 );
+
+		} else {
+
+			_direction.set( 0, 0, 1 );
+
+		}
+
+		group.updateMatrixWorld( true );
+
+		// transform the shape into the local frame of the tile set
+		const relativeGroup = group.clone();
+		relativeGroup
+			.matrixWorld
+			.premultiply( tiles.group.matrixWorldInverse )
+			.decompose( relativeGroup.position, relativeGroup.quaternion, relativeGroup.scale );
+
+		// add a shape to the plugin
+		plugin.addShape( relativeGroup, _direction, threshold );
+
+	}, [ group, tiles, plugin, direction, relativeToEllipsoid, threshold ] );
+
+	return <group ref={ setGroup } visible={ debug } raycast={ () => false }>{ children }</group>;
+
+}
+
+// Wrapper for TilesFlatteningPlugin
+export const TileFlatteningPlugin = forwardRef( function TileFlatteningPlugin( props, ref ) {
+
+	const { children, ...rest } = props;
+
+	return <TilesPlugin plugin={ TilesFlatteningPluginImpl } ref={ ref } { ...rest }>{ children }</TilesPlugin>;
+
+} );

--- a/example/r3f/plugins/TileFlatteningPlugin.jsx
+++ b/example/r3f/plugins/TileFlatteningPlugin.jsx
@@ -3,6 +3,9 @@ import { TilesPlugin, TilesPluginContext, TilesRendererContext } from '3d-tiles-
 import { TileFlatteningPlugin as TilesFlatteningPluginImpl } from '3d-tiles-renderer/plugins';
 import { Box3, Vector3 } from 'three';
 
+// NOTE: The flattening shape will not automatically update when child transforms are adjusted so in order
+// to force a remount of the component the use should modify a "key" property when it needs to change.
+
 // Helper class for adding a flattening shape to the scene
 export function TileFlatteningShape( props ) {
 

--- a/example/r3f/plugins/TileFlatteningPlugin.jsx
+++ b/example/r3f/plugins/TileFlatteningPlugin.jsx
@@ -60,6 +60,12 @@ export function TileFlatteningShape( props ) {
 		// add a shape to the plugin
 		plugin.addShape( relativeGroup, _direction, threshold );
 
+		return () => {
+
+			plugin.deleteShape( relativeGroup );
+
+		};
+
 	}, [ group, tiles, plugin, direction, relativeToEllipsoid, threshold ] );
 
 	return <group ref={ setGroup } visible={ debug } raycast={ () => false }>{ children }</group>;

--- a/example/r3f/plugins/TileFlatteningPlugin.jsx
+++ b/example/r3f/plugins/TileFlatteningPlugin.jsx
@@ -29,6 +29,17 @@ export function TileFlatteningShape( props ) {
 
 		}
 
+		// ensure world transforms are up to date
+		tiles.group.updateMatrixWorld();
+		group.updateMatrixWorld( true );
+
+		// transform the shape into the local frame of the tile set
+		const relativeGroup = group.clone();
+		relativeGroup
+			.matrixWorld
+			.premultiply( tiles.group.matrixWorldInverse )
+			.decompose( relativeGroup.position, relativeGroup.quaternion, relativeGroup.scale );
+
 		// Calculate the direction to flatten on
 		const _direction = new Vector3();
 		if ( direction ) {
@@ -38,7 +49,7 @@ export function TileFlatteningShape( props ) {
 		} else if ( relativeToEllipsoid ) {
 
 			const box = new Box3();
-			box.setFromObject( group );
+			box.setFromObject( relativeGroup );
 			box.getCenter( _direction );
 			tiles.ellipsoid.getPositionToNormal( _direction, _direction ).multiplyScalar( - 1 );
 
@@ -47,15 +58,6 @@ export function TileFlatteningShape( props ) {
 			_direction.set( 0, 0, 1 );
 
 		}
-
-		group.updateMatrixWorld( true );
-
-		// transform the shape into the local frame of the tile set
-		const relativeGroup = group.clone();
-		relativeGroup
-			.matrixWorld
-			.premultiply( tiles.group.matrixWorldInverse )
-			.decompose( relativeGroup.position, relativeGroup.quaternion, relativeGroup.scale );
 
 		// add a shape to the plugin
 		plugin.addShape( relativeGroup, _direction, threshold );

--- a/example/r3f/plugins/TileFlatteningPlugin.jsx
+++ b/example/r3f/plugins/TileFlatteningPlugin.jsx
@@ -12,10 +12,19 @@ export function TileFlatteningShape( props ) {
 
 	const {
 		children,
-		debug = false,
-		relativeToEllipsoid = false,
+
+		// if true then the child geometry is rendered
+		visible = false,
+
+		// the "threshold" option for "addShape"
 		threshold = Infinity,
+
+		// the "direction" option for "addShape"
 		direction = null,
+
+		// if true then a projection direction is derived from the shape position
+		// relative to the tile set ellipsoid if "direction" is not present
+		relativeToEllipsoid = false,
 	} = props;
 
 	const [ group, setGroup ] = useState( null );
@@ -70,7 +79,7 @@ export function TileFlatteningShape( props ) {
 
 	}, [ group, tiles, plugin, direction, relativeToEllipsoid, threshold ] );
 
-	return <group ref={ setGroup } visible={ debug } raycast={ () => false }>{ children }</group>;
+	return <group ref={ setGroup } visible={ visible } raycast={ () => false }>{ children }</group>;
 
 }
 

--- a/src/plugins/three/TileFlatteningPlugin.js
+++ b/src/plugins/three/TileFlatteningPlugin.js
@@ -228,7 +228,7 @@ export class TileFlatteningPlugin {
 
 	}
 
-	addShape( mesh, direction = new Vector3( 0, - 1, 0 ), threshold = Infinity ) {
+	addShape( mesh, direction = new Vector3( 0, 0, - 1 ), threshold = Infinity ) {
 
 		if ( this.hasShape( mesh ) ) {
 

--- a/src/r3f/components/CameraTransition.jsx
+++ b/src/r3f/components/CameraTransition.jsx
@@ -40,7 +40,7 @@ export const CameraTransition = forwardRef( function CameraTransition( props, re
 
 		// only respect the camera initially so the default camera settings are automatically used
 
-	}, [] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect( () => {
 

--- a/src/r3f/components/TilesRenderer.jsx
+++ b/src/r3f/components/TilesRenderer.jsx
@@ -9,6 +9,7 @@ import { WGS84_ELLIPSOID } from '../../three/math/GeoConstants.js';
 
 // context for accessing the tile set
 export const TilesRendererContext = createContext( null );
+export const TilesPluginContext = createContext( null );
 
 // group that matches the transform of the tile set root group
 function TileSetRoot( { children } ) {
@@ -142,7 +143,7 @@ export function EastNorthUpFrame( props ) {
 // component for registering a plugin
 export const TilesPlugin = forwardRef( function TilesPlugin( props, ref ) {
 
-	const { plugin, args, ...options } = props;
+	const { plugin, args, children, ...options } = props;
 	const tiles = useContext( TilesRendererContext );
 
 	// create the instance
@@ -194,6 +195,8 @@ export const TilesPlugin = forwardRef( function TilesPlugin( props, ref ) {
 		};
 
 	}, [ instance, tiles ] );
+
+	return <TilesPluginContext.Provider value={ instance }>{ children }</TilesPluginContext.Provider>
 
 } );
 

--- a/src/r3f/components/TilesRenderer.jsx
+++ b/src/r3f/components/TilesRenderer.jsx
@@ -196,7 +196,7 @@ export const TilesPlugin = forwardRef( function TilesPlugin( props, ref ) {
 
 	}, [ instance, tiles ] );
 
-	return <TilesPluginContext.Provider value={ instance }>{ children }</TilesPluginContext.Provider>
+	return <TilesPluginContext.Provider value={ instance }>{ children }</TilesPluginContext.Provider>;
 
 } );
 


### PR DESCRIPTION
**TODO**
- Add an r3f example

Use:

```jsx
function example() {

  return <>
    <TilesRenderer>
      { /* ... */ }

      <TilesFlatteningPlugin>
        <TileFlatteningShape>
          <EastNorthUpFrame lat={ lat } lon={ lon }>
            <mesh>{ /* ... */ }</mesh>
          </EastNorthUpFrame>
        </TileFlatteningShape>
      </TilesFlatteningPlugin>
    </TilesRenderer>
  </>;

}
```

Example of flattening mt fuji:

```js
<TileFlatteningShape relativeToEllipsoid visible={ false } key={ 1001 }>
  <EastNorthUpFrame
    lat={ 0.6171588954807069 }
    lon={ 2.4212498927311814 }
    height={ 1000 }
  >
    <mesh scale={ 10000 }>
      <planeGeometry />
    </mesh>
  </EastNorthUpFrame>
</TileFlatteningShape>
```

<img width="702" alt="image" src="https://github.com/user-attachments/assets/a2561729-05f1-4090-b5f7-1aa5ecdb5448" />
