### PR TITLE
Fix loaders' working path creation

### DIFF
--- a/src/core/renderer/loaders/I3DMLoaderBase.js
+++ b/src/core/renderer/loaders/I3DMLoaderBase.js
@@ -6,6 +6,7 @@ import { FeatureTable } from '../utilities/FeatureTable.js';
 import { arrayToString } from '../utilities/arrayToString.js';
 import { LoaderBase } from './LoaderBase.js';
 import { readMagicBytes } from '../utilities/readMagicBytes.js';
+import { getWorkingPath } from '../utilities/urlExtension.js';
 
 export class I3DMLoaderBase extends LoaderBase {
 
@@ -88,9 +89,7 @@ export class I3DMLoaderBase extends LoaderBase {
 			const externalUri = this.resolveExternalURL( arrayToString( bodyBytes ) );
 
 			//Store the gltf working path
-			const uriSplits = externalUri.split( /[\\/]/g );
-			uriSplits.pop();
-			gltfWorkingPath = uriSplits.join( '/' ) + '/';
+			gltfWorkingPath = getWorkingPath( externalUri );
 
 			promise = fetch( externalUri, this.fetchOptions )
 				.then( res => {

--- a/src/core/renderer/loaders/I3DMLoaderBase.js
+++ b/src/core/renderer/loaders/I3DMLoaderBase.js
@@ -90,7 +90,7 @@ export class I3DMLoaderBase extends LoaderBase {
 			//Store the gltf working path
 			const uriSplits = externalUri.split( /[\\/]/g );
 			uriSplits.pop();
-			gltfWorkingPath = uriSplits.join( '/' );
+			gltfWorkingPath = uriSplits.join( '/' ) + '/';
 
 			promise = fetch( externalUri, this.fetchOptions )
 				.then( res => {

--- a/src/core/renderer/loaders/LoaderBase.d.ts
+++ b/src/core/renderer/loaders/LoaderBase.d.ts
@@ -4,7 +4,6 @@ export class LoaderBase<Result = any, ParseResult = Promise< Result >> {
 	workingPath: string;
 	load( url: string ): Promise< Result >;
 	resolveExternalURL( url: string ): string;
-	workingPathForURL( url: string ): string
 	parse( buffer: ArrayBuffer ): ParseResult;
 
 }

--- a/src/core/renderer/loaders/LoaderBase.js
+++ b/src/core/renderer/loaders/LoaderBase.js
@@ -45,7 +45,7 @@ export class LoaderBase {
 
 		if ( /^[^\\/]/.test( url ) && ! /^http/.test( url ) ) {
 
-			return this.workingPath + '/' + url;
+			return new URL( url, this.workingPath ).href;
 
 		} else {
 

--- a/src/core/renderer/loaders/LoaderBase.js
+++ b/src/core/renderer/loaders/LoaderBase.js
@@ -1,3 +1,5 @@
+import { getWorkingPath } from '../utilities/urlExtension.js';
+
 export class LoaderBase {
 
 	constructor() {
@@ -31,7 +33,7 @@ export class LoaderBase {
 
 				if ( this.workingPath === '' ) {
 
-					this.workingPath = this.workingPathForURL( url );
+					this.workingPath = getWorkingPath( url );
 
 				}
 
@@ -43,24 +45,7 @@ export class LoaderBase {
 
 	resolveExternalURL( url ) {
 
-		if ( /^[^\\/]/.test( url ) && ! /^http/.test( url ) ) {
-
-			return new URL( url, this.workingPath ).href;
-
-		} else {
-
-			return url;
-
-		}
-
-	}
-
-	workingPathForURL( url ) {
-
-		const splits = url.split( /[\\/]/g );
-		splits.pop();
-		const workingPath = splits.join( '/' );
-		return workingPath + '/';
+		return new URL( url, this.workingPath ).href;
 
 	}
 

--- a/src/core/renderer/utilities/urlExtension.js
+++ b/src/core/renderer/utilities/urlExtension.js
@@ -26,3 +26,10 @@ export function getUrlExtension( url ) {
 	return filename.substring( lastPeriod + 1 ) || null;
 
 }
+
+// Returns a working path with a trailing slash
+export function getWorkingPath( url ) {
+
+	return url.replace( /[\\/][^\\/]+$/, '' ) + '/';
+
+}

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -573,7 +573,7 @@ export class TilesRenderer extends TilesRendererBase {
 		const cached = tile.cached;
 		const uriSplits = uri.split( /[\\/]/g );
 		uriSplits.pop();
-		const workingPath = uriSplits.join( '/' );
+		const workingPath = uriSplits.join( '/' ) + '/';
 		const fetchOptions = this.fetchOptions;
 
 		const manager = this.manager;

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -20,6 +20,7 @@ import { ExtendedFrustum } from '../math/ExtendedFrustum.js';
 import { estimateBytesUsed } from './utilities.js';
 import { WGS84_ELLIPSOID } from '../math/GeoConstants.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { getWorkingPath } from '../../../core/renderer/utilities/urlExtension.js';
 
 const _mat = new Matrix4();
 const _euler = new Euler();
@@ -571,9 +572,7 @@ export class TilesRenderer extends TilesRendererBase {
 	async parseTile( buffer, tile, extension, uri, abortSignal ) {
 
 		const cached = tile.cached;
-		const uriSplits = uri.split( /[\\/]/g );
-		uriSplits.pop();
-		const workingPath = uriSplits.join( '/' ) + '/';
+		const workingPath = getWorkingPath( uri );
 		const fetchOptions = this.fetchOptions;
 
 		const manager = this.manager;


### PR DESCRIPTION
Resolves #1282.

Trailing slash was not always added to `workingPath` and `resolveExternalURL` was not accounting for relative path (such as "../../tree.glb" in the tile mentioned in #1282).