### PR TITLE
Add complete TypeScript definitions for CameraTransitionManager

### DIFF
--- a/src/three/renderer/controls/CameraTransitionManager.d.ts
+++ b/src/three/renderer/controls/CameraTransitionManager.d.ts
@@ -1,17 +1,39 @@
-import { EventDispatcher, OrthographicCamera, PerspectiveCamera } from 'three';
+import { EventDispatcher, OrthographicCamera, PerspectiveCamera, Vector3 } from 'three';
 
-export class CameraTransitionManager extends EventDispatcher {
+export interface CameraTransitionManagerEventMap {
+	'camera-change': { camera: PerspectiveCamera | OrthographicCamera; prevCamera: PerspectiveCamera | OrthographicCamera };
+	'transition-start': {};
+	'transition-end': {};
+	'toggle': {};
+	'change': { alpha: number };
+}
+
+export class CameraTransitionManager extends EventDispatcher<CameraTransitionManagerEventMap> {
 
 	get animating(): boolean;
+	get alpha(): number;
 	get camera(): PerspectiveCamera | OrthographicCamera;
 
 	get mode(): 'perspective' | 'orthographic';
 	set mode( v: 'perspective' | 'orthographic' );
 
+	// settings
+	fixedPoint: Vector3;
+	duration: number;
+	autoSync: boolean;
+	orthographicPositionalZoom: boolean;
+	orthographicOffset: number;
+	easeFunction: ( x: number ) => number;
+
+	// cameras
+	perspectiveCamera: PerspectiveCamera;
+	orthographicCamera: OrthographicCamera;
+	transitionCamera: PerspectiveCamera;
+
 	constructor( perspectiveCamera?: PerspectiveCamera, orthographicCamera?: OrthographicCamera );
 
 	toggle(): void;
-	update(): void;
+	update( deltaTime?: number ): void;
 
 	syncCameras(): void;
 

--- a/src/three/renderer/index.d.ts
+++ b/src/three/renderer/index.d.ts
@@ -15,4 +15,4 @@ export * from './math/TileBoundingVolume.js';
 // three.js controls
 export { GlobeControls } from './controls/GlobeControls.js';
 export { EnvironmentControls } from './controls/EnvironmentControls.js';
-export { CameraTransitionManager } from './controls/CameraTransitionManager.js';
+export { CameraTransitionManager, CameraTransitionManagerEventMap } from './controls/CameraTransitionManager.js';


### PR DESCRIPTION
## Description

This PR adds complete TypeScript definitions for the `CameraTransitionManager` class to expose all public API that was previously missing from the type definitions.

## Changes

- **Event typing**: Added `CameraTransitionManagerEventMap` interface defining all event types:
  - `camera-change`: Fired when the active camera changes
  - `transition-start`: Fired when a transition animation begins
  - `transition-end`: Fired when a transition animation ends
  - `toggle`: Fired when cameras are toggled
  - `change`: Fired during transition with alpha progress

- **Missing properties**: Added all public properties from the JavaScript implementation:
  - `fixedPoint`: Vector3 - The point in space that remains stable during transitions
  - `duration`: number - Transition duration in milliseconds
  - `autoSync`: boolean - Whether to automatically sync cameras
  - `orthographicPositionalZoom`: boolean - Zoom behavior setting
  - `orthographicOffset`: number - Offset for orthographic camera positioning
  - `easeFunction`: (x: number) => number - Custom easing function
  - `perspectiveCamera`: PerspectiveCamera - The perspective camera instance
  - `orthographicCamera`: OrthographicCamera - The orthographic camera instance
  - `transitionCamera`: PerspectiveCamera - The intermediate camera used during transitions

- **Missing getter**: Added `alpha` getter property that returns transition progress

- **Method signature**: Updated `update()` to include optional `deltaTime` parameter

- **Export**: Added `CameraTransitionManagerEventMap` to index exports

## Pattern

This PR follows the same pattern used by `EnvironmentControls` in the repository, using `EventDispatcher<EventMap>` for type-safe event handling.

## Testing

Type definitions have been verified against the JavaScript implementation in `src/three/renderer/controls/CameraTransitionManager.js`.

## Related

This resolves type definition gaps that required users to create extended type definitions in their projects (e.g., see usage in aec-craft/nb-generative).