### PR TITLE
Add missing option to GeoJSONOverlay type

### DIFF
--- a/src/three/plugins/images/ImageOverlayPlugin.d.ts
+++ b/src/three/plugins/images/ImageOverlayPlugin.d.ts
@@ -53,6 +53,7 @@ export class GeoJSONOverlay extends ImageOverlay {
 		levels?: number, // max rasterization zoom
 		pointRadius?: number,
 		strokeStyle?: string,
+		strokeWidth?: number,
 		fillStyle?: string,
 		color?: number | Color,
 		opacity?: number,


### PR DESCRIPTION
Added the missing `strokeWidth` property to the `GeoJSONOverlay` type definition. The implementation already supported this option, but it was absent from the type definition, causing TypeScript error.