### PR TITLE
GoogleCloudAuthPlugin: Throw error when the session token response is not ok

### DIFF
--- a/src/plugins/three/GoogleCloudAuthPlugin.js
+++ b/src/plugins/three/GoogleCloudAuthPlugin.js
@@ -193,7 +193,7 @@ export class GoogleCloudAuthPlugin {
 
 					}
 
-					res.json();
+					return res.json();
 
 				} )
 				.then( res => {


### PR DESCRIPTION
This PR updates the GoogleCloudAuthPlugin to throw an error when the session token response is not ok.

**Issue to solve:**

GoogleCloudAuthPlugin proceeds to [traverse the content](https://github.com/NASA-AMMOS/3DTilesRendererJS/blob/12acc904a7037f27cb4eabc36170eadf4b20749f/src/plugins/three/GoogleCloudAuthPlugin.js#L4) even when the session token request fails, thus the error becomes:

```
TypeError: Cannot read properties of undefined (reading 'content') at ...
```

and we cannot determine the cause of the error, such as malformed tokens, too many requests, and so on.