### PR TITLE
Controls simplification

### DIFF
--- a/example/googleMapsExample.js
+++ b/example/googleMapsExample.js
@@ -207,7 +207,7 @@ function updateHash() {
 
 	}
 
-	if ( transition.mode !== 'perspective' ) {
+	if ( transition.mode !== 'perspective' && ! transition.animating ) {
 
 		controls.getPivotPoint( transition.fixedPoint );
 		transition.syncCameras();

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -1449,16 +1449,16 @@ export class EnvironmentControls extends EventDispatcher {
 
 	}
 
-
+	// clamp rotation to the given "up" vector
 	_clampRotation( up ) {
 
-		const { camera, minAltitude, maxAltitude } = this;
+		const { camera, minAltitude, maxAltitude, state, pivotPoint, zoomPoint, zoomPointSet } = this;
 
 		camera.updateMatrixWorld();
 
 		// calculate current angles and clamp
-		_forward.set( 0, 0, 1 ).transformDirection( camera.matrixWorld ).normalize();
-		_right.set( 1, 0, 0 ).transformDirection( camera.matrixWorld ).normalize();
+		_forward.set( 0, 0, 1 ).transformDirection( camera.matrixWorld );
+		_right.set( 1, 0, 0 ).transformDirection( camera.matrixWorld );
 
 		// get the signed angle relative to the top down view
 		if ( up.dot( _forward ) > 1 - 1e-2 ) {
@@ -1467,21 +1467,21 @@ export class EnvironmentControls extends EventDispatcher {
 
 		} else {
 
-			_vec.crossVectors( up, _forward ).normalize();
+			_vec.crossVectors( up, _forward );
 
 		}
 
+		// find the angle to target
 		const sign = Math.sign( _vec.dot( _right ) );
 		const angle = sign * up.angleTo( _forward );
-
-		let offset;
+		let targetAngle;
 		if ( angle > maxAltitude ) {
 
-			offset = maxAltitude;
+			targetAngle = maxAltitude;
 
 		} else if ( angle < minAltitude ) {
 
-			offset = minAltitude;
+			targetAngle = minAltitude;
 
 		} else {
 
@@ -1489,31 +1489,14 @@ export class EnvironmentControls extends EventDispatcher {
 
 		}
 
+		// construct a rotation basis
 		_forward.copy( up );
-		_quaternion.setFromAxisAngle( _right, offset );
+		_quaternion.setFromAxisAngle( _right, targetAngle );
 		_forward.applyQuaternion( _quaternion ).normalize();
 		_vec.crossVectors( _forward, _right ).normalize();
 
 		_rotMatrix.makeBasis( _right, _vec, _forward );
-		_quaternion.setFromRotationMatrix( _rotMatrix );
-
-
-
-
-
-
-		// _quaternion.setFromAxisAngle( _right, - offset );
-		camera.quaternion.copy( _quaternion );
-
-
-
-		// console.log('ADJUSTING')
-
-
-
-
-
-		const { state, pivotPoint, zoomPoint, zoomPointSet } = this;
+		camera.quaternion.setFromRotationMatrix( _rotMatrix );
 
 		// calculate the active point
 		let fixedPoint = null;

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -685,7 +685,7 @@ export class EnvironmentControls extends EventDispatcher {
 			if ( state === DRAG || state === ROTATE ) {
 
 				_forward.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
-				this.inertiaTargetDistance = _vec.copy( this.pivotPoint ).sub( camera.position ).dot( _forward );
+				this.inertiaTargetDistance = _vec.copy( pivotPoint ).sub( camera.position ).dot( _forward );
 
 			} else if ( state === NONE ) {
 
@@ -707,9 +707,8 @@ export class EnvironmentControls extends EventDispatcher {
 		// if using an orthographic camera then rotate around drag pivot
 		// reuse the "hit" information since it can be slow to perform multiple hits
 		const hit = camera.isOrthographicCamera ? null : adjustHeight && this._getPointBelowCamera() || null;
-		const rotationPoint = camera.isOrthographicCamera ? pivotPoint : hit && hit.point || null;
 		this.getCameraUpDirection( _localUp );
-		this._setFrame( _localUp, rotationPoint );
+		this._setFrame( _localUp );
 
 		// when dragging the camera and drag point may be moved
 		// to accommodate terrain so we try to move it back down

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -1262,22 +1262,22 @@ export class EnvironmentControls extends EventDispatcher {
 		// calculate current angles and clamp
 		_forward.set( 0, 0, 1 ).transformDirection( camera.matrixWorld );
 		_right.set( 1, 0, 0 ).transformDirection( camera.matrixWorld );
-		// this.getUpDirection( pivotPoint, _localUp );
-		this.getCameraUpDirection( _localUp );
+		this.getUpDirection( pivotPoint, _localUp );
 
 		// get the signed angle relative to the top down view
-		if ( _localUp.dot( _forward ) > 1 - 1e-2 ) {
+		let angle;
+		if ( _localUp.dot( _forward ) > 1 - 1e-10 ) {
 
-			_vec.copy( _right );
+			angle = 0;
 
 		} else {
 
 			_vec.crossVectors( _localUp, _forward ).normalize();
 
-		}
+			const sign = Math.sign( _vec.dot( _right ) );
+			angle = sign * _localUp.angleTo( _forward );
 
-		const sign = Math.sign( _vec.dot( _right ) );
-		const angle = sign * _localUp.angleTo( _forward );
+		}
 
 		// clamp the rotation to be within the provided limits
 		// clamp to 0 here, as well, so we don't "pop" to the the value range
@@ -1461,19 +1461,21 @@ export class EnvironmentControls extends EventDispatcher {
 		_right.set( 1, 0, 0 ).transformDirection( camera.matrixWorld );
 
 		// get the signed angle relative to the top down view
-		if ( up.dot( _forward ) > 1 - 1e-2 ) {
+		let angle;
+		if ( up.dot( _forward ) > 1 - 1e-10 ) {
 
-			_vec.copy( _right );
+			angle = 0;
 
 		} else {
 
 			_vec.crossVectors( up, _forward );
 
+			const sign = Math.sign( _vec.dot( _right ) );
+			angle = sign * up.angleTo( _forward );
+
 		}
 
 		// find the angle to target
-		const sign = Math.sign( _vec.dot( _right ) );
-		const angle = sign * up.angleTo( _forward );
 		let targetAngle;
 		if ( angle > maxAltitude ) {
 

--- a/src/three/controls/EnvironmentControls.js
+++ b/src/three/controls/EnvironmentControls.js
@@ -110,6 +110,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 		// settings for GlobeControls
 		this.scaleZoomOrientationAtEdges = false;
+		this.autoAdjustCameraRotation = true;
 
 		// internal state
 		this.state = NONE;
@@ -663,6 +664,7 @@ export class EnvironmentControls extends EventDispatcher {
 			up,
 			state,
 			adjustHeight,
+			autoAdjustCameraRotation,
 		} = this;
 
 		camera.updateMatrixWorld();
@@ -681,6 +683,7 @@ export class EnvironmentControls extends EventDispatcher {
 
 		// update the actions
 		const inertiaNeedsUpdate = this._inertiaNeedsUpdate();
+		const adjustCameraRotation = this.needsUpdate || inertiaNeedsUpdate;
 		if ( this.needsUpdate || inertiaNeedsUpdate ) {
 
 			const zoomDelta = this.zoomDelta;
@@ -752,6 +755,17 @@ export class EnvironmentControls extends EventDispatcher {
 		}
 
 		this.pointerTracker.updateFrame();
+
+		if ( adjustCameraRotation && autoAdjustCameraRotation ) {
+
+			this.getCameraUpDirection( _localUp );
+			this._alignCameraUp( _localUp, 1 );
+
+			this.getCameraUpDirection( _localUp );
+			this._clampRotation( _localUp );
+
+
+		}
 
 	}
 

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -68,7 +68,6 @@ export class GlobeControls extends EnvironmentControls {
 		this.nearMargin = 0.25;
 		this.farMargin = 0;
 		this.useFallbackPlane = false;
-		this.reorientOnDrag = false;
 
 		this.globeInertia = new Quaternion();
 		this.globeInertiaFactor = 0;

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -7,7 +7,7 @@ import {
 	Ray,
 	Group,
 } from 'three';
-import { DRAG, ZOOM, ROTATE, EnvironmentControls, NONE } from './EnvironmentControls.js';
+import { DRAG, ZOOM, EnvironmentControls, NONE } from './EnvironmentControls.js';
 import { closestRayEllipsoidSurfacePointEstimate, closestRaySpherePointFromRotation, makeRotateAroundPoint, mouseToCoords, setRaycasterFromCamera } from './utils.js';
 import { Ellipsoid } from '../math/Ellipsoid.js';
 import { WGS84_ELLIPSOID } from '../math/GeoConstants.js';
@@ -18,7 +18,6 @@ const _pos = /* @__PURE__ */ new Vector3();
 const _vec = /* @__PURE__ */ new Vector3();
 const _center = /* @__PURE__ */ new Vector3();
 const _forward = /* @__PURE__ */ new Vector3();
-const _right = /* @__PURE__ */ new Vector3();
 const _targetRight = /* @__PURE__ */ new Vector3();
 const _globalUp = /* @__PURE__ */ new Vector3();
 const _quaternion = /* @__PURE__ */ new Quaternion();
@@ -609,159 +608,6 @@ export class GlobeControls extends EnvironmentControls {
 		this._alignCameraUp( _globalUp, alpha );
 
 	}
-
-	// tilt the camera to align with the provided "up" value
-	_alignCameraUp( up, alpha = 1 ) {
-
-		const { camera, state, pivotPoint, zoomPoint, zoomPointSet } = this;
-
-		// get the transform vectors
-		camera.updateMatrixWorld();
-		_forward.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
-		_right.set( - 1, 0, 0 ).transformDirection( camera.matrixWorld );
-
-		// compute an alpha based on the camera direction so we don't try to update the up direction
-		// when the camera is facing that way.
-		let multiplier = MathUtils.mapLinear( 1 - Math.abs( _forward.dot( up ) ), 0, 0.2, 0, 1 );
-		multiplier = MathUtils.clamp( multiplier, 0, 1 );
-		alpha *= multiplier;
-
-		// calculate the target direction for the right-facing vector
-		_targetRight.crossVectors( up, _forward );
-		_targetRight.lerp( _right, 1 - alpha ).normalize();
-
-		// adjust the camera transformation
-		_quaternion.setFromUnitVectors( _right, _targetRight );
-		camera.quaternion.premultiply( _quaternion );
-
-		// calculate the active point
-		let fixedPoint = null;
-		if ( state === DRAG || state === ROTATE ) {
-
-			fixedPoint = _pos.copy( pivotPoint );
-
-		} else if ( zoomPointSet ) {
-
-			fixedPoint = _pos.copy( zoomPoint );
-
-		}
-
-		// shift the camera in an effort to keep the fixed point in the same spot
-		if ( fixedPoint ) {
-
-			_invMatrix.copy( camera.matrixWorld ).invert();
-			_vec.copy( fixedPoint ).applyMatrix4( _invMatrix );
-
-			camera.updateMatrixWorld();
-			_vec.applyMatrix4( camera.matrixWorld );
-
-			_center.subVectors( fixedPoint, _vec );
-			camera.position.add( _center );
-
-		}
-
-		camera.updateMatrixWorld();
-
-	}
-
-
-	_clampRotation( up ) {
-
-		const { camera, minAltitude, maxAltitude } = this;
-
-		camera.updateMatrixWorld();
-
-		// calculate current angles and clamp
-		_forward.set( 0, 0, 1 ).transformDirection( camera.matrixWorld ).normalize();
-		_right.set( 1, 0, 0 ).transformDirection( camera.matrixWorld ).normalize();
-
-		// get the signed angle relative to the top down view
-		if ( up.dot( _forward ) > 1 - 1e-2 ) {
-
-			_vec.copy( _right );
-
-		} else {
-
-			_vec.crossVectors( up, _forward ).normalize();
-
-		}
-
-		const sign = Math.sign( _vec.dot( _right ) );
-		const angle = sign * up.angleTo( _forward );
-
-		let offset;
-		if ( angle > maxAltitude ) {
-
-			offset = maxAltitude;
-
-		} else if ( angle < minAltitude ) {
-
-			offset = minAltitude;
-
-		} else {
-
-			return;
-
-		}
-
-		_forward.copy( up );
-		_quaternion.setFromAxisAngle( _right, offset );
-		_forward.applyQuaternion( _quaternion ).normalize();
-		_vec.crossVectors( _forward, _right ).normalize();
-
-		_rotMatrix.makeBasis( _right, _vec, _forward );
-		_quaternion.setFromRotationMatrix( _rotMatrix );
-
-
-
-
-
-
-		// _quaternion.setFromAxisAngle( _right, - offset );
-		camera.quaternion.copy( _quaternion );
-
-
-
-		// console.log('ADJUSTING')
-
-
-
-
-
-		const { state, pivotPoint, zoomPoint, zoomPointSet } = this;
-
-		// calculate the active point
-		let fixedPoint = null;
-		if ( state === DRAG || state === ROTATE ) {
-
-			fixedPoint = _pos.copy( pivotPoint );
-
-		} else if ( zoomPointSet ) {
-
-			fixedPoint = _pos.copy( zoomPoint );
-
-		}
-
-		// shift the camera in an effort to keep the fixed point in the same spot
-		if ( fixedPoint ) {
-
-			_invMatrix.copy( camera.matrixWorld ).invert();
-			_vec.copy( fixedPoint ).applyMatrix4( _invMatrix );
-
-			camera.updateMatrixWorld();
-			_vec.applyMatrix4( camera.matrixWorld );
-
-			_center.subVectors( fixedPoint, _vec );
-			camera.position.add( _center );
-
-		}
-
-		camera.updateMatrixWorld();
-
-
-
-	}
-
 
 	// tilt the camera to look at the center of the globe
 	_tiltTowardsCenter( alpha ) {

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -67,6 +67,7 @@ export class GlobeControls extends EnvironmentControls {
 		this.nearMargin = 0.25;
 		this.farMargin = 0;
 		this.useFallbackPlane = false;
+		this.autoAdjustCameraRotation = false;
 
 		this.globeInertia = new Quaternion();
 		this.globeInertiaFactor = 0;
@@ -208,7 +209,7 @@ export class GlobeControls extends EnvironmentControls {
 
 		}
 
-		const needsUpdate = this.needsUpdate;
+		const adjustCameraRotation = this.needsUpdate || this._inertiaNeedsUpdate();
 
 		// fire basic controls update
 		super.update( deltaTime );
@@ -217,7 +218,7 @@ export class GlobeControls extends EnvironmentControls {
 		this.adjustCamera( camera );
 
 		// align the camera up vector if the camera as updated
-		if ( needsUpdate && this._isNearControls() ) {
+		if ( adjustCameraRotation && this._isNearControls() ) {
 
 			this.getCameraUpDirection( _globalUp );
 			this._alignCameraUp( _globalUp, 1 );

--- a/src/three/controls/GlobeControls.js
+++ b/src/three/controls/GlobeControls.js
@@ -120,7 +120,7 @@ export class GlobeControls extends EnvironmentControls {
 		// use the closest point if no pivot was provided or it's closer
 		if (
 			super.getPivotPoint( target ) === null ||
-			target.distanceTo( _ray.origin ) > _vec.distanceTo( _ray.origin )
+			_pos.subVectors( target, _ray.origin ).dot( _ray.direction ) > _pos.subVectors( _vec, _ray.origin ).dot( _ray.direction )
 		) {
 
 			target.copy( _vec );


### PR DESCRIPTION
Fix #751
Fix #997

Fix some rotation drifting, clamp rotation based on camera location

**TODO**
- Call clamp, align up in EnvironmentControls.
- Confirm whether we need 1-1e-2 logic to handle rotation oddities. Possibly just clamp when at that high range (current rotation check is designed to check for overshoot)