### PR TITLE
ImageOverlayPlugin: Add support for splitting the tiles

### DIFF
--- a/src/plugins/core/EnforceNonZeroErrorPlugin.d.ts
+++ b/src/plugins/core/EnforceNonZeroErrorPlugin.d.ts
@@ -1,0 +1,1 @@
+export class EnforceNonZeroErrorPlugin {}

--- a/src/plugins/core/EnforceNonZeroErrorPlugin.js
+++ b/src/plugins/core/EnforceNonZeroErrorPlugin.js
@@ -1,0 +1,35 @@
+export class EnforceNonZeroErrorPlugin {
+
+	constructor() {
+
+		this.name = 'ENFORCE_NONZERO_ERROR';
+		this.priority = - Infinity;
+		this.originalError = new Map();
+
+	}
+
+	preprocessNode( tile ) {
+
+		if ( tile.geometricError === 0 ) {
+
+			let parent = tile.parent;
+			let depth = 1;
+			while ( parent !== null ) {
+
+				if ( parent.geometricError !== 0 && parent.geometricError !== Infinity && ! parent.__hasUnrenderableContent ) {
+
+					tile.geometricError = parent.geometricError * ( 2 ** - depth );
+					return;
+
+				}
+
+				parent = parent.parent;
+				depth ++;
+
+			}
+
+		}
+
+	}
+
+}

--- a/src/plugins/core/EnforceNonZeroErrorPlugin.js
+++ b/src/plugins/core/EnforceNonZeroErrorPlugin.js
@@ -10,21 +10,34 @@ export class EnforceNonZeroErrorPlugin {
 
 	preprocessNode( tile ) {
 
+		// if a tile has zero error then traverse the parents and find some geometric error value in
+		// the parent hierarchy to use for calculating a pseudo geometric error for this tile.
 		if ( tile.geometricError === 0 ) {
 
 			let parent = tile.parent;
 			let depth = 1;
+
+			let targetDepth = - 1;
+			let targetError = Infinity;
 			while ( parent !== null ) {
 
-				if ( parent.geometricError !== 0 && parent.geometricError !== Infinity && ! parent.__hasUnrenderableContent ) {
+				if ( parent.geometricError !== 0 && parent.geometricError < targetError) {
 
-					tile.geometricError = parent.geometricError * ( 2 ** - depth );
-					return;
+					targetError = parent.geometricError;
+					targetDepth = depth;
 
 				}
 
 				parent = parent.parent;
 				depth ++;
+
+			}
+
+			// find the smallest error in the parent list to avoid grabbing artificially inflated error values
+			// for the sake of forced refinement. Then scale the error by the depth.
+			if ( targetDepth !== - 1 ) {
+
+				tile.geometricError = parent.geometricError * ( 2 ** - depth );
 
 			}
 

--- a/src/plugins/core/ImplicitTilingPlugin.d.ts
+++ b/src/plugins/core/ImplicitTilingPlugin.d.ts
@@ -1,2 +1,1 @@
 export class ImplicitTilingPlugin {}
-

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -20,6 +20,7 @@ export * from './three/images/EPSGTilesPlugin.js';
 
 // common plugins
 export { ImplicitTilingPlugin } from './core/ImplicitTilingPlugin.js';
+export { EnforceNonZeroErrorPlugin } from './core/EnforceNonZeroErrorPlugin.js';
 
 // gltf extensions
 export { GLTFCesiumRTCExtension } from './three/gltf/GLTFCesiumRTCExtension.js';


### PR DESCRIPTION
Fix #1204 

- Add a plugin to enforce non-zero error for cases where leaves are always zero-error.

**TODO**
- Add support for the splitter to ImageOverlayPlugin.
- Add / adjust demo (swiss topo?).