### PR TITLE
TilesAttributionOverlay: Enable the use outside of HTTPS contexts

### DIFF
--- a/src/r3f/components/TilesAttributionOverlay.jsx
+++ b/src/r3f/components/TilesAttributionOverlay.jsx
@@ -2,6 +2,22 @@ import { useContext, useState, useEffect, useMemo } from 'react';
 import { TilesRendererContext } from './TilesRenderer.jsx';
 import { CanvasDOMOverlay } from './CanvasDOMOverlay.jsx';
 
+function randomUUID() {
+
+	if ( window.crypto.randomUUID ) {
+
+		return window.crypto.randomUUID();
+
+	}
+
+	// https://stackoverflow.com/a/2117523
+	return '10000000-1000-4000-8000-100000000000'.replace(
+		/[018]/g,
+		c => ( + c ^ crypto.getRandomValues( new Uint8Array( 1 ) )[ 0 ] & 15 >> + c / 4 ).toString( 16 )
+	);
+
+}
+
 // Overlay for displaying tile data set attributions
 export function TilesAttributionOverlay( { children, style, generateAttributions, ...rest } ) {
 
@@ -47,7 +63,7 @@ export function TilesAttributionOverlay( { children, style, generateAttributions
 	}, [ tiles ] );
 
 	// Generate CSS for modifying child elements implicit to the html attributions
-	const classId = useMemo( () => 'class_' + window.crypto.randomUUID(), [] );
+	const classId = useMemo( () => 'class_' + randomUUID(), [] );
 	const styles = useMemo( () => `
 		#${ classId } a {
 			color: white;


### PR DESCRIPTION
This PR enables the use of `TilesAttributionOverlay` outside of HTTPS contexts.

**Issue to solve:**

The class ID for `TilesAttributionOverlay` is generated using `crypto.randomUUID`, which is only available in HTTPS contexts. This prevents it from being used in local development over HTTP except on loopback addresses. Since cryptographically secure randomness of class IDs is not essential, it's reasonable to provide a fallback to allow its use outside of HTTPS contexts.