### PR TITLE
Simplification of LRUCache usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _Personal [Google Tiles API Key](https://developers.google.com/maps/documentatio
 
 [Rendering shadows from offscreen tiles example](https://nasa-ammos.github.io/3DTilesRendererJS/example/bundle/offscreenShadows.html)
 
-[Alterate texture overlays](https://nasa-ammos.github.io/3DTilesRendererJS/example/bundle/landformSiteOverlay.html)
+[Alternate texture overlays](https://nasa-ammos.github.io/3DTilesRendererJS/example/bundle/landformSiteOverlay.html)
 
 **Plugins**
 

--- a/src/core/renderer/utilities/LRUCache.js
+++ b/src/core/renderer/utilities/LRUCache.js
@@ -98,14 +98,15 @@ class LRUCache {
 
 		}
 
-		if ( this.isFull() ) {
+		const itemList = this.itemList;
+		const unloadPriorityCallback = this.unloadPriorityCallback || this.defaultPriorityCallback;
+		if ( this.isFull() && unloadPriorityCallback( item, itemList[ 0 ] ) > 0 ) {
 
 			return false;
 
 		}
 
 		const usedSet = this.usedSet;
-		const itemList = this.itemList;
 		const callbacks = this.callbacks;
 		itemList.push( item );
 		usedSet.add( item );
@@ -238,7 +239,7 @@ class LRUCache {
 
 					const loadedA = loadedSet.has( a );
 					const loadedB = loadedSet.has( b );
-					if ( loadedA === loadedB ) {
+					if ( loadedA === loadedB || true ) {
 
 						// Use the sort function otherwise
 						// higher priority should be further to the left
@@ -279,7 +280,6 @@ class LRUCache {
 				const item = itemList[ removedNodes ];
 				const bytes = bytesMap.get( item ) || 0;
 				if (
-					usedSet.has( item ) && loadedSet.has( item ) ||
 					this.cachedBytes - removedBytes - bytes < maxBytesSize &&
 					itemList.length - removedNodes <= maxSize
 				) {

--- a/src/three/plugins/fade/FadeMaterialManager.js
+++ b/src/three/plugins/fade/FadeMaterialManager.js
@@ -24,7 +24,7 @@ export class FadeMaterialManager {
 		scene.traverse( child => {
 
 			const material = child.material;
-			if ( material ) {
+			if ( material && fadeParams.has( material ) ) {
 
 				const params = fadeParams.get( material );
 				params.fadeIn.value = fadeIn;


### PR DESCRIPTION
Related to #1230, #1232

Simplify the usage of the cache and enable it to push already-loaded nodes out if they are lower priority (tbd?).

**TODO**
- Enabling lru cache to kick out loaded, visible tiles is causing flickering with the fade plugin. Does it need to be more robust?
- Is it actually a problem that child nodes are loaded while parents are not?
  - It shouldn't be since children are guaranteed to be disposed before the parents. Though the child geometry will be isolated and possibly block parent tiles from loading in very specific cases.
- Will this cause oscillation? To many unnecessary loads that are quickly evicted because memory is not known ahead of time?
- Do we preemtively _prevent_ the load geometric tiles because we know they will require memory and be evicted if they're too low down the priority list?