### PR TITLE
GeoJSONOverlay: Add support for drawing polygons with holes

### DIFF
--- a/src/three/plugins/images/sources/GeoJSONImageSource.js
+++ b/src/three/plugins/images/sources/GeoJSONImageSource.js
@@ -308,12 +308,18 @@ export class GeoJSONImageSource extends TiledImageSource {
 		} else if ( type === 'LineString' ) {
 
 			ctx.beginPath();
-
 			geometry.coordinates.forEach( ( [ lon, lat ], i ) => {
 
 				const [ px, py ] = projectPoint( lon, lat );
-				if ( i === 0 ) ctx.moveTo( px, py );
-				else ctx.lineTo( px, py );
+				if ( i === 0 ) {
+
+					ctx.moveTo( px, py );
+
+				} else {
+
+					ctx.lineTo( px, py );
+
+				}
 
 			} );
 
@@ -321,58 +327,78 @@ export class GeoJSONImageSource extends TiledImageSource {
 
 		} else if ( type === 'MultiLineString' ) {
 
+			ctx.beginPath();
 			geometry.coordinates.forEach( ( line ) => {
 
-				ctx.beginPath();
 				line.forEach( ( [ lon, lat ], i ) => {
 
 					const [ px, py ] = projectPoint( lon, lat );
-					if ( i === 0 ) ctx.moveTo( px, py );
-					else ctx.lineTo( px, py );
+					if ( i === 0 ) {
+
+						ctx.moveTo( px, py );
+
+					} else {
+
+						ctx.lineTo( px, py );
+
+					}
 
 				} );
-				ctx.stroke();
 
 			} );
+			ctx.stroke();
 
 		} else if ( type === 'Polygon' ) {
 
+			ctx.beginPath();
 			geometry.coordinates.forEach( ( ring, rIndex ) => {
 
-				ctx.beginPath();
 				ring.forEach( ( [ lon, lat ], i ) => {
 
 					const [ px, py ] = projectPoint( lon, lat );
-					if ( i === 0 ) ctx.moveTo( px, py );
-					else ctx.lineTo( px, py );
+					if ( i === 0 ) {
+
+						ctx.moveTo( px, py );
+
+					} else {
+
+						ctx.lineTo( px, py );
+
+					}
 
 				} );
 				ctx.closePath();
-				// fill only outer ring
-				if ( rIndex === 0 ) ctx.fill();
-				ctx.stroke();
 
 			} );
+			ctx.fill( 'evenodd' );
+			ctx.stroke();
 
 		} else if ( type === 'MultiPolygon' ) {
 
 			geometry.coordinates.forEach( ( polygon ) => {
 
+				ctx.beginPath();
 				polygon.forEach( ( ring, rIndex ) => {
 
-					ctx.beginPath();
 					ring.forEach( ( [ lon, lat ], i ) => {
 
 						const [ px, py ] = projectPoint( lon, lat );
-						if ( i === 0 ) ctx.moveTo( px, py );
-						else ctx.lineTo( px, py );
+						if ( i === 0 ) {
+
+							ctx.moveTo( px, py );
+
+						} else {
+
+							ctx.lineTo( px, py );
+
+						}
 
 					} );
 					ctx.closePath();
-					if ( rIndex === 0 ) ctx.fill();
-					ctx.stroke();
 
 				} );
+				ctx.fill( 'evenodd' );
+				ctx.stroke();
 
 			} );
 


### PR DESCRIPTION
Based on #1325 

Uses "evenodd" fill for drawing polygon holes.

**Before**
<img width="200" alt="image" src="https://github.com/user-attachments/assets/2cbdab71-5623-4c9e-a161-5410380fe85c" />

**After**
<img width="200" alt="image" src="https://github.com/user-attachments/assets/9059ae66-ba33-4d07-846f-6127608e9440" />

cc @SoftwareMechanic 