### PR TITLE
Fix unregisterPlugin not working with name overload

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -222,7 +222,7 @@ export class TilesRendererBase {
 		const plugins = this.plugins;
 		if ( typeof plugin === 'string' ) {
 
-			plugin = this.getPluginByName( name );
+			plugin = this.getPluginByName( plugin );
 
 		}
 

--- a/test/TilesRendererBase.test.js
+++ b/test/TilesRendererBase.test.js
@@ -1,0 +1,15 @@
+import { TilesRendererBase } from '../src/core/renderer';
+
+describe( 'TilesRendererBase', () => {
+
+	it( 'should unregister plugin by name', () => {
+
+		const renderer = new TilesRendererBase();
+
+		renderer.registerPlugin( { name: 'test' } );
+
+		expect( renderer.unregisterPlugin( 'test' ) ).toBe( true );
+
+	} );
+
+} );


### PR DESCRIPTION
When calling `TilesRendererBase.unregisterPlugin` with a name, it doesn't remove the plugin because it is using the wrong variable