### PR TITLE
Fix access of `getPointerCount` by invocating instead of accessing `length`

### DIFF
--- a/src/three/renderer/controls/PointerTracker.js
+++ b/src/three/renderer/controls/PointerTracker.js
@@ -131,7 +131,7 @@ export class PointerTracker {
 		delete this.previousPositions[ id ];
 		delete this.startPositions[ id ];
 
-		if ( this.getPointerCount.length === 0 ) {
+		if ( this.getPointerCount() === 0 ) {
 
 			this.buttons = 0;
 			this.pointerType = null;


### PR DESCRIPTION
Something I noticed which I don't believe was right.