### PR TITLE
MemoryUtils: Add null check for texture when calculating bytes

### DIFF
--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -363,7 +363,7 @@ export class ImageOverlayPlugin {
 
 				const { target } = tileInfo.get( tile );
 				bytes = bytes || 0;
-				bytes += MemoryUtils.safeTextureGetByteLength( target?.texture );
+				bytes += MemoryUtils.getTextureByteLength( target?.texture );
 
 			}
 

--- a/src/three/renderer/utils/MemoryUtils.js
+++ b/src/three/renderer/utils/MemoryUtils.js
@@ -1,7 +1,13 @@
 import { estimateBytesUsed as _estimateBytesUsed } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { TextureUtils } from 'three';
 
-export function safeTextureGetByteLength( tex ) {
+export function getTextureByteLength( tex ) {
+
+	if ( ! tex ) {
+
+		return 0;
+
+	}
 
 	const { format, type, image } = tex;
 	const { width, height } = image;
@@ -38,7 +44,7 @@ export function estimateBytesUsed( object ) {
 				const value = material[ key ];
 				if ( value && value.isTexture && ! dedupeSet.has( value ) ) {
 
-					totalBytes += safeTextureGetByteLength( value );
+					totalBytes += getTextureByteLength( value );
 					dedupeSet.add( value );
 
 				}


### PR DESCRIPTION
Fix #1346

- Rename "safeTextureGetByteLength" to "getTextureByteLength"
- Fix case where "safeTextureGetByteLength" would throw an error if passed null (introduced in #1335)