### PR TITLE
Fix types, always use mercator for XYZ tiles

### DIFF
--- a/src/three/plugins/images/DeepZoomImagePlugin.d.ts
+++ b/src/three/plugins/images/DeepZoomImagePlugin.d.ts
@@ -3,6 +3,7 @@ export class DeepZoomImagePlugin {
 	constructor( options: {
 		center?: boolean,
 		useRecommendedSettings?: boolean,
+		url?: string,
 	} );
 
 }

--- a/src/three/plugins/images/EPSGTilesPlugin.d.ts
+++ b/src/three/plugins/images/EPSGTilesPlugin.d.ts
@@ -8,6 +8,7 @@ export class XYZTilesPlugin {
 		shape?: 'ellipsoid' | 'planar',
 		bounds?: [ number, number, number, number ],
 		useRecommendedSettings?: boolean,
+		url?: string,
 	} );
 
 }
@@ -18,6 +19,7 @@ export class TMSTilesPlugin {
 		center?: boolean,
 		shape?: 'ellipsoid' | 'planar',
 		useRecommendedSettings?: boolean,
+		url?: string,
 	} );
 
 }

--- a/src/three/plugins/images/EPSGTilesPlugin.d.ts
+++ b/src/three/plugins/images/EPSGTilesPlugin.d.ts
@@ -5,7 +5,7 @@ export class XYZTilesPlugin {
 		center?: boolean,
 		levels?: number,
 		tileDimension?: number,
-		projection?: 'ellipsoid' | 'planar',
+		shape?: 'ellipsoid' | 'planar',
 		bounds?: [ number, number, number, number ],
 		useRecommendedSettings?: boolean,
 	} );
@@ -16,7 +16,7 @@ export class TMSTilesPlugin {
 
 	constructor( options: {
 		center?: boolean,
-		projection?: 'ellipsoid' | 'planar',
+		shape?: 'ellipsoid' | 'planar',
 		useRecommendedSettings?: boolean,
 	} );
 
@@ -28,7 +28,7 @@ export class WMTSTilesPlugin {
 		center?: boolean,
 		levels?: number,
 		tileDimension?: number,
-		projection?: 'ellipsoid' | 'planar',
+		shape?: 'ellipsoid' | 'planar',
 		bounds?: [ number, number, number, number ],
 		useRecommendedSettings?: boolean,
 	} );

--- a/src/three/plugins/images/EPSGTilesPlugin.js
+++ b/src/three/plugins/images/EPSGTilesPlugin.js
@@ -14,7 +14,6 @@ export class XYZTilesPlugin extends EllipsoidProjectionTilesPlugin {
 		const {
 			levels,
 			tileDimension,
-			projection,
 			bounds,
 			url,
 			...rest
@@ -23,7 +22,7 @@ export class XYZTilesPlugin extends EllipsoidProjectionTilesPlugin {
 		super( rest );
 
 		this.name = 'XYZ_TILES_PLUGIN';
-		this.imageSource = new XYZImageSource( { url, levels, tileDimension, projection, bounds } );
+		this.imageSource = new XYZImageSource( { url, levels, tileDimension, bounds } );
 
 	}
 

--- a/src/three/plugins/images/sources/XYZImageSource.js
+++ b/src/three/plugins/images/sources/XYZImageSource.js
@@ -10,13 +10,11 @@ export class XYZImageSource extends TiledImageSource {
 		const {
 			levels = 20,
 			tileDimension = 256,
-			projection = 'EPSG:3857',
 			url = null,
 		} = options;
 
 		this.tileDimension = tileDimension;
 		this.levels = levels;
-		this.projection = projection;
 		this.url = url;
 
 	}
@@ -33,10 +31,10 @@ export class XYZImageSource extends TiledImageSource {
 	init() {
 
 		// transform the url
-		const { tiling, tileDimension, levels, projection, url } = this;
+		const { tiling, tileDimension, levels, url } = this;
 
 		tiling.flipY = ! /{\s*reverseY|-\s*y\s*}/g.test( url );
-		tiling.setProjection( new ProjectionScheme( projection ) );
+		tiling.setProjection( new ProjectionScheme( 'EPSG:3857' ) );
 		tiling.setContentBounds( ...tiling.projection.getBounds() );
 		tiling.generateLevels( levels, tiling.projection.tileCountX, tiling.projection.tileCountY, {
 			tilePixelWidth: tileDimension,


### PR DESCRIPTION
Fix #1270

- Fix d.ts typo - "projection" -> "shape".
- Force "XYZ Tiles" to always use web mercator.