### PR TITLE
Wrapped shader updates

### DIFF
--- a/example/src/plugins/topolines/TopoLinesPlugin.js
+++ b/example/src/plugins/topolines/TopoLinesPlugin.js
@@ -286,6 +286,12 @@ export class TopoLinesPlugin {
 		tiles.group.add( resolutionSampleObject );
 		this._resolutionSampleObject = resolutionSampleObject;
 
+		tiles.forEachLoadedModel( scene => {
+
+			this.processTileModel( scene );
+
+		} );
+
 	}
 
 	updateDefines( scene = null ) {
@@ -376,6 +382,22 @@ export class TopoLinesPlugin {
 		this.updateDefines();
 
 		this._resolutionSampleObject.dispose();
+
+		// dispose of all the materials to force a shader rebuild of the shader since the behavior relies on
+		// assigning uniforms parameters
+		this.tiles.forEachLoadedModel( scene => {
+
+			scene.traverse( c => {
+
+				if ( c.material ) {
+
+					c.material.dispose();
+
+				}
+
+			} );
+
+		} );
 
 	}
 

--- a/example/src/plugins/topolines/wrapTopoLineMaterial.js
+++ b/example/src/plugins/topolines/wrapTopoLineMaterial.js
@@ -2,6 +2,8 @@
 
 import { Color, Matrix4, Vector2, Vector3 } from 'three';
 
+const TOPO_PARAMS = Symbol( 'TOPO_PARAMS' );
+
 const ELLIPSOID_FUNC = /* glsl */`
 
 	vec3 getPositionToSurfacePoint( vec3 radius, vec3 pos ) {
@@ -112,6 +114,13 @@ const MATH_FUNC = /* glsl */`
 // before compile can be used to chain shader adjustments. Returns the added uniforms used for fading.
 export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 
+	// if the material has already been wrapped then return the params
+	if ( material[ TOPO_PARAMS ] ) {
+
+		return material[ TOPO_PARAMS ];
+
+	}
+
 	const params = {
 		resolution: { value: new Vector2() },
 		pixelRatio: { value: 1 },
@@ -131,6 +140,8 @@ export function wrapTopoLineMaterial( material, previousOnBeforeCompile ) {
 
 		thickness: { value: 1.0 },
 	};
+
+	material[ TOPO_PARAMS ] = params;
 
 	material.defines = {
 		...( material.defines || {} ),

--- a/src/plugins/three/fade/FadeMaterialManager.js
+++ b/src/plugins/three/fade/FadeMaterialManager.js
@@ -71,6 +71,8 @@ export class FadeMaterialManager {
 
 		}
 
+		this.setFade( scene, 1, 0 );
+
 		// revert the materials
 		const fadeParams = this._fadeParams;
 		scene.traverse( child => {
@@ -79,8 +81,6 @@ export class FadeMaterialManager {
 			if ( material ) {
 
 				fadeParams.delete( material );
-				material.onBeforeCompile = () => {};
-				material.needsUpdate = true;
 
 			}
 

--- a/src/plugins/three/fade/FadeMaterialManager.js
+++ b/src/plugins/three/fade/FadeMaterialManager.js
@@ -71,6 +71,7 @@ export class FadeMaterialManager {
 
 		}
 
+		// mark the materials such that they are displayed at full value
 		this.setFade( scene, 1, 0 );
 
 		// revert the materials

--- a/src/plugins/three/fade/wrapFadeMaterial.js
+++ b/src/plugins/three/fade/wrapFadeMaterial.js
@@ -1,12 +1,22 @@
 // Adjusts the provided material to support fading in and out using a bayer pattern. Providing a "previous"
 // before compile can be used to chain shader adjustments. Returns the added uniforms used for fading.
+const FADE_PARAMS = Symbol( 'FADE_PARAMS' );
 export function wrapFadeMaterial( material, previousOnBeforeCompile ) {
+
+	// if the material has already been wrapped then return the params
+	if ( material[ FADE_PARAMS ] ) {
+
+		return material[ FADE_PARAMS ];
+
+	}
 
 	const params = {
 		fadeIn: { value: 0 },
 		fadeOut: { value: 0 },
 		fadeTexture: { value: null },
 	};
+
+	material[ FADE_PARAMS ] = params;
 
 	material.defines = {
 		...( material.defines || {} ),

--- a/src/plugins/three/images/overlays/wrapOverlaysMaterial.js
+++ b/src/plugins/three/images/overlays/wrapOverlaysMaterial.js
@@ -1,10 +1,21 @@
+const OVERLAY_PARAMS = Symbol( 'OVERLAY_PARAMS' );
+
 // before compile can be used to chain shader adjustments. Returns the added uniforms used for fading.
 export function wrapOverlaysMaterial( material, previousOnBeforeCompile ) {
+
+	// if the material has already been wrapped then return the params
+	if ( material[ OVERLAY_PARAMS ] ) {
+
+		return material[ OVERLAY_PARAMS ];
+
+	}
 
 	const params = {
 		layerMaps: { value: [] },
 		layerColor: { value: [] },
 	};
+
+	material[ OVERLAY_PARAMS ] = params;
 
 	material.defines = {
 		...( material.defines || {} ),


### PR DESCRIPTION
Fix #1185
Fix #1189
Related to #1155 

Adjust the material wrapping strategies to be resilient to multiple calls. Adjust TopoLinesPlugin to work if it's added after initialization.