### PR TITLE
Add additional properties to EnvironmentControls types.

### DIFF
--- a/src/three/controls/EnvironmentControls.d.ts
+++ b/src/three/controls/EnvironmentControls.d.ts
@@ -1,4 +1,4 @@
-import { Camera, EventDispatcher, Object3D, Vector3 } from 'three';
+import { Camera, Clock, EventDispatcher, Object3D, Plane, Raycaster, Vector3 } from 'three';
 import { TilesRenderer } from '../TilesRenderer.js';
 
 export interface EnvironmentControlsEventMap {
@@ -11,6 +11,12 @@ export class EnvironmentControls extends EventDispatcher<EnvironmentControlsEven
 
 	readonly isEnvironmentControls: true;
 
+	domElement: HTMLElement;
+	camera: Camera;
+	scene: Object3D;
+	tilesRenderer: TilesRenderer;
+
+	// settings
 	enabled: boolean;
 	cameraRadius: number;
 	rotationSpeed: number;
@@ -26,7 +32,17 @@ export class EnvironmentControls extends EventDispatcher<EnvironmentControlsEven
 	dampingFactor: number;
 	useFallbackPlane: boolean;
 
+	fallbackPlane: Plane;
+	up: Vector3;
+	clock: Clock;
 	pivotPoint: Vector3;
+
+	// settings for GlobeControls
+	reorientOnDrag: boolean;
+	scaleZoomOrientationAtEdges: boolean;
+
+	// raycaster
+	raycaster: Raycaster;
 
 	constructor(
 		scene?: Object3D,

--- a/src/three/controls/EnvironmentControls.d.ts
+++ b/src/three/controls/EnvironmentControls.d.ts
@@ -1,4 +1,4 @@
-import { Camera, Clock, EventDispatcher, Object3D, Plane, Raycaster, Vector3 } from 'three';
+import { Camera, EventDispatcher, Object3D, Plane, Vector3 } from 'three';
 import { TilesRenderer } from '../TilesRenderer.js';
 
 export interface EnvironmentControlsEventMap {
@@ -11,10 +11,10 @@ export class EnvironmentControls extends EventDispatcher<EnvironmentControlsEven
 
 	readonly isEnvironmentControls: true;
 
-	domElement: HTMLElement;
-	camera: Camera;
-	scene: Object3D;
-	tilesRenderer: TilesRenderer;
+	readonly domElement: HTMLElement;
+	readonly camera: Camera;
+	readonly scene: Object3D;
+	readonly tilesRenderer: TilesRenderer;
 
 	// settings
 	enabled: boolean;
@@ -34,15 +34,7 @@ export class EnvironmentControls extends EventDispatcher<EnvironmentControlsEven
 
 	fallbackPlane: Plane;
 	up: Vector3;
-	clock: Clock;
 	pivotPoint: Vector3;
-
-	// settings for GlobeControls
-	reorientOnDrag: boolean;
-	scaleZoomOrientationAtEdges: boolean;
-
-	// raycaster
-	raycaster: Raycaster;
 
 	constructor(
 		scene?: Object3D,


### PR DESCRIPTION
Added some properties that were missing and from the types. 

`up` and `fallbackPlane` are required to be set from outside like in the `deepZoom` example. Added some others that seemed relevant. 

`camera`, `scene` and `tilesRenderer` have setters, so can be made readonly in types or removed if you don't want to expose it in the api.