### PR TITLE
Fix Google Maps overlay

### DIFF
--- a/src/three/plugins/images/ImageOverlayPlugin.d.ts
+++ b/src/three/plugins/images/ImageOverlayPlugin.d.ts
@@ -85,7 +85,7 @@ export class GoogleMapsOverlay extends ImageOverlay {
 		apiToken: string,
 		autoRefreshToken?: boolean,
 		logoUrl?: string,
-		sessionOptions?: null | { mapType: string, language: string, region: string },
+		sessionOptions: { mapType: string, language: string, region: string } & { [key: string]: any },
 
 		color: number | Color,
 		opacity: number,

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1615,7 +1615,7 @@ export class GoogleMapsOverlay extends ImageOverlay {
 			.then( json => {
 
 				this.imageSource.tileDimension = json.tileWidth;
-				this.imageSource = 'https://tile.googleapis.com/v1/2dtiles/{z}/{x}/{y}';
+				this.imageSource.url = 'https://tile.googleapis.com/v1/2dtiles/{z}/{x}/{y}';
 				return this.imageSource.init();
 
 			} );


### PR DESCRIPTION
A refactoring of the plugin introduced a small (but breaking) issue I fix here.

Moreover, I improved the constructor typings, as according to [the docs](https://developers.google.com/maps/documentation/tile/session_tokens?_gl=1*3o9lcg*_up*MQ..*_ga*ODU3NzEzMzIzLjE3NTQ4MzQ1MTQ.*_ga_NRWSTWS78N*czE3NTQ4MzQ1MTQkbzEkZzAkdDE3NTQ4MzQ1MTQkajYwJGwwJGgw), the `sessionOptions` params you listed are required. Other optional params can be listed.