### PR TITLE
Fix various typings

### DIFF
--- a/src/plugins/three/DebugTilesPlugin.d.ts
+++ b/src/plugins/three/DebugTilesPlugin.d.ts
@@ -40,6 +40,4 @@ export class DebugTilesPlugin {
 	getDebugColor : ( val: number, target: Color ) => void;
 	customColorCallback : ( val: Tile, target: Color ) => void;
 
-	dispose(): void;
-
 }

--- a/src/plugins/three/DebugTilesPlugin.d.ts
+++ b/src/plugins/three/DebugTilesPlugin.d.ts
@@ -1,5 +1,5 @@
 import { Tile } from '../../base/Tile.js';
-import { Color } from 'three';
+import { Color, Object3D } from 'three';
 
 export enum ColorMode {}
 export const NONE : ColorMode;
@@ -14,6 +14,18 @@ export const RANDOM_NODE_COLOR: ColorMode;
 export const CUSTOM_COLOR: ColorMode;
 export class DebugTilesPlugin {
 
+	constructor( options?: {
+		displayParentBounds?: boolean,
+		displayBoxBounds?: boolean,
+		displaySphereBounds?: boolean,
+		displayRegionBounds?: boolean,
+		colorMode?: ColorMode,
+		maxDebugDepth?: number,
+		maxDebugDistance?: number,
+		maxDebugError?: number,
+		customColorCallback?: ( tile: Tile, object: Object3D ) => void,
+	} );
+
 	enabled: boolean;
 
 	displayBoxBounds : boolean;
@@ -27,5 +39,7 @@ export class DebugTilesPlugin {
 
 	getDebugColor : ( val: number, target: Color ) => void;
 	customColorCallback : ( val: Tile, target: Color ) => void;
+
+	dispose(): void;
 
 }

--- a/src/three/TilesRenderer.d.ts
+++ b/src/three/TilesRenderer.d.ts
@@ -22,6 +22,7 @@ export interface TilesRendererEventMap {
 export class TilesRenderer<TEventMap extends TilesRendererEventMap = TilesRendererEventMap> extends TilesRendererBase implements EventDispatcher<TEventMap> {
 
 	ellipsoid: Ellipsoid;
+	cameras: Camera[];
 	autoDisableRendererCulling : boolean;
 	optimizeRaycast : boolean;
 

--- a/src/three/math/Ellipsoid.d.ts
+++ b/src/three/math/Ellipsoid.d.ts
@@ -1,4 +1,4 @@
-import { Vector3, Matrix4 } from 'three';
+import { Vector3, Matrix4, Ray } from 'three';
 
 export enum Frames {}
 export const ENU_FRAME: Frames;
@@ -16,6 +16,7 @@ export class Ellipsoid {
 	getCartographicToNormal( lat: number, lon: number, target: Vector3 ): Vector3;
 	getPositionToNormal( pos: Vector3, target: Vector3 ): Vector3;
 	getPositionToSurfacePoint( pos: Vector3, target: Vector3 ): Vector3;
+	getPositionElevation( pos: Vector3 ): number;
 
 	getAzElRollFromRotationMatrix(
 		lat: number, lon: number, rotationMatrix: Matrix4,
@@ -33,5 +34,13 @@ export class Ellipsoid {
 
 	getEastNorthUpFrame( lat: number, lon: number, target: Matrix4 ): Matrix4;
 	getEastNorthUpAxes( lat: number, lon: number, vecEast: Vector3, vecNorth: Vector3, vecUp: Vector3, point?: Vector3 ): void;
+
+	intersectRay( ray: Ray, target: Vector3 ): Vector3 | null;
+
+	calculateHorizonDistance( latitude: number, elevation: number ): number;
+	calculateEffectiveRadius( latitude: number ): number;
+
+	copy( source: Ellipsoid ): Ellipsoid;
+	clone(): Ellipsoid;
 
 }


### PR DESCRIPTION
I am not sure exactly what is public API, but I think at least the typings for Ellipsoid were just missing.

For the `cameras` of `TilesRenderer`, I am not sure if this is supposed to be exposed. My use case was to compute the camera elevation in the `intersectsTile` function of a custom `BaseRegion` from `LoadRegionPlugin`. Let me know if you see a better way to do it.