### PR TITLE
Remove conditional import for TextureUtils

### DIFF
--- a/src/three/plugins/images/sources/TiledImageSource.js
+++ b/src/three/plugins/images/sources/TiledImageSource.js
@@ -1,7 +1,6 @@
 import { DataCache } from '../utils/DataCache.js';
 import { TilingScheme } from '../utils/TilingScheme.js';
-import { SRGBColorSpace, Texture } from 'three';
-import * as THREE from 'three';
+import { SRGBColorSpace, Texture, TextureUtils } from 'three';
 
 // TODO: support queries for detail at level - ie projected pixel size for geometric error mapping
 // Goes here or in "TilingScheme"?
@@ -38,14 +37,6 @@ export class TiledImageSource extends DataCache {
 	}
 
 	getMemoryUsage( tex ) {
-
-		// deprecated: remove in next major release
-		const { TextureUtils } = THREE;
-		if ( ! TextureUtils ) {
-
-			return 0;
-
-		}
 
 		const { format, type, image, generateMipmaps } = tex;
 		const { width, height } = image;

--- a/src/three/renderer/utils/MemoryUtils.js
+++ b/src/three/renderer/utils/MemoryUtils.js
@@ -1,16 +1,7 @@
 import { estimateBytesUsed as _estimateBytesUsed } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import * as THREE from 'three';
+import { TextureUtils } from 'three';
 
 export function safeTextureGetByteLength( tex ) {
-
-	// NOTE: This is for backwards compatibility and should be removed later
-	// deprecated: remove in next major release
-	const { TextureUtils } = THREE;
-	if ( ! TextureUtils || ! tex ) {
-
-		return 0;
-
-	}
 
 	const { format, type, image } = tex;
 	const { width, height } = image;


### PR DESCRIPTION
The conditional import of the `TextureUtils` as
```js
const { TextureUtils } = THREE;
if ( ! TextureUtils ) {

  return 0;

}
```
causes bundler to disabling entirely tree-shaking (i.e. dead code removal) on `three.js`.

Since `TextureUtils` is available since r166 and `3d-tiles-renderer` depends on `three` > r170, I think it is safe to use the standard ESM import.