### PR TITLE
ReorientationPlugin: Add missing transformLatlonHeightToOrigin method to type definition

### DIFF
--- a/src/plugins/three/ReorientationPlugin.d.ts
+++ b/src/plugins/three/ReorientationPlugin.d.ts
@@ -9,4 +9,6 @@ export class ReorientationPlugin {
 		height?: number,
 	} );
 
+	transformLatLonHeightToOrigin( lat: number, lon: number, height?: number ): void;
+
 }


### PR DESCRIPTION
Adds the missing `transformLatlonHeightToOrigin` method to the `ReorientationPlugin` TypeScript definitions.

This method is available at runtime but was not declared in the types, which caused a TypeScript error when using it as documented.

Fixes #1168

