### PR TITLE
min three version is 167

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@react-three/fiber": "^8.17.9 || ^9.0.0",
         "react": "^18.3.1 || ^19.0.0",
         "react-dom": "^18.3.1 || ^19.0.0",
-        "three": ">=0.166.0"
+        "three": ">=0.167.0"
       },
       "peerDependenciesMeta": {
         "@react-three/fiber": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@react-three/fiber": "^8.17.9 || ^9.0.0",
     "react": "^18.3.1 || ^19.0.0",
     "react-dom": "^18.3.1 || ^19.0.0",
-    "three": ">=0.166.0"
+    "three": ">=0.167.0"
   },
   "peerDependenciesMeta": {
     "@react-three/fiber": {


### PR DESCRIPTION
v167 is when Matrix2 shipped https://github.com/mrdoob/three.js/pull/28923

I noticed while updating a local example build from an old-old-old version of three, but I wanted to update in the smallest chunk required to test, updating to 166 per the existing peer deps results in the error below.

```
✘ [ERROR] No matching export in "node_modules/three/build/three.module.js" for import "Matrix2"

    node_modules/3d-tiles-renderer/build/WMSCapabilitiesLoader-j6h8dwK_.js:3:434:
      3 │ ...Triangle as Ht, Vector4 as Ue, Matrix4 as Q, Matrix3 as kn, Matrix2 as jn, WebGLRenderer as zn, WebGLRenderTarget as Ut, Shade...
        ╵
```