### PR TITLE
Set `plugin[ PLUGIN_REGISTERED ] = false` when unregistering a plugin

### DIFF
--- a/src/base/TilesRendererBase.js
+++ b/src/base/TilesRendererBase.js
@@ -219,6 +219,8 @@ export class TilesRendererBase {
 
 		if ( plugins.includes( plugin ) ) {
 
+			plugin[ PLUGIN_REGISTERED ] = false;
+
 			const index = plugins.indexOf( plugin );
 			plugins.splice( index, 1 );
 			if ( plugin.dispose ) {


### PR DESCRIPTION
Not sure if this behavior is intentional, but I think when it's possible to unregister a plugin, it should also be able to be registered again.

For context: I'm using a custom material that doesn't support the fade plugin (or it's at least buggy/throws exceptions, when changing the material on the fly), so I'm temporarily disabling this plugin for this material, until the original material is used again.