### PR TITLE
Correctly remove event listener on UpdateOnChangePlugin dispose

### DIFF
--- a/src/plugins/three/UpdateOnChangePlugin.js
+++ b/src/plugins/three/UpdateOnChangePlugin.js
@@ -85,9 +85,9 @@ export class UpdateOnChangePlugin {
 
 		const tiles = this.tiles;
 		tiles.removeEventListener( 'camera-resolution-change', this._needsUpdateCallback );
-		tiles.removeEventListener( 'load-content', this._needsUpdateCallback );
-		tiles.removeEventListener( 'camera-add', this._onCameraAdd );
-		tiles.removeEventListener( 'camera-delete', this._onCameraDelete );
+		tiles.removeEventListener( 'needs-update', this._needsUpdateCallback );
+		tiles.removeEventListener( 'add-camera', this._onCameraAdd );
+		tiles.removeEventListener( 'delete-camera', this._onCameraDelete );
 
 	}
 


### PR DESCRIPTION
From line 38-40 of UpdateOnChangePlugin.js, three event listener `needs-update`, `add-camera`, `delete-camera` are added.
However, in the `dispose` function, they are not correctly removed
Instead, `load-content`, `camera-add`, `camera-delete` are removed but they are never added