### PR TITLE
Fix load-tile-set event content to match type and docs

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -297,6 +297,7 @@ export class TilesRendererBase {
 					this.dispatchEvent( {
 						type: 'load-tile-set',
 						tileSet: root,
+						url: this.rootURL,
 					} );
 
 				} )


### PR DESCRIPTION
Similar to #1139 - we were using the url in the old onLoadTileset callback, and while it's in the type/docs for the new event, it's not passed in the code.

```
// Fired when a new root or child tile set is loaded.
{ type: 'load-tile-set', tileSet: Object, url: String }
```

Is this correct? at a glance in TilesRendererBase, it doesn't look like it fires when child tile set's are loaded, and if it DOES, then the url I added here is incorrect? 👋 catching up on a few years of changes - and our existing tileset's don't get past the root yet.