### PR TITLE
Add 'tiles-settled' event for robust detection of visual stability

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -430,7 +430,7 @@ export class TilesRendererBase {
 
 		if ( ! this.isLoading && ! runningTasks ) {
 
-			this.framesSinceLastLoad++;
+			this.framesSinceLastLoad ++;
 
 			// Wait for 2 frames to ensure the update loop has had a chance to queue new downloads.
 			if ( this.framesSinceLastLoad === 2 ) {


### PR DESCRIPTION
**Description**
It seems that `tiles-load-end` fires as soon as the download queue is empty, which can happen before the scene is fully stable (e.g. before children are queued).

I introduced a `tiles-settled` event that waits for **2 consecutive frames** of inactivity to ensure the renderer is truly done.

**Use Case**
I am using this in a headless worker for elevation raycasting. The standard `tiles-load-end` event was occasionally causing me to sample low-resolution tiles; this new event solved the issue.