### PR TITLE
ImageOverlayPlugin: Add support for cesium tiles

### DIFF
--- a/example/mapTiles.js
+++ b/example/mapTiles.js
@@ -51,6 +51,7 @@ function init() {
 	gui.add( params, 'errorTarget', 1, 40 ).onChange( () => {
 
 		tiles.getPluginByName( 'UPDATE_ON_CHANGE_PLUGIN' ).needsUpdate = true;
+		scheduleRender();
 
 	} );
 

--- a/example/quantMeshOverlays.html
+++ b/example/quantMeshOverlays.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+		<meta charset="utf-8"/>
+
+		<title>Quantized Mesh with Overlays Example</title>
+		<link rel="stylesheet" href="./styles.css">
+    </head>
+    <body>
+		<div id="info">
+			<div>
+				Quantized Mesh and tiled imagery overlay example using <a href="https://ion.cesium.com/">Cesium Ion</a> & <a href="https://www.openstreetmap.org/#map=8/19.769/-99.300">OpenStreetMap</a>.
+				<br/>
+				Cesium Ion API token required.
+			</div>
+		</div>
+
+		<div id="footer">
+			<div id="credits"></div>
+			<div id="logos">
+				<img src="./logos/cesiumion.png" />
+			</div>
+		</div>
+        <script type="module" src="./quantMeshOverlays.js"></script>
+    </body>
+</html>

--- a/example/quantMeshOverlays.js
+++ b/example/quantMeshOverlays.js
@@ -19,13 +19,14 @@ import Stats from 'three/examples/jsm/libs/stats.module.js';
 import { CesiumIonOverlay } from '../src/plugins/three/images/ImageOverlayPlugin.js';
 import { XYZTilesOverlay } from '../src/plugins/three/images/ImageOverlayPlugin.js';
 
-let controls, scene, renderer, tiles, camera, washingtonOverlay;
+let controls, scene, renderer, tiles, camera, washingtonOverlay, baseOverlay;
 let statsContainer, stats;
 
 const params = {
 
 	enableCacheDisplay: false,
 	enableRendererStats: false,
+	mapBase: false,
 	errorTarget: 2,
 	layerOpacity: 1.0,
 	reload: reinstantiateTiles,
@@ -58,16 +59,11 @@ function reinstantiateTiles() {
 		renderer,
 		resolution: 1024,
 		overlays: [
-			new XYZTilesOverlay( {
-				url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-			} ),
-			// new CesiumIonOverlay( {
-			// 	assetId: '3954',
-			// 	apiToken: import.meta.env.VITE_ION_KEY,
-			// } ),
 			washingtonOverlay,
 		]
 	} ) );
+
+	updateBaseOverlay();
 
 	tiles.group.rotation.x = - Math.PI / 2;
 	scene.add( tiles.group );
@@ -116,6 +112,7 @@ function init() {
 	gui.width = 300;
 	gui.add( params, 'enableCacheDisplay' );
 	gui.add( params, 'enableRendererStats' );
+	gui.add( params, 'mapBase' ).onChange( updateBaseOverlay );
 	gui.add( params, 'errorTarget', 1, 30, 1 );
 	gui.add( params, 'layerOpacity', 0, 1 ).onChange( v => {
 
@@ -132,6 +129,35 @@ function init() {
 	stats = new Stats();
 	stats.showPanel( 0 );
 	document.body.appendChild( stats.dom );
+
+}
+
+function updateBaseOverlay() {
+
+	const plugin = tiles.getPluginByName( 'IMAGE_OVERLAY_PLUGIN' );
+	if ( baseOverlay ) {
+
+		plugin.deleteOverlay( baseOverlay );
+		console.log('DELETED')
+
+	}
+
+	if ( params.mapBase ) {
+
+		baseOverlay = new XYZTilesOverlay( {
+			url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+		} );
+
+	} else {
+
+		baseOverlay = new CesiumIonOverlay( {
+			assetId: '3954',
+			apiToken: import.meta.env.VITE_ION_KEY,
+		} );
+
+	}
+
+	plugin.addOverlay( baseOverlay, - 1 );
 
 }
 

--- a/example/quantMeshOverlays.js
+++ b/example/quantMeshOverlays.js
@@ -57,10 +57,7 @@ function reinstantiateTiles() {
 	tiles.registerPlugin( new TilesFadePlugin() );
 	tiles.registerPlugin( new ImageOverlayPlugin( {
 		renderer,
-		resolution: 1024,
-		overlays: [
-			washingtonOverlay,
-		]
+		overlays: [ washingtonOverlay ],
 	} ) );
 
 	updateBaseOverlay();
@@ -138,7 +135,6 @@ function updateBaseOverlay() {
 	if ( baseOverlay ) {
 
 		plugin.deleteOverlay( baseOverlay );
-		console.log('DELETED')
 
 	}
 

--- a/example/quantMeshOverlays.js
+++ b/example/quantMeshOverlays.js
@@ -1,0 +1,224 @@
+import {
+	GlobeControls,
+	TilesRenderer,
+} from '3d-tiles-renderer';
+import {
+	TilesFadePlugin,
+	CesiumIonAuthPlugin,
+	ImageOverlayPlugin,
+} from '3d-tiles-renderer/plugins';
+import {
+	Scene,
+	WebGLRenderer,
+	PerspectiveCamera,
+	AmbientLight,
+	DirectionalLight,
+} from 'three';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import Stats from 'three/examples/jsm/libs/stats.module.js';
+import { CesiumIonOverlay } from '../src/plugins/three/images/ImageOverlayPlugin.js';
+import { XYZTilesOverlay } from '../src/plugins/three/images/ImageOverlayPlugin.js';
+
+let controls, scene, renderer, tiles, camera, washingtonOverlay;
+let statsContainer, stats;
+
+const params = {
+
+	enableCacheDisplay: false,
+	enableRendererStats: false,
+	errorTarget: 2,
+	layerOpacity: 1.0,
+	reload: reinstantiateTiles,
+
+};
+
+init();
+animate();
+
+function reinstantiateTiles() {
+
+	if ( tiles ) {
+
+		scene.remove( tiles.group );
+		tiles.dispose();
+		tiles = null;
+
+	}
+
+	washingtonOverlay = new CesiumIonOverlay( {
+		opacity: params.layerOpacity,
+		assetId: '3827',
+		apiToken: import.meta.env.VITE_ION_KEY,
+	} );
+
+	tiles = new TilesRenderer();
+	tiles.registerPlugin( new CesiumIonAuthPlugin( { apiToken: import.meta.env.VITE_ION_KEY, assetId: '1', autoRefreshToken: true } ) );
+	tiles.registerPlugin( new TilesFadePlugin() );
+	tiles.registerPlugin( new ImageOverlayPlugin( {
+		renderer,
+		resolution: 1024,
+		overlays: [
+			new XYZTilesOverlay( {
+				url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+			} ),
+			// new CesiumIonOverlay( {
+			// 	assetId: '3954',
+			// 	apiToken: import.meta.env.VITE_ION_KEY,
+			// } ),
+			washingtonOverlay,
+		]
+	} ) );
+
+	tiles.group.rotation.x = - Math.PI / 2;
+	scene.add( tiles.group );
+
+	tiles.setResolutionFromRenderer( camera, renderer );
+	tiles.setCamera( camera );
+
+	controls.setTilesRenderer( tiles );
+
+}
+
+function init() {
+
+	// renderer
+	renderer = new WebGLRenderer( { antialias: true } );
+	renderer.setClearColor( 0x151c1f );
+	document.body.appendChild( renderer.domElement );
+
+	// scene
+	scene = new Scene();
+
+	// camera and transition set up
+	camera = new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 1, 160000000 );
+	camera.position.set( 4800000, 2570000, 14720000 );
+	camera.lookAt( 0, 0, 0 );
+
+	// lights
+	const ambientLight = new AmbientLight( 0xffffff, 0.25 );
+	const dirLight = new DirectionalLight( 0xffffff, 3 );
+	dirLight.position.set( 1, 1, 1 );
+	camera.add( ambientLight, dirLight, dirLight.target );
+	scene.add( camera );
+
+	// controls
+	controls = new GlobeControls( scene, camera, renderer.domElement, null );
+	controls.enableDamping = true;
+
+	// initialize tiles
+	reinstantiateTiles();
+
+	onWindowResize();
+	window.addEventListener( 'resize', onWindowResize, false );
+
+	// GUI
+	const gui = new GUI();
+	gui.width = 300;
+	gui.add( params, 'enableCacheDisplay' );
+	gui.add( params, 'enableRendererStats' );
+	gui.add( params, 'errorTarget', 1, 30, 1 );
+	gui.add( params, 'layerOpacity', 0, 1 ).onChange( v => {
+
+		washingtonOverlay.opacity = v;
+		tiles.getPluginByName( 'IMAGE_OVERLAY_PLUGIN' ).needsUpdate = true;
+
+	} );
+	gui.add( params, 'reload' );
+
+	statsContainer = document.createElement( 'div' );
+	document.getElementById( 'info' ).appendChild( statsContainer );
+
+	// Stats
+	stats = new Stats();
+	stats.showPanel( 0 );
+	document.body.appendChild( stats.dom );
+
+}
+
+function onWindowResize() {
+
+	const aspect = window.innerWidth / window.innerHeight;
+
+	camera.aspect = aspect;
+	camera.updateProjectionMatrix();
+
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.setPixelRatio( window.devicePixelRatio );
+
+}
+
+function animate() {
+
+	requestAnimationFrame( animate );
+
+	if ( ! tiles ) return;
+
+	controls.update();
+
+	// update options
+	tiles.setResolutionFromRenderer( camera, renderer );
+	tiles.setCamera( camera );
+
+	// update tiles
+	camera.updateMatrixWorld();
+	tiles.errorTarget = params.errorTarget;
+	tiles.update();
+
+	renderer.render( scene, camera );
+	stats.update();
+
+	updateHtml();
+
+}
+
+function updateHtml() {
+
+	// render html text updates
+	let str = '';
+
+	if ( params.enableCacheDisplay ) {
+
+		const lruCache = tiles.lruCache;
+		const cacheFullness = lruCache.cachedBytes / lruCache.maxBytesSize;
+		str += `Downloading: ${ tiles.stats.downloading } Parsing: ${ tiles.stats.parsing } Visible: ${ tiles.visibleTiles.size }<br/>`;
+		str += `Cache: ${ ( 100 * cacheFullness ).toFixed( 2 ) }% ~${ ( lruCache.cachedBytes / 1000 / 1000 ).toFixed( 2 ) }mb<br/>`;
+
+	}
+
+	if ( params.enableRendererStats ) {
+
+		const memory = renderer.info.memory;
+		const render = renderer.info.render;
+		const programCount = renderer.info.programs.length;
+		str += `Geometries: ${ memory.geometries } Textures: ${ memory.textures } Programs: ${ programCount } Draw Calls: ${ render.calls }`;
+
+		const batchPlugin = tiles.getPluginByName( 'BATCHED_TILES_PLUGIN' );
+		const fadePlugin = tiles.getPluginByName( 'FADE_TILES_PLUGIN' );
+		if ( batchPlugin ) {
+
+			let tot = 0;
+			batchPlugin.batchedMesh?._instanceInfo.forEach( info => {
+
+				if ( info.visible && info.active ) tot ++;
+
+			} );
+
+			fadePlugin.batchedMesh?._instanceInfo.forEach( info => {
+
+				if ( info.visible && info.active ) tot ++;
+
+			} );
+
+			str += ', Batched: ' + tot;
+
+		}
+
+	}
+
+	if ( statsContainer.innerHTML !== str ) {
+
+		statsContainer.innerHTML = str;
+
+	}
+
+}

--- a/src/base/traverseFunctions.js
+++ b/src/base/traverseFunctions.js
@@ -245,20 +245,23 @@ export function markUsedTiles( tile, renderer ) {
 	}
 
 	// Disabled for now because this will cause otherwise unused children to be added to the lru cache
-	// if none of the children are in the frustum then this tile shouldn't be displayed
-	if ( tile.refine === 'REPLACE' && ! anyChildrenInFrustum && children.length !== 0 && ! tile.__hasUnrenderableContent ) {
+	// if none of the children are in the frustum then this tile shouldn't be displayed.
+	// Otherwise this can cause load oscillation as parents are traversed and loaded and then determined
+	// to not be used because children aren't visible. See #1165.
+	// if ( tile.refine === 'REPLACE' && ! anyChildrenInFrustum && children.length !== 0 && ! tile.__hasUnrenderableContent ) {
 
-		// TODO: we're not checking tiles with unrenderable content here since external tile sets might look like they're in the frustum,
-		// load the children, then the children indicate that it's not visible, causing it to be unloaded. Then it will be loaded again.
-		// The impact when including external tile set roots in the check is more significant but can't be used unless we keep external tile
-		// sets around even when they're not needed. See issue #741.
+	// 	// TODO: we're not checking tiles with unrenderable content here since external tile sets might look like they're in the frustum,
+	// 	// load the children, then the children indicate that it's not visible, causing it to be unloaded. Then it will be loaded again.
+	// 	// The impact when including external tile set roots in the check is more significant but can't be used unless we keep external tile
+	// 	// sets around even when they're not needed. See issue #741.
 
-		// TODO: what if we mark the tile as not in the frustum but we _do_ mark it as used? Then we can stop frustum traversal and at least
-		// prevent tiles from rendering unless they're needed.
-		tile.__inFrustum = false;
-		return;
+	// 	// TODO: what if we mark the tile as not in the frustum but we _do_ mark it as used? Then we can stop frustum traversal and at least
+	// 	// prevent tiles from rendering unless they're needed.
+	// 	console.log('FAILED')
+	// 	tile.__inFrustum = false;
+	// 	return;
 
-	}
+	// }
 
 	// wait until after the above condition to mark the traversed tile as used or not
 	markUsed( tile, renderer );

--- a/src/plugins/base/auth/CesiumIonAuth.js
+++ b/src/plugins/base/auth/CesiumIonAuth.js
@@ -1,0 +1,92 @@
+export class CesiumIonAuth {
+
+	constructor( options = {} ) {
+
+		const { apiToken, autoRefreshToken = false } = options;
+		this.apiToken = apiToken;
+		this.autoRefreshToken = autoRefreshToken;
+		this.authURL = null;
+		this._tokenRefreshPromise = null;
+		this._bearerToken = null;
+
+	}
+
+	async fetch( url, options ) {
+
+		await this._tokenRefreshPromise;
+
+		const fetchOptions = { ...options };
+		fetchOptions.headers = fetchOptions.headers || {};
+		fetchOptions.headers = {
+			...fetchOptions.headers,
+			Authorization: this._bearerToken,
+		};
+
+		const res = await fetch( url, fetchOptions );
+		if ( res.status >= 400 && res.status <= 499 && this.autoRefreshToken ) {
+
+			await this.refreshToken( options );
+			return fetch( this.preprocessURL( url ), options );
+
+		} else {
+
+			return res;
+
+		}
+
+	}
+
+	dispose() {
+
+		this._disposed = true;
+
+	}
+
+	refreshToken( options ) {
+
+		if ( this._tokenRefreshPromise === null ) {
+
+			// construct the url to fetch the endpoint
+			const url = new URL( this.authURL );
+			url.searchParams.append( 'access_token', this.apiToken );
+
+			this._tokenRefreshPromise = fetch( url, options )
+				.then( res => {
+
+					if ( this._disposed ) {
+
+						return null;
+
+					}
+
+					if ( ! res.ok ) {
+
+						throw new Error( `CesiumIonAuthPlugin: Failed to load data with error code ${ res.status }` );
+
+					}
+
+					return res.json();
+
+				} )
+				.then( json => {
+
+					if ( this._disposed ) {
+
+						return null;
+
+					}
+
+					this._bearerToken = `Bearer ${ json.accessToken }`;
+					this._tokenRefreshPromise = null;
+
+					return json;
+
+				} );
+
+		}
+
+		return this._tokenRefreshPromise;
+
+	}
+
+}

--- a/src/plugins/base/auth/CesiumIonAuth.js
+++ b/src/plugins/base/auth/CesiumIonAuth.js
@@ -38,12 +38,6 @@ export class CesiumIonAuth {
 
 	}
 
-	dispose() {
-
-		this._disposed = true;
-
-	}
-
 	refreshToken( options ) {
 
 		if ( this._tokenRefreshPromise === null ) {
@@ -55,12 +49,6 @@ export class CesiumIonAuth {
 			this._tokenRefreshPromise = fetch( url, options )
 				.then( res => {
 
-					if ( this._disposed ) {
-
-						return null;
-
-					}
-
 					if ( ! res.ok ) {
 
 						throw new Error( `CesiumIonAuthPlugin: Failed to load data with error code ${ res.status }` );
@@ -71,12 +59,6 @@ export class CesiumIonAuth {
 
 				} )
 				.then( json => {
-
-					if ( this._disposed ) {
-
-						return null;
-
-					}
 
 					this._bearerToken = `Bearer ${ json.accessToken }`;
 					this._tokenRefreshPromise = null;

--- a/src/plugins/base/auth/CesiumIonAuth.js
+++ b/src/plugins/base/auth/CesiumIonAuth.js
@@ -15,6 +15,7 @@ export class CesiumIonAuth {
 
 		await this._tokenRefreshPromise;
 
+		// insert the authorization token
 		const fetchOptions = { ...options };
 		fetchOptions.headers = fetchOptions.headers || {};
 		fetchOptions.headers = {
@@ -22,6 +23,7 @@ export class CesiumIonAuth {
 			Authorization: this._bearerToken,
 		};
 
+		// try to refresh the token if we failed ot render
 		const res = await fetch( url, fetchOptions );
 		if ( res.status >= 400 && res.status <= 499 && this.autoRefreshToken ) {
 

--- a/src/plugins/base/auth/CesiumIonAuth.js
+++ b/src/plugins/base/auth/CesiumIonAuth.js
@@ -1,3 +1,4 @@
+// Class for making fetches to Cesium Ion, refreshing the token if needed.
 export class CesiumIonAuth {
 
 	constructor( options = {} ) {

--- a/src/plugins/base/auth/CesiumIonAuth.js
+++ b/src/plugins/base/auth/CesiumIonAuth.js
@@ -28,7 +28,7 @@ export class CesiumIonAuth {
 		if ( res.status >= 400 && res.status <= 499 && this.autoRefreshToken ) {
 
 			await this.refreshToken( options );
-			return fetch( this.preprocessURL( url ), options );
+			return fetch( url, fetchOptions );
 
 		} else {
 

--- a/src/plugins/three/CesiumIonAuthPlugin.js
+++ b/src/plugins/three/CesiumIonAuthPlugin.js
@@ -101,7 +101,16 @@ export class CesiumIonAuthPlugin {
 
 	fetchData( uri, options ) {
 
-		return this.auth.fetch( uri, options );
+		const tiles = this.tiles;
+		if ( tiles.getPluginByName( 'GOOGLE_CLOUD_AUTH_PLUGIN' ) !== null ) {
+
+			return null;
+
+		} else {
+
+			return this.auth.fetch( uri, options );
+
+		}
 
 	}
 

--- a/src/plugins/three/CesiumIonAuthPlugin.js
+++ b/src/plugins/three/CesiumIonAuthPlugin.js
@@ -184,10 +184,4 @@ export class CesiumIonAuthPlugin {
 
 	}
 
-	dispose() {
-
-		this.auth.dispose();
-
-	}
-
 }

--- a/src/plugins/three/GoogleCloudAuthPlugin.js
+++ b/src/plugins/three/GoogleCloudAuthPlugin.js
@@ -133,6 +133,7 @@ export class GoogleCloudAuthPlugin {
 		uri = new URL( uri );
 		if ( /^http/.test( uri.protocol ) ) {
 
+			uri.searchParams.delete( 'key' );
 			uri.searchParams.append( 'key', this.apiToken );
 			if ( this.sessionToken !== null ) {
 

--- a/src/plugins/three/QuantizedMeshPlugin.js
+++ b/src/plugins/three/QuantizedMeshPlugin.js
@@ -359,9 +359,6 @@ export class QuantizedMeshPlugin {
 
 	expandChildren( tile ) {
 
-		tile.children.length = 0;
-		tile.__childrenProcessed = 0;
-
 		const level = tile[ TILE_LEVEL ];
 		const x = tile[ TILE_X ];
 		const y = tile[ TILE_Y ];

--- a/src/plugins/three/QuantizedMeshPlugin.js
+++ b/src/plugins/three/QuantizedMeshPlugin.js
@@ -104,6 +104,7 @@ export class QuantizedMeshPlugin {
 	// Plugin function
 	init( tiles ) {
 
+		// TODO: should we avoid setting this globally?
 		tiles.fetchOptions.headers = tiles.fetchOptions.headers || {};
 		tiles.fetchOptions.headers.Accept = 'application/vnd.quantized-mesh,application/octet-stream;q=0.9';
 
@@ -116,22 +117,6 @@ export class QuantizedMeshPlugin {
 		this.tiles = tiles;
 
 	}
-
-	// NOTE: we expand children only once the mesh data is loaded to ensure the mesh
-	// data is ready for clipping
-	// preprocessNode( tile, dir, parentTile ) {
-
-	// 	// generate children
-	// 	const level = tile[ TILE_LEVEL ];
-	// 	const maxLevel = getMaxLevel( this.layer );
-	// 	const hasMetadata = getTileHasMetadata( tile, this.layer );
-	// 	if ( level >= 0 && level < maxLevel && ! hasMetadata ) {
-
-	// 		this.expandChildren( tile );
-
-	// 	}
-
-	// }
 
 	loadRootTileSet() {
 

--- a/src/plugins/three/QuantizedMeshPlugin.js
+++ b/src/plugins/three/QuantizedMeshPlugin.js
@@ -104,8 +104,8 @@ export class QuantizedMeshPlugin {
 	// Plugin function
 	init( tiles ) {
 
-		tiles.fetchOptions.header = tiles.fetchOptions.header || {};
-		tiles.fetchOptions.header.Accept = 'application/vnd.quantized-mesh,application/octet-stream;q=0.9';
+		tiles.fetchOptions.headers = tiles.fetchOptions.headers || {};
+		tiles.fetchOptions.headers.Accept = 'application/vnd.quantized-mesh,application/octet-stream;q=0.9';
 
 		if ( this.useRecommendedSettings ) {
 
@@ -174,7 +174,7 @@ export class QuantizedMeshPlugin {
 				// extensions
 				if ( extensions.length > 0 ) {
 
-					tiles.fetchOptions.header[ 'Accept' ] += `;extensions=${ extensions.join( '-' ) }`;
+					tiles.fetchOptions.headers[ 'Accept' ] += `;extensions=${ extensions.join( '-' ) }`;
 
 				}
 

--- a/src/plugins/three/images/ImageFormatPlugin.js
+++ b/src/plugins/three/images/ImageFormatPlugin.js
@@ -74,7 +74,7 @@ export class ImageFormatPlugin {
 		const tx = tile[ TILE_X ];
 		const ty = tile[ TILE_Y ];
 		const level = tile[ TILE_LEVEL ];
-		const texture = await this.imageSource.processBuffer( buffer );
+		const texture = await this.imageSource.processBufferToTexture( buffer );
 		this.imageSource.setData( tx, ty, level, texture );
 
 		// Construct mesh

--- a/src/plugins/three/images/ImageOverlayPlugin.d.ts
+++ b/src/plugins/three/images/ImageOverlayPlugin.d.ts
@@ -39,3 +39,16 @@ export class TMSTilesOverlay extends ImageOverlay {
 	} );
 
 }
+
+export class CesiumIonOverlay extends ImageOverlay {
+
+	constructor( options: {
+		assetId: number | string,
+		apiToken: string,
+		autoRefreshToken?: boolean
+
+		color: number | Color,
+		opacity: number,
+	} );
+
+}

--- a/src/plugins/three/images/ImageOverlayPlugin.js
+++ b/src/plugins/three/images/ImageOverlayPlugin.js
@@ -79,8 +79,8 @@ export class ImageOverlayPlugin {
 
 			if ( this.needsUpdate ) {
 
-				const overlayOrder = this.overlayOrder;
-				this.overlays.sort( ( a, b ) => {
+				const { overlays, overlayOrder } = this;
+				overlays.sort( ( a, b ) => {
 
 					return overlayOrder.get( a ) - overlayOrder.get( b );
 
@@ -93,7 +93,7 @@ export class ImageOverlayPlugin {
 				const id = execId;
 
 				// wait for all overlays to be ready
-				const promises = this.overlays.map( overlay => overlay.whenReady() );
+				const promises = overlays.map( overlay => overlay.whenReady() );
 				await Promise.all( promises );
 
 				if ( id === execId ) {
@@ -295,7 +295,6 @@ export class ImageOverlayPlugin {
 
 	async initTileState( scene, tile ) {
 
-		const overlays = this.overlays;
 		const { tiles, tileMeshInfo, resolution } = this;
 		const { ellipsoid, group } = tiles;
 

--- a/src/plugins/three/images/ImageOverlayPlugin.js
+++ b/src/plugins/three/images/ImageOverlayPlugin.js
@@ -184,7 +184,7 @@ export class ImageOverlayPlugin {
 
 		// dispose of all overlays
 		const overlays = [ ...this.overlays ];
-		overlays.forEach( ( { overlay } ) => {
+		overlays.forEach( overlay => {
 
 			this.deleteOverlay( overlay );
 
@@ -224,7 +224,7 @@ export class ImageOverlayPlugin {
 
 	setOverlayOrder( overlay, order ) {
 
-		const index = this.overlays.findIndex( info => info.overlay === overlay );
+		const index = this.overlays.indexOf( overlay );
 		if ( index !== - 1 ) {
 
 			this.overlayOrder.set( overlay, order );
@@ -236,7 +236,7 @@ export class ImageOverlayPlugin {
 
 	deleteOverlay( overlay ) {
 
-		const index = this.overlays.findIndex( info => info.overlay === overlay );
+		const index = this.overlays.indexOf( overlay );
 		if ( index !== - 1 ) {
 
 			overlay.dispose();

--- a/src/plugins/three/images/ImageOverlayPlugin.js
+++ b/src/plugins/three/images/ImageOverlayPlugin.js
@@ -161,6 +161,20 @@ export class ImageOverlayPlugin {
 
 	}
 
+	getAttributions( target ) {
+
+		this.overlays.forEach( overlay => {
+
+			if ( overlay.opacity > 0 ) {
+
+				overlay.getAttributions( target );
+
+			}
+
+		} );
+
+	}
+
 	dispose() {
 
 		// dispose textures
@@ -414,6 +428,10 @@ class ImageOverlay {
 
 	}
 
+	getAttributions( target ) {
+
+	}
+
 	dispose() {
 
 		this.imageSource.dispose();
@@ -483,6 +501,7 @@ export class CesiumIonOverlay extends ImageOverlay {
 
 		this.auth.authURL = `https://api.cesium.com/v1/assets/${ assetId }/endpoint`;
 		this.imageSource.fetchData = ( ...args ) => this.auth.fetch( ...args );
+		this._attributions = [];
 
 	}
 
@@ -493,6 +512,11 @@ export class CesiumIonOverlay extends ImageOverlay {
 			.refreshToken()
 			.then( json => {
 
+				this._attributions = json.attributions.map( att => ( {
+					value: att.html,
+					type: 'html',
+					collapsible: att.collapsible,
+				} ) );
 				return this.imageSource.init( json.url );
 
 			} );
@@ -502,6 +526,12 @@ export class CesiumIonOverlay extends ImageOverlay {
 	whenReady() {
 
 		return this._whenReady;
+
+	}
+
+	getAttributions( target ) {
+
+		target.push( ...this._attributions );
 
 	}
 

--- a/src/plugins/three/images/ImageOverlayPlugin.js
+++ b/src/plugins/three/images/ImageOverlayPlugin.js
@@ -357,6 +357,7 @@ export class ImageOverlayPlugin {
 			if ( map ) {
 
 				tileComposer.draw( map, range );
+				map.dispose();
 
 			} else {
 
@@ -369,7 +370,6 @@ export class ImageOverlayPlugin {
 			uvRemapper.setUVs( uv, geometry.getAttribute( 'uv' ), geometry.index );
 			uvRemapper.draw( scratchTarget.texture );
 			material.map = target.texture;
-			map.dispose();
 
 		} );
 

--- a/src/plugins/three/images/ImageOverlayPlugin.js
+++ b/src/plugins/three/images/ImageOverlayPlugin.js
@@ -185,6 +185,7 @@ export class ImageOverlayPlugin {
 
 		const { tiles, activeOverlays } = this;
 		overlay.imageSource.fetchOptions = tiles.fetchOptions;
+		overlay.init();
 
 		if ( order === null ) {
 
@@ -416,7 +417,13 @@ export class XYZTilesOverlay extends ImageOverlay {
 
 		super( options );
 		this.imageSource = new XYZImageSource( options );
-		this._whenReady = this.imageSource.init( options.url );
+		this.url = options.url;
+
+	}
+
+	init() {
+
+		this._whenReady = this.imageSource.init( this.url );
 
 	}
 
@@ -434,7 +441,13 @@ export class TMSTilesOverlay extends ImageOverlay {
 
 		super( options );
 		this.imageSource = new TMSImageSource( options );
-		this._whenReady = this.imageSource.init( options.url );
+		this.url = options.url;
+
+	}
+
+	init() {
+
+		this._whenReady = this.imageSource.init( this.url );
 
 	}
 
@@ -459,6 +472,11 @@ export class CesiumIonOverlay extends ImageOverlay {
 
 		this.auth.authURL = `https://api.cesium.com/v1/assets/${ assetId }/endpoint`;
 		this.imageSource.fetchData = ( ...args ) => this.auth.fetch( ...args );
+
+	}
+
+	init() {
+
 		this._whenReady = this
 			.auth
 			.refreshToken()

--- a/src/plugins/three/images/ImageOverlayPlugin.js
+++ b/src/plugins/three/images/ImageOverlayPlugin.js
@@ -59,9 +59,15 @@ export class ImageOverlayPlugin {
 		} );
 
 		// init overlays
-		const overlays = this.overlays;
+		const { overlays, overlayOrder } = this;
 		this.overlays = [];
 		overlays.forEach( ( overlay, order ) => {
+
+			if ( overlayOrder.has( overlay ) ) {
+
+				order = overlayOrder.overlay;
+
+			}
 
 			this.addOverlay( overlay, order );
 

--- a/src/plugins/three/images/ImageOverlayPlugin.js
+++ b/src/plugins/three/images/ImageOverlayPlugin.js
@@ -215,7 +215,6 @@ export class ImageOverlayPlugin {
 
 		this.tiles.removeEventListener( 'update-after', this._onUpdateAfter );
 
-
 	}
 
 	// public
@@ -408,6 +407,15 @@ export class ImageOverlayPlugin {
 
 		// reset the meshes
 		this.resetTileOverlay( tile );
+
+		// if there are no overlays then don't bother copying texture data.
+		// this also doubles as a check for when the plugin has been disposed and async
+		// functions are continuing to run.
+		if ( overlays.length === 0 ) {
+
+			return;
+
+		}
 
 		const meshInfo = tileMeshInfo.get( tile );
 		meshInfo.forEach( ( info, mesh ) => {

--- a/src/plugins/three/images/overlays/TiledTextureComposer.js
+++ b/src/plugins/three/images/overlays/TiledTextureComposer.js
@@ -64,6 +64,8 @@ export class TiledTextureComposer {
 		renderer.setRenderTarget( currentRenderTarget );
 		renderer.autoClear = currentAutoClear;
 
+		material.map = null;
+
 	}
 
 	// clear the set target

--- a/src/plugins/three/images/overlays/UVRemapper.js
+++ b/src/plugins/three/images/overlays/UVRemapper.js
@@ -48,6 +48,8 @@ export class UVRemapper {
 		renderer.setRenderTarget( currentRenderTarget );
 		renderer.autoClear = currentAutoClear;
 
+		material.map = null;
+
 	}
 
 	dispose() {
@@ -122,7 +124,7 @@ function ensureBufferAttribute( buffer ) {
 
 	if ( buffer instanceof BufferAttribute ) {
 
-		return buffer;
+		return buffer.clone();
 
 	} else if ( buffer instanceof Float32Array ) {
 

--- a/src/plugins/three/images/overlays/utils.js
+++ b/src/plugins/three/images/overlays/utils.js
@@ -3,12 +3,13 @@ import { Vector3 } from 'three';
 // iterates over all present tiles in the given tile set at the given level in the given range
 export function forEachTileInBounds( range, level, tiling, callback ) {
 
-	// pull the bounds in a bit to avoid loading unnecessary tiles
+	// pull the bounds in a bit to avoid loading unnecessary tiles. 1e-7 was chosen since smaller values
+	// are not larger enough and cause extra tiles to load in cases where 1-to-1 tile-to-image should occur
 	let [ minLon, minLat, maxLon, maxLat ] = range;
-	minLat += 1e-5;
-	minLon += 1e-5;
-	maxLat -= 1e-5;
-	maxLon -= 1e-5;
+	minLat += 1e-7;
+	minLon += 1e-7;
+	maxLat -= 1e-7;
+	maxLon -= 1e-7;
 
 	const clampedLevel = Math.max( Math.min( level, tiling.maxLevel ), tiling.minLevel );
 	const [ minX, minY, maxX, maxY ] = tiling.getTilesInRange( minLon, minLat, maxLon, maxLat, clampedLevel );

--- a/src/plugins/three/images/sources/TMSImageSource.js
+++ b/src/plugins/three/images/sources/TMSImageSource.js
@@ -24,7 +24,7 @@ export class TMSImageSource extends TiledImageSource {
 	init( url ) {
 
 		return this
-			.fetchData( url, this.fetchOptions )
+			.fetchData( new URL( 'tilemapresource.xml', url ), this.fetchOptions )
 			.then( res => res.text() )
 			.then( text => {
 

--- a/src/plugins/three/images/sources/TiledImageSource.js
+++ b/src/plugins/three/images/sources/TiledImageSource.js
@@ -1,6 +1,7 @@
 import { DataCache } from '../utils/DataCache.js';
 import { TilingScheme } from '../utils/TilingScheme.js';
 import { SRGBColorSpace, Texture } from 'three';
+import * as THREE from 'three';
 
 // TODO: support queries for detail at level - ie projected pixel size for geometric error mapping
 // Goes here or in "TilingScheme"?
@@ -35,6 +36,23 @@ export class TiledImageSource extends DataCache {
 		texture.needsUpdate = true;
 
 		return texture;
+
+	}
+
+	getMemoryUsage( tex ) {
+
+		// deprecated: remove in next major release
+		const { TextureUtils } = THREE;
+		if ( ! TextureUtils ) {
+
+			return 0;
+
+		}
+
+		const { format, type, image, generateMipmaps } = tex;
+		const { width, height } = image;
+		const bytes = TextureUtils.getByteLength( width, height, format, type );
+		return generateMipmaps ? bytes * 4 / 3 : bytes;
 
 	}
 

--- a/src/plugins/three/images/utils/DataCache.js
+++ b/src/plugins/three/images/utils/DataCache.js
@@ -163,7 +163,6 @@ export class DataCache {
 				delete cache[ key ];
 				this.count --;
 				this.cachedBytes -= info.bytes;
-				console.log()
 
 			}
 

--- a/src/plugins/three/images/utils/DataCache.js
+++ b/src/plugins/three/images/utils/DataCache.js
@@ -11,12 +11,19 @@ export class DataCache {
 	constructor() {
 
 		this.cache = {};
+		this.count = 0;
+		this.cachedBytes = 0;
 
 	}
 
 	// overridable
 	fetchItem() {}
 	disposeItem() {}
+	getMemoryUsage( item ) {
+
+		return 0;
+
+	}
 
 	// sets the data in the cache explicitly without need to load
 	setData( ...args ) {
@@ -34,7 +41,10 @@ export class DataCache {
 				abortController: new AbortController(),
 				result: data,
 				count: 1,
+				bytes: this.getMemoryUsage( data ),
 			};
+			this.count ++;
+			this.cachedBytes += this.cache[ key ].bytes;
 
 		}
 
@@ -58,17 +68,21 @@ export class DataCache {
 				abortController,
 				result: null,
 				count: 1,
+				bytes: 0,
 			};
 
 			info.result = this.fetchItem( ...args, abortController.signal )
 				.then( res => {
 
 					info.result = res;
+					info.bytes = this.getMemoryUsage( res );
+					this.cachedBytes += info.bytes;
 					return res;
 
 				} );
 
 			this.cache[ key ] = info;
+			this.count ++;
 
 		}
 
@@ -79,41 +93,8 @@ export class DataCache {
 	// decrements the lock counter for the item and deletes the item if it has reached zero
 	release( ...args ) {
 
-		const { cache } = this;
 		const key = hash( ...args );
-		if ( key in cache ) {
-
-			// decrement the lock
-			const info = cache[ key ];
-			info.count --;
-
-			// if the item is no longer being used
-			if ( info.count === 0 ) {
-
-				const { result, abortController } = info;
-				abortController.abort();
-
-				// dispose of the object even if it still is in progress
-				if ( result instanceof Promise ) {
-
-					// "disposeItem" will throw potentially if fetch, etc are cancelled using the abort signal
-					result.then( item => this.disposeItem( item ) ).catch( () => {} );
-
-				} else {
-
-					this.disposeItem( result );
-
-				}
-
-				delete cache[ key ];
-
-			}
-
-			return true;
-
-		}
-
-		return false;
+		this.releaseViaFullKey( key );
 
 	}
 
@@ -140,22 +121,57 @@ export class DataCache {
 		const { cache } = this;
 		for ( const key in cache ) {
 
-			const { abortController, result } = cache[ key ];
+			const { abortController } = cache[ key ];
 			abortController.abort();
 
-			if ( result instanceof Promise ) {
-
-				result.then( item => this.disposeItem( item ) ).catch( () => {} );
-
-			} else {
-
-				this.disposeItem( result );
-
-			}
+			this.releaseViaFullKey( key, true );
 
 		}
 
 		this.cache = {};
+
+	}
+
+	// releases an item with an optional force flag
+	releaseViaFullKey( key, force = false ) {
+
+		const { cache } = this;
+		if ( key in cache ) {
+
+			// decrement the lock
+			const info = cache[ key ];
+			info.count --;
+
+			// if the item is no longer being used
+			if ( info.count === 0 || force ) {
+
+				const { result, abortController } = info;
+				abortController.abort();
+
+				// dispose of the object even if it still is in progress
+				if ( result instanceof Promise ) {
+
+					// "disposeItem" will throw potentially if fetch, etc are cancelled using the abort signal
+					result.then( item => this.disposeItem( item ) ).catch( () => {} );
+
+				} else {
+
+					this.disposeItem( result );
+
+				}
+
+				delete cache[ key ];
+				this.count --;
+				this.cachedBytes -= info.bytes;
+				console.log()
+
+			}
+
+			return true;
+
+		}
+
+		return false;
 
 	}
 

--- a/src/three/utilities.js
+++ b/src/three/utilities.js
@@ -5,6 +5,7 @@ import * as THREE from 'three';
 export function estimateBytesUsed( object ) {
 
 	// NOTE: This is for backwards compatibility and should be removed later
+	// deprecated: remove in next major release
 	const { TextureUtils } = THREE;
 	if ( ! TextureUtils ) {
 


### PR DESCRIPTION
Related to #1155 

**TODO**
- ~Fix the load oscillation~
  - Caused by deleting tiles, losing cached tile size. Tiles are deleted once the size is understood, children size is lost.
  - Specific to Quantized mesh? Only tiles that resolve to 0 size can be deleted this way. Why not dispose as is normal? Why delete split meshes?
  - auto set butes size from inferred split?
  - why doesn't it settle?
  - It seems that the parent is getting removed before the children? How?
  - Possibly due to inconsistent ways that items are marked as "used".
  - see [this link](http://localhost:5173/googleMapsExample.html#lat=38.1196&lon=-78.9054&height=25204.82&az=9.38&el=-43.50&roll=0.00).

- ~Fix layer adding / removal~
- ~Quick disposal causes texture accumulation.~