### PR TITLE
Make `enabled` in `DebugTilesPlugin` robust.

### DIFF
--- a/src/plugins/three/DebugTilesPlugin.d.ts
+++ b/src/plugins/three/DebugTilesPlugin.d.ts
@@ -12,7 +12,22 @@ export const IS_LEAF : ColorMode;
 export const RANDOM_COLOR : ColorMode;
 export const RANDOM_NODE_COLOR: ColorMode;
 export const CUSTOM_COLOR: ColorMode;
+
 export class DebugTilesPlugin {
+
+	constructor( options?: {
+		displayParentBounds?: boolean,
+		displayBoxBounds?: boolean,
+		displaySphereBounds?: boolean,
+		displayRegionBounds?: boolean,
+		colorMode?: ColorMode,
+		maxDebugDepth?: number,
+		maxDebugDistance?: number,
+		maxDebugError?: number,
+		customColorCallback?: ( val: Tile, target: Color ) => void,
+		unlit?: boolean,
+		enabled?: boolean,
+	} );
 
 	static ColorModes: typeof ColorMode;
 

--- a/src/plugins/three/DebugTilesPlugin.js
+++ b/src/plugins/three/DebugTilesPlugin.js
@@ -13,7 +13,7 @@ const _sphere = /* @__PURE__ */ new Sphere();
 const emptyRaycast = () => {};
 const colors = {};
 
-// Return a consistant random color for an index
+// Return a consistent random color for an index
 export function getIndexedRandomColor( index ) {
 
 	if ( ! colors[ index ] ) {
@@ -111,13 +111,13 @@ export class DebugTilesPlugin {
 			maxDebugError: - 1,
 			customColorCallback: null,
 			unlit: false,
+			enabled: true,
 			...options,
 		};
 
 		this.name = 'DEBUG_TILES_PLUGIN';
 		this.tiles = null;
 
-		this._enabled = true;
 		this._colorMode = null;
 		this._unlit = null;
 		this.materialsNeedUpdate = false;
@@ -129,6 +129,7 @@ export class DebugTilesPlugin {
 		this.regionGroup = null;
 
 		// options
+		this._enabled = options.enabled;
 		this._displayParentBounds = options.displayParentBounds;
 		this.displayBoxBounds = options.displayBoxBounds;
 		this.displaySphereBounds = options.displaySphereBounds;
@@ -158,19 +159,17 @@ export class DebugTilesPlugin {
 
 		if ( v !== this._enabled ) {
 
-			this._enabled = v;
-
-			if ( this._enabled ) {
-
-				if ( this.tiles ) {
-
-					this.init( this.tiles );
-
-				}
-
-			} else {
+			if (!v) {
 
 				this.dispose();
+
+			}
+
+			this._enabled = v;
+
+			if ( this._enabled && this.tiles ) {
+
+				this.init( this.tiles );
 
 			}
 
@@ -223,6 +222,12 @@ export class DebugTilesPlugin {
 	init( tiles ) {
 
 		this.tiles = tiles;
+
+		if (!this.enabled) {
+
+			return;
+
+		}
 
 		// initialize groups
 		const tilesGroup = tiles.group;
@@ -922,6 +927,12 @@ export class DebugTilesPlugin {
 	}
 
 	dispose() {
+
+		if (!this.enabled) {
+
+			return;
+
+		}
 
 		const tiles = this.tiles;
 

--- a/src/plugins/three/DebugTilesPlugin.js
+++ b/src/plugins/three/DebugTilesPlugin.js
@@ -934,26 +934,22 @@ export class DebugTilesPlugin {
 
 		const tiles = this.tiles;
 
-		if ( tiles ) {
+		tiles.removeEventListener( 'load-tile-set', this._onLoadTileSetCB );
+		tiles.removeEventListener( 'load-model', this._onLoadModelCB );
+		tiles.removeEventListener( 'dispose-model', this._onDisposeModelCB );
+		tiles.removeEventListener( 'update-after', this._onUpdateAfterCB );
+		tiles.removeEventListener( 'tile-visibility-change', this._onTileVisibilityChangeCB );
 
-			tiles.removeEventListener( 'load-tile-set', this._onLoadTileSetCB );
-			tiles.removeEventListener( 'load-model', this._onLoadModelCB );
-			tiles.removeEventListener( 'dispose-model', this._onDisposeModelCB );
-			tiles.removeEventListener( 'update-after', this._onUpdateAfterCB );
-			tiles.removeEventListener( 'tile-visibility-change', this._onTileVisibilityChangeCB );
+		// reset all materials
+		this.colorMode = NONE;
+		this._onUpdateAfter();
 
-			// reset all materials
-			this.colorMode = NONE;
-			this._onUpdateAfter();
+		// dispose of all helper objects
+		tiles.traverse( tile => {
 
-			// dispose of all helper objects
-			tiles.traverse( tile => {
+			this._onDisposeModel( tile );
 
-				this._onDisposeModel( tile );
-
-			} );
-
-		}
+		} );
 
 		this.boxGroup?.removeFromParent();
 		this.sphereGroup?.removeFromParent();

--- a/src/plugins/three/DebugTilesPlugin.js
+++ b/src/plugins/three/DebugTilesPlugin.js
@@ -157,23 +157,21 @@ export class DebugTilesPlugin {
 
 	set enabled( v ) {
 
-		if ( v !== this._enabled ) {
+		if ( v !== this._enabled && this.tiles !== null ) {
 
-			if ( ! v ) {
+			if ( v ) {
+
+				this.init( this.tiles );
+
+			} else {
 
 				this.dispose();
 
 			}
 
-			this._enabled = v;
-
-			if ( this._enabled && this.tiles ) {
-
-				this.init( this.tiles );
-
-			}
-
 		}
+
+		this._enabled = v;
 
 	}
 

--- a/src/plugins/three/DebugTilesPlugin.js
+++ b/src/plugins/three/DebugTilesPlugin.js
@@ -159,7 +159,7 @@ export class DebugTilesPlugin {
 
 		if ( v !== this._enabled ) {
 
-			if (!v) {
+			if ( ! v ) {
 
 				this.dispose();
 
@@ -223,7 +223,7 @@ export class DebugTilesPlugin {
 
 		this.tiles = tiles;
 
-		if (!this.enabled) {
+		if ( ! this.enabled ) {
 
 			return;
 
@@ -928,7 +928,7 @@ export class DebugTilesPlugin {
 
 	dispose() {
 
-		if (!this.enabled) {
+		if ( ! this.enabled ) {
 
 			return;
 


### PR DESCRIPTION
The `enabled` property was slightly buggy, if it was disabled it before registering the plugin, it still got enabled.
This should make this more robust, and add more typing definitions as well for the constructor (which now also allows `enabled` as property).