### PR TITLE
Added a plugin for clipping the globe geometry starting from geojson geometries

### DIFF
--- a/src/three/plugins/images/ImageOverlayPlugin.d.ts
+++ b/src/three/plugins/images/ImageOverlayPlugin.d.ts
@@ -57,33 +57,15 @@ export class GeoJSONOverlay extends ImageOverlay {
 
 		frame?: Matrix4 | null,
 
-	} );
-
-}
-
-export class GeoJSONClipOverlay extends GeoJSONOverlay {
-
-	constructor( options: {
-
-		isClipOverlay : boolean,
-		clipThreshold : number,
-		clipInside : boolean,
-
-		// rasterize GeoJSON per tile (forwarded to GeoJSONImageSource)
-		geojson?: any, // FeatureCollection or null (if url provided)
-		url?: string, // optional URL alternative to geojson object
-		tileDimension?: number, // tile size in px (runtime name: tileDimension)
-		levels?: number, // max rasterization zoom
-		pointRadius?: number,
-		strokeStyle?: string,
-		fillStyle?: string,
-		color?: number | Color,
-		opacity?: number,
-		frame?: Matrix4 | null,
+		// clip options
+		alphaMode?: 'layer' | 'global',
+		alphaTest?: number, // 0..1, 0 = no hard clip
+		alphaInvert?: boolean, // false = cut inside (keep outside); true = cut outside (keep inside)
 
 	} );
 
 }
+
 
 export class WMSTilesOverlay extends ImageOverlay {
 

--- a/src/three/plugins/images/overlays/wrapOverlaysMaterial.js
+++ b/src/three/plugins/images/overlays/wrapOverlaysMaterial.js
@@ -20,12 +20,20 @@ export function wrapOverlaysMaterial( material, options ) {
 		layerMaps: { value: [] },
 		layerColor: { value: [] },
 
-		// clip overlay uniforms
+		// NEW: per-layer hard threshold (applied in 'layer' mode)
+		layerAlphaTest: { value: [] },
+
+		// clip/global-mask uniforms
 		overlayClipMap: { value: null },
 		overlayClipThreshold: { value: 0.5 },
-		overlayClipInside: { value: 1 }, // 1 = keep inside, 0 = keep outside
-		overlayClipEnabled: { value: 0 }, // 0 = disabled, 1 = enabled
+		overlayClipInside: { value: 1 },
+		overlayClipEnabled: { value: 0 },
 
+		// NEW: make clip path work across all tiles
+		overlayClipHasMap: { value: 0 },
+		overlayClipFallbackAlpha: { value: 1.0 },
+		overlayClipForce: { value: 0 },
+		overlayClipDebug: { value: 0 },
 	};
 
 	material[ OVERLAY_PARAMS ] = params;
@@ -46,7 +54,7 @@ export function wrapOverlaysMaterial( material, options ) {
 		};
 
 		// Toggle the define only when we actually provide the attribute and map.
-		if ( params.overlayClipMap.value ) {
+		if ( params.overlayClipMap.value || params.overlayClipForce.value ) {
 
 			shader.defines.USE_OVERLAY_CLIP = 1;
 
@@ -92,6 +100,7 @@ export function wrapOverlaysMaterial( material, options ) {
 					struct LayerTint { vec3 color; float opacity; };
 					uniform sampler2D layerMaps[ LAYER_COUNT ];
 					uniform LayerTint layerColor[ LAYER_COUNT ];
+					uniform float layerAlphaTest[ LAYER_COUNT ];
 				#endif
 
 				#pragma unroll_loop_start
@@ -108,20 +117,24 @@ export function wrapOverlaysMaterial( material, options ) {
 					uniform int overlayClipInside;
 					uniform int overlayClipEnabled;
 					uniform int overlayClipDebug;
+					uniform int overlayClipHasMap;
+					uniform float overlayClipFallbackAlpha;
+					uniform int overlayClipForce;
 					varying vec3 v_clip_uv;
 				#endif
 
 				${ value }
 			` )
 			.replace( 'void main() {', /* glsl */`
-                void main() {
-                #ifdef USE_OVERLAY_CLIP
-                    // Optional debug tint: show mask as red (outside) vs keep color (inside)
-                    if ( overlayClipDebug == 1 ) {
-                        float a = texture( overlayClipMap, v_clip_uv.xy ).a;
-                        // fall through; tint will be applied after base color
-                    }
-                #endif
+				void main() {
+				#ifdef USE_OVERLAY_CLIP
+					if ( overlayClipDebug == 1 ) {
+						// debug read (no-op unless you tint)
+						float a = (overlayClipHasMap == 1)
+							? texture( overlayClipMap, v_clip_uv.xy ).a
+							: overlayClipFallbackAlpha;
+					}
+				#endif
 			` )
 			.replace( /#include <color_fragment>/, value => /* glsl */`
 				${ value }
@@ -135,7 +148,9 @@ export function wrapOverlaysMaterial( material, options ) {
 							smoothstep( 1.0 + wDelta, 1.0, v_clip_uv.z );
 
 						if ( wOpacity > 0.0 ) {
-							float clipAlpha = texture( overlayClipMap, v_clip_uv.xy ).a;
+							float clipAlpha = (overlayClipHasMap == 1)
+								? texture( overlayClipMap, v_clip_uv.xy ).a
+								: overlayClipFallbackAlpha;
 							bool inside = clipAlpha >= overlayClipThreshold;
 							bool discardFragment = (overlayClipInside == 1) ? (!inside) : inside;
 							if ( discardFragment ) discard;
@@ -157,14 +172,22 @@ export function wrapOverlaysMaterial( material, options ) {
 							layerUV = v_layer_uv_UNROLLED_LOOP_INDEX;
 							tint = texture( layerMaps[ i ], layerUV.xy );
 
+							// NEW: per-layer alpha hard threshold ('layer' mode only)
+							float threshold = layerAlphaTest[ i ];
+							if ( threshold > 0.0 ) {
+								tint.a = step( threshold, tint.a );
+							}
+
 							wDelta = max( fwidth( layerUV.z ), 1e-7 );
 							wOpacity =
 								smoothstep( - wDelta, 0.0, layerUV.z ) *
 								smoothstep( 1.0 + wDelta, 1.0, layerUV.z );
 
+							// apply tint & opacity
 							tint.rgb *= layerColor[ i ].color;
 							tint.rgba *= layerColor[ i ].opacity * wOpacity;
 
+							// premultiplied alpha equation
 							diffuseColor = tint + diffuseColor * ( 1.0 - tint.a );
 						#endif
 					}


### PR DESCRIPTION
Fix #1365

this could be useful to represent assets on tiles, especially photorealistic tiles, without using the TileFlatteningPlugin.
the purpose is to render our models in their original position, removing artifacts given by the photorealistic tiles.

this pull request is aimed at solving (partially) the issue #1365 

I say **partially** because as we have discussed in the issue, there could be other ways, with other pros/cons to achieve the same effect.


questions:

1. do we want it to extend the geojson class as it is now in this initial state of the pr, or a new class only for it?
2. is it ok to modify the _wrapOverlaysMaterials_ like has beeen done, or we somehow want to use the alphamap default property from the materials?
