### PR TITLE
Fix typings for QuantizedMeshPlugin

### DIFF
--- a/src/plugins/index.d.ts
+++ b/src/plugins/index.d.ts
@@ -9,6 +9,7 @@ export { UnloadTilesPlugin } from './three/UnloadTilesPlugin.js';
 export { TilesFadePlugin } from './three/fade/TilesFadePlugin.js';
 export { BatchedTilesPlugin } from './three/batched/BatchedTilesPlugin.js';
 export { TileFlatteningPlugin } from './three/TileFlatteningPlugin.js';
+export { QuantizedMeshPlugin } from './three/QuantizedMeshPlugin.js';
 export * from './three/LoadRegionPlugin.js';
 export * from './three/DebugTilesPlugin.js';
 

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -9,6 +9,7 @@ export { UnloadTilesPlugin } from './three/UnloadTilesPlugin.js';
 export { TilesFadePlugin } from './three/fade/TilesFadePlugin.js';
 export { BatchedTilesPlugin } from './three/batched/BatchedTilesPlugin.js';
 export { TileFlatteningPlugin } from './three/TileFlatteningPlugin.js';
+export { QuantizedMeshPlugin } from './three/QuantizedMeshPlugin.js';
 export * from './three/LoadRegionPlugin.js';
 export * from './three/DebugTilesPlugin.js';
 


### PR DESCRIPTION
Thank you for this new `QuantizedMeshPlugin` plugin! Experimenting with it in Typescript, I noticed the exports were missing. Let me know if any rework is required from me, otherwise it can be merged as far as I am concerned. Thanks!