### PR TITLE
Google Maps Example fix hash in orthographic mode

### DIFF
--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -272,7 +272,7 @@ function initFromHash() {
 	tiles.group.updateMatrixWorld();
 
 	// get the position fields
-	const camera = transition.camera;
+	const camera = transition.perspectiveCamera;
 	const lat = parseFloat( urlParams.get( 'lat' ) );
 	const lon = parseFloat( urlParams.get( 'lon' ) );
 	const height = parseFloat( urlParams.get( 'height' ) ) || 1000;
@@ -305,6 +305,15 @@ function initFromHash() {
 		WGS84_ELLIPSOID.getCartographicToPosition( lat * MathUtils.DEG2RAD, lon * MathUtils.DEG2RAD, height, camera.position );
 		camera.position.applyMatrix4( tiles.group.matrixWorld );
 		camera.lookAt( 0, 0, 0 );
+
+	}
+
+	if ( transition.mode !== 'perspective' ) {
+
+		const currentMode = transition.mode;
+		transition.mode = 'perspective';
+		transition.syncCameras();
+		transition.mode = currentMode;
 
 	}
 

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -207,7 +207,13 @@ function updateHash() {
 
 	}
 
-	const camera = transition.camera;
+	if ( transition.mode !== 'perspective' ) {
+
+		transition.syncCameras();
+
+	}
+
+	const camera = transition.perspectiveCamera;
 	const cartographicResult = {};
 	const orientationResult = {};
 	const tilesMatInv = tiles.group.matrixWorld.clone().invert();

--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -209,6 +209,7 @@ function updateHash() {
 
 	if ( transition.mode !== 'perspective' ) {
 
+		controls.getPivotPoint( transition.fixedPoint );
 		transition.syncCameras();
 
 	}


### PR DESCRIPTION
Hi, heres the PR for #1166.

Currently this just adjusts `updateHash` to always use the perspective camera.

I'm not sure how to properly adjust `initFromHash`. It would be nice to do it similarly but `syncCameras` would need to sync from perspective to orthographic and I'm unsure how to accomplish that without briefly changing the `transition.mode` or meddling with internals in order to force `fromCamera` to the perspective camera. Maybe we could add an optional parameter to `syncCameras` to explicitly specify the sync direction?