### PR TITLE
Add support for NodeMaterial in TilesFadePlugin

### DIFF
--- a/example/webgpu/fadingTiles.html
+++ b/example/webgpu/fadingTiles.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+		<meta charset="utf-8"/>
+
+		<title>Dither Fade Tiles</title>
+		<link rel="stylesheet" href="./styles.css">
+    </head>
+    <body class="light">
+		<div id="info">
+			Demonstration of tiles using a dither fade to change, smoothing out the transition.
+		</div>
+        <script src="./fadingTiles.js" type="module"></script>
+    </body>
+</html>

--- a/example/webgpu/fadingTiles.html
+++ b/example/webgpu/fadingTiles.html
@@ -5,7 +5,7 @@
 		<meta charset="utf-8"/>
 
 		<title>Dither Fade Tiles</title>
-		<link rel="stylesheet" href="./styles.css">
+		<link rel="stylesheet" href="../styles.css">
     </head>
     <body class="light">
 		<div id="info">

--- a/example/webgpu/fadingTiles.js
+++ b/example/webgpu/fadingTiles.js
@@ -1,0 +1,243 @@
+import {
+	Scene,
+	PerspectiveCamera,
+	OrthographicCamera,
+	Group,
+} from 'three';
+import { MeshBasicNodeMaterial, WebGPURenderer } from 'three/webgpu';
+import { TilesFadePlugin } from '3d-tiles-renderer/plugins';
+import { EnvironmentControls, TilesRenderer, CameraTransitionManager } from '3d-tiles-renderer';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+
+let controls, scene, renderer;
+let groundTiles, skyTiles, tilesParent, transition;
+
+const params = {
+
+	reinstantiateTiles,
+	fadeRootTiles: false,
+	useFade: true,
+	errorTarget: 6,
+	fadeDuration: 0.5,
+	renderScale: 1,
+	fadingGroundTiles: '0 tiles',
+
+	orthographic: false,
+	transitionDuration: 0.25,
+
+};
+
+init().then( () => {
+
+	render();
+
+} );
+
+async function init() {
+
+	// renderer
+	renderer = new WebGPURenderer( { antialias: true } );
+	await renderer.init();
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.setClearColor( 0xd8cec0 );
+
+	document.body.appendChild( renderer.domElement );
+
+	// scene
+	scene = new Scene();
+
+	// set up cameras and ortho / perspective transition
+	transition = new CameraTransitionManager(
+		new PerspectiveCamera( 60, window.innerWidth / window.innerHeight, 0.25, 4000 ),
+		new OrthographicCamera( - 1, 1, 1, - 1, 0, 4000 ),
+	);
+	transition.camera.position.set( 20, 10, 20 );
+	transition.camera.lookAt( 0, 0, 0 );
+	transition.autoSync = false;
+
+	transition.addEventListener( 'camera-change', ( { camera, prevCamera } ) => {
+
+		skyTiles.deleteCamera( prevCamera );
+		groundTiles.deleteCamera( prevCamera );
+
+		skyTiles.setCamera( camera );
+		groundTiles.setCamera( camera );
+
+		controls.setCamera( camera );
+
+	} );
+
+	// controls
+	controls = new EnvironmentControls( scene, transition.camera, renderer.domElement );
+	controls.minZoomDistance = 2;
+	controls.cameraRadius = 1;
+
+	// tiles parent group
+	tilesParent = new Group();
+	tilesParent.rotation.set( Math.PI / 2, 0, 0 );
+	scene.add( tilesParent );
+
+	// init tiles
+	reinstantiateTiles();
+
+	// events
+	onWindowResize();
+	window.addEventListener( 'resize', onWindowResize, false );
+
+	// gui initialization
+	const gui = new GUI();
+	const cameraFolder = gui.addFolder( 'camera' );
+	cameraFolder.add( params, 'orthographic' ).onChange( v => {
+
+		transition.fixedPoint.copy( controls.pivotPoint );
+
+		// adjust the camera before the transition begins
+		transition.syncCameras();
+		controls.adjustCamera( transition.perspectiveCamera );
+		controls.adjustCamera( transition.orthographicCamera );
+		transition.toggle();
+
+	} );
+	cameraFolder.add( params, 'transitionDuration', 0, 1.5 );
+
+	const fadeFolder = gui.addFolder( 'fade' );
+	fadeFolder.add( params, 'useFade' );
+	fadeFolder.add( params, 'fadeRootTiles' );
+	fadeFolder.add( params, 'errorTarget', 0, 1000 );
+	fadeFolder.add( params, 'fadeDuration', 0, 5 );
+	fadeFolder.add( params, 'renderScale', 0.1, 1.0, 0.05 ).onChange( v => renderer.setPixelRatio( v * window.devicePixelRatio ) );
+
+	const textController = fadeFolder.add( params, 'fadingGroundTiles' ).listen().disable();
+	textController.domElement.style.opacity = 1.0;
+
+	gui.add( params, 'reinstantiateTiles' );
+
+	gui.open();
+
+}
+
+function replaceMaterial( tiles ) {
+
+	tiles.addEventListener( 'load-model', ( { scene } ) => {
+
+		scene.traverse( c => {
+
+			if ( c.material ) {
+
+				const originalMaterial = c.material;
+				const material = new MeshBasicNodeMaterial();
+				if ( originalMaterial.map ) {
+
+					material.map = originalMaterial.map.clone();
+
+				}
+				c.originalMaterial = c.material;
+				c.material = material;
+
+			}
+
+		} );
+
+	} );
+
+	tiles.addEventListener( 'dispose-model', ( { scene } ) => {
+
+		scene.traverse( c => {
+
+			if ( c.material ) {
+
+				c.material.dispose();
+
+			}
+
+		} );
+
+	} );
+
+}
+
+function reinstantiateTiles() {
+
+	if ( groundTiles ) {
+
+		groundTiles.dispose();
+		groundTiles.group.removeFromParent();
+
+		skyTiles.dispose();
+		skyTiles.group.removeFromParent();
+
+	}
+
+	groundTiles = new TilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_colorize_tileset.json' );
+	groundTiles.fetchOptions.mode = 'cors';
+	groundTiles.lruCache.minSize = 900;
+	groundTiles.lruCache.maxSize = 1300;
+	groundTiles.errorTarget = 12;
+	replaceMaterial( groundTiles );
+	groundTiles.registerPlugin( new TilesFadePlugin() );
+	groundTiles.setCamera( transition.camera );
+
+	skyTiles = new TilesRenderer( 'https://raw.githubusercontent.com/NASA-AMMOS/3DTilesSampleData/master/msl-dingo-gap/0528_0260184_to_s64o256_colorize/0528_0260184_to_s64o256_sky/0528_0260184_to_s64o256_sky_tileset.json' );
+	skyTiles.fetchOptions.mode = 'cors';
+	skyTiles.lruCache = groundTiles.lruCache;
+	replaceMaterial( skyTiles );
+	skyTiles.registerPlugin( new TilesFadePlugin() );
+	skyTiles.setCamera( transition.camera );
+
+
+	tilesParent.add( groundTiles.group, skyTiles.group );
+
+}
+
+function onWindowResize() {
+
+	const { perspectiveCamera, orthographicCamera } = transition;
+	const aspect = window.innerWidth / window.innerHeight;
+
+	orthographicCamera.bottom = - 40;
+	orthographicCamera.top = 40;
+	orthographicCamera.left = - 40 * aspect;
+	orthographicCamera.right = 40 * aspect;
+	orthographicCamera.updateProjectionMatrix();
+
+	perspectiveCamera.aspect = aspect;
+	perspectiveCamera.updateProjectionMatrix();
+
+	renderer.setSize( window.innerWidth, window.innerHeight );
+
+}
+
+function render() {
+
+	requestAnimationFrame( render );
+
+	controls.enabled = ! transition.animating;
+	controls.update();
+
+	transition.duration = 1000 * params.transitionDuration;
+	transition.update();
+
+	const camera = transition.camera;
+	camera.updateMatrixWorld();
+
+	const groundPlugin = groundTiles.getPluginByName( 'FADE_TILES_PLUGIN' );
+	groundPlugin.fadeRootTiles = params.fadeRootTiles;
+	groundPlugin.fadeDuration = params.useFade ? params.fadeDuration * 1000 : 0;
+	groundTiles.errorTarget = params.errorTarget;
+	groundTiles.setCamera( camera );
+	groundTiles.setResolutionFromRenderer( camera, renderer );
+	groundTiles.update();
+
+	const skyPlugin = skyTiles.getPluginByName( 'FADE_TILES_PLUGIN' );
+	skyPlugin.fadeRootTiles = params.fadeRootTiles;
+	skyPlugin.fadeDuration = params.useFade ? params.fadeDuration * 1000 : 0;
+	skyTiles.setCamera( camera );
+	skyTiles.setResolutionFromRenderer( camera, renderer );
+	skyTiles.update();
+
+	renderer.render( scene, camera );
+
+	params.fadingGroundTiles = groundPlugin.fadingTiles + ' tiles';
+
+}

--- a/src/three/plugins/fade/wrapFadeMaterial.js
+++ b/src/three/plugins/fade/wrapFadeMaterial.js
@@ -212,9 +212,15 @@ function modifyNodeMaterial( material, params ) {
 
 	material.params = params;
 
-	let FEATURE_FADE = false;
+	let FEATURE_FADE = 0;
 
 	material.defines = {
+
+		get FEATURE_FADE() {
+
+			return FEATURE_FADE;
+
+		},
 
 		set FEATURE_FADE( value ) {
 


### PR DESCRIPTION
This PR adds preliminary support for `NodeMaterial` in `TilesFadePlugin`. I consider this preliminary because it doesn't support `BatchedMesh`, as I have not been able to use `BatchedMeshPlugin` with `WebGPURenderer` yet.

A possible incompatibility is that it will not work if the user is using importmaps and doesn't have a route to `three/tsl`.

An example page was added for demonstration purposes, but it's mostly a duplicate. It would be ideal to add the ability to switch the renderer in `fadingTiles.html`. I'll be happy to remove it, or to work on it if this PR is legitimate.