### PR TITLE
Added custom fetchOptions management for overlays, added a proxyUrl parameter

### DIFF
--- a/src/three/plugins/images/ImageOverlayPlugin.d.ts
+++ b/src/three/plugins/images/ImageOverlayPlugin.d.ts
@@ -20,6 +20,8 @@ export class ImageOverlay {
 	color: number | Color;
 	opacity: number;
 	frame?: Matrix4 | null;
+	proxyUrl?: string;
+	fetchOptions?: any;
 
 }
 
@@ -71,7 +73,6 @@ export class WMSTilesOverlay extends ImageOverlay {
 		levels?: number,
 		transparent?: boolean,
 		contentBoundingBox?: [ number, number, number, number ],
-
 		color: number | Color,
 		opacity: number,
 		frame?: Matrix4 | null,

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -961,7 +961,9 @@ export class ImageOverlayPlugin {
 	_initOverlay( overlay ) {
 
 		const { tiles } = this;
-		overlay.imageSource.fetchOptions = tiles.fetchOptions;
+		//overlay.imageSource.fetchOptions = tiles.fetchOptions;
+		overlay.imageSource.fetchOptions = { ...tiles.fetchOptions, ...overlay.fetchOptions };
+
 		if ( ! overlay.isInitialized ) {
 
 			overlay.imageSource.fetchData = ( ...args ) => tiles
@@ -1407,8 +1409,12 @@ class ImageOverlay {
 			opacity = 1,
 			color = 0xffffff,
 			frame = null,
+			fetchOptions = {},
+			proxyUrl = null,
 		} = options;
 		this.imageSource = null;
+		this.fetchOptions = fetchOptions;
+		this.proxyUrl = proxyUrl;
 		this.opacity = opacity;
 		this.color = new Color( color );
 		this.frame = frame !== null ? frame.clone() : null;
@@ -1428,9 +1434,12 @@ class ImageOverlay {
 
 	}
 
-	fetch( ...args ) {
+	// Apply proxy prefix and merge options
+	fetch( url, options = {} ) {
 
-		return fetch( ...args );
+		const finalUrl = this.proxyUrl ? `${ this.proxyUrl }${ encodeURIComponent( url ) }` : url;
+		const finalOptions = { ...this.fetchOptions, ...options };
+		return fetch( finalUrl, finalOptions );
 
 	}
 

--- a/src/three/plugins/images/sources/WMSImageSource.js
+++ b/src/three/plugins/images/sources/WMSImageSource.js
@@ -140,7 +140,6 @@ export class WMSImageSource extends TiledImageSource {
 			REQUEST: 'GetMap',
 			VERSION: version,
 			LAYERS: layer,
-			STYLES: styles,
 			[ crsParam ]: crs,
 			BBOX: bboxParam.join( ',' ),
 			WIDTH: tileDimension,
@@ -148,6 +147,14 @@ export class WMSImageSource extends TiledImageSource {
 			FORMAT: format,
 			TRANSPARENT: transparent ? 'TRUE' : 'FALSE',
 		} );
+
+		// Only add STYLES if it's defined (not null or undefined)
+		// This is a WMS-specific parameter, and giving it an unexpected value can lead to errors
+		if ( styles !== null && styles !== undefined ) {
+
+			params.set( 'STYLES', styles );
+
+		}
 
 		return new URL( '?' + params.toString(), this.url ).toString();
 


### PR DESCRIPTION
The reason for the proxyUrl is that usually the front end can not directly communicate with external servers, causing CORS issues.
so a proxy is needed in order to manage the request server side, regardless of the need for custom fetch options.

the proxy is also used by the CesiumJS Library, here just a code example:

```
        const imageryProvider = new CesiumJs.WebMapServiceImageryProvider({
          url: new CesiumJs.Resource({
            url: wmsUrl,
            headers,
            proxy: new CesiumJs.DefaultProxy("/api/proxy?url="),
          }),
          layers: layerName,
          enablePickFeatures: true,
          parameters: {
            transparent: true,
            format: "image/png",
            version: "1.3.0",
          },
        });
```

for the custom headers, the ImageOverlay class now takes also fetchOptions parameter and use them while fetching the imageSource.

just 2 things:

1. if you want, I can send you privately via e-mail an example which uses the authentication (and a proxy that you should create separately). I can give you the credentials, but of course this would be just to let you test it eventually.
2. I noticed something that was happening also while I was trying to implement WMS initially, when using EPSG:4326, (and not 3857) the layer is not correctly applied to the map, with my example with authentication, you can clearly see this. we could solve it for this PR, or otherwise i could create a new Issue for that. as you prefer :)

just for reference here an image of what I mean in the point 2.
<img width="1643" height="608" alt="immagine" src="https://github.com/user-attachments/assets/8f9157a7-890c-4388-be18-f6d0a5450144" />


if you notice something, don't hesitate to tell me!


