### PR TITLE
Remove unused __childrenWereVisible property from TileInternal and TilesRendererBase

### DIFF
--- a/src/core/renderer/tiles/TileInternal.d.ts
+++ b/src/core/renderer/tiles/TileInternal.d.ts
@@ -18,7 +18,6 @@ export interface TileInternal extends Tile {
 
 	// Visibility tracking
 	__allChildrenLoaded: boolean;
-	__childrenWereVisible: boolean;
 	__inFrustum: boolean;
 	__wasSetVisible: boolean;
 

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -567,7 +567,6 @@ export class TilesRendererBase {
 
 		tile.__wasSetVisible = false;
 		tile.__visible = false;
-		tile.__childrenWereVisible = false;
 		tile.__allChildrenLoaded = false;
 
 		tile.__wasSetActive = false;


### PR DESCRIPTION
The __childrenWereVisible property was no longer being used and was cluttering the tile initialization code. Removing deprecated properties helps keep the codebase clean and reduces confusion for developers working with the tile system.