### PR TITLE
Make QuantizedMeshPlugin more tolerant

### DIFF
--- a/src/plugins/three/QuantizedMeshPlugin.js
+++ b/src/plugins/three/QuantizedMeshPlugin.js
@@ -20,7 +20,7 @@ function isAvailable( layer, level, x, y ) {
 		available,
 	} = layer;
 
-	if ( level >= minzoom && level <= maxzoom && level < available.length ) {
+	if ( level >= ( minzoom ?? 0 ) && level <= ( maxzoom ?? Infinity ) && level < available.length ) {
 
 		// TODO: consider a binary search
 		const availableSet = available[ level ];
@@ -150,7 +150,7 @@ export class QuantizedMeshPlugin {
 
 				this.layer = json;
 
-				if ( json.extensions.length > 0 ) {
+				if ( json.extensions?.length > 0 ) {
 
 					tiles.fetchOptions.header[ 'Accept' ] += `;extensions=${ json.extensions.join( '-' ) }`;
 

--- a/src/plugins/three/QuantizedMeshPlugin.js
+++ b/src/plugins/three/QuantizedMeshPlugin.js
@@ -15,12 +15,12 @@ const _vec = /* @__PURE__ */ new Vector3();
 function isAvailable( layer, level, x, y ) {
 
 	const {
-		minzoom,
-		maxzoom,
+		minzoom = 0,
+		maxzoom = Infinity,
 		available,
 	} = layer;
 
-	if ( level >= ( minzoom ?? 0 ) && level <= ( maxzoom ?? Infinity ) && level < available.length ) {
+	if ( level >= minzoom && level <= maxzoom && level < available.length ) {
 
 		// TODO: consider a binary search
 		const availableSet = available[ level ];
@@ -149,14 +149,18 @@ export class QuantizedMeshPlugin {
 			.then( json => {
 
 				this.layer = json;
+				const {
+					bounds,
+					projection = 'EPSG:4326',
+					extensions = []
+				} = json;
 
-				if ( json.extensions?.length > 0 ) {
+				if ( extensions.length > 0 ) {
 
-					tiles.fetchOptions.header[ 'Accept' ] += `;extensions=${ json.extensions.join( '-' ) }`;
+					tiles.fetchOptions.header[ 'Accept' ] += `;extensions=${ extensions.join( '-' ) }`;
 
 				}
 
-				const { bounds } = json;
 				const west = MathUtils.DEG2RAD * bounds[ 0 ];
 				const south = MathUtils.DEG2RAD * bounds[ 1 ];
 				const east = MathUtils.DEG2RAD * bounds[ 2 ];
@@ -180,7 +184,7 @@ export class QuantizedMeshPlugin {
 					},
 				};
 
-				const xTiles = json.projection === 'EPSG:4326' ? 2 : 1;
+				const xTiles = projection === 'EPSG:4326' ? 2 : 1;
 				for ( let x = 0; x < xTiles; x ++ ) {
 
 					const step = ( east - west ) / xTiles;


### PR DESCRIPTION
As mentioned [here](https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/1102#issuecomment-2854753190), I wanted to test the new `QuantizedMeshPlugin` with the officiel terrain of Switzerland ([layer.json](https://3d.geo.admin.ch/ch.swisstopo.terrain.3d/v1/layer.json)).

These changes allow the tileset to render, as the layer.json file properties are not exhaustive and errors where raised otherwise.

I even managed to texture the terrain with the Swiss official orthophotos, using the `TextureOverlayPlugin`, even though I currently have a few issues to load everything efficiently. This is also not the highest available quality of texture, since it takes the highest zoom level of the quantized mesh terrain and not the one of the orthophoto currently. WIP.

<img width="1510" alt="Capture d’écran 2025-05-15 à 00 14 34" src="https://github.com/user-attachments/assets/5e57a938-f925-4fb4-888c-5af7c6b3074c" />
