### PR TITLE
Deprecate events, add new load events

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -366,7 +366,7 @@ export class TilesRendererBase {
 					this.dispatchEvent( { type: 'load-content' } );
 
 					this.dispatchEvent( {
-						type: 'load-tileset-end',
+						type: 'load-tileset',
 						tileset: root,
 						url: processedUrl,
 					} );
@@ -1089,7 +1089,7 @@ export class TilesRendererBase {
 				if ( isExternalTileset ) {
 
 					this.dispatchEvent( {
-						type: 'load-tileset-end',
+						type: 'load-tileset',
 						tileset: externalTileset,
 						tile,
 						url: uri,
@@ -1100,7 +1100,7 @@ export class TilesRendererBase {
 				if ( tile.cached.scene ) {
 
 					this.dispatchEvent( {
-						type: 'load-model-end',
+						type: 'load-model',
 						scene: tile.cached.scene,
 						tile,
 						url: uri,

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -298,7 +298,7 @@ export class ImageOverlayPlugin {
 		};
 
 		tiles.addEventListener( 'update-after', this._onUpdateAfter );
-		tiles.addEventListener( 'tile-download-start', this._onTileDownloadStart );
+		tiles.addEventListener( 'load-model-start', this._onTileDownloadStart );
 
 		this.overlays.forEach( overlay => {
 

--- a/src/three/renderer/tiles/TilesRenderer.d.ts
+++ b/src/three/renderer/tiles/TilesRenderer.d.ts
@@ -7,21 +7,17 @@ export interface TilesRendererEventMap {
 	'add-camera': { camera: Camera };
 	'delete-camera': { camera: Camera };
 	'camera-resolution-change': {};
-	'load-tileset-start': { tile: Tile, url: string };
-	'load-tileset-end': { tileset: object, tile?: Tile, url: string };
-	/** @deprecated Use 'load-tileset-end' instead. */
-	'load-tileset': { tileset: object, /* @deprecated Use tileset instead */ tileSet?: object, url: string };
-	/* @deprecated Use 'load-tileset-end' instead */
+	'load-tileset-start': { tile: Tile | null, url: string };
+	'load-tileset': { tileset: object, tile?: Tile, url: string, /* @deprecated Use tileset instead */ tileSet?: object };
+	/* @deprecated Use 'load-tileset' instead */
 	'load-tile-set': { tileset: object, /* @deprecated Use tileset instead */ tileSet?: object, url: string };
 	'load-model-start': { tile: Tile, url: string };
-	'load-model-end': { scene: Object3D; tile: Tile, url: string };
-	/** @deprecated Use 'load-model-end' instead. */
 	'load-model': { scene: Object3D; tile: Tile, url: string };
 	'tiles-load-start': {};
 	'tiles-load-end': {};
 	/** @deprecated Use 'load-tileset-start' or 'load-model-start' instead. */
 	'tile-download-start': { tile: Tile, url: string };
-	/** @deprecated Use 'load-tileset-end' or 'load-model-end' instead. */
+	/** @deprecated Event provides no useful information. Use 'load-tileset' or 'load-model' instead. */
 	'load-content': {};
 	'dispose-model': { scene: Object3D; tile: Tile };
 	'tile-visibility-change': { scene: Object3D; tile: Tile; visible: boolean };

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -113,20 +113,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 		}
 
-		if ( type === 'load-tileset' ) {
-
-			console.warn( 'TilesRenderer: "load-tileset" event has been deprecated. Use "load-tileset-end" instead.' );
-			type = 'load-tileset-end';
-
-		}
-
-		if ( type === 'load-model' ) {
-
-			console.warn( 'TilesRenderer: "load-model" event has been deprecated. Use "load-model-end" instead.' );
-			type = 'load-model-end';
-
-		}
-
 		if ( type === 'load-content' ) {
 
 			console.warn( 'TilesRenderer: "load-content" event has been deprecated. Use "load-tileset" or "load-model" instead.' );
@@ -152,20 +138,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 		}
 
-		if ( type === 'load-tileset' ) {
-
-			console.warn( 'TilesRenderer: "load-tileset" event has been deprecated. Use "load-tileset-end" instead.' );
-			type = 'load-tileset-end';
-
-		}
-
-		if ( type === 'load-model' ) {
-
-			console.warn( 'TilesRenderer: "load-model" event has been deprecated. Use "load-model-end" instead.' );
-			type = 'load-model-end';
-
-		}
-
 		return EventDispatcher.prototype.hasEventListener.call( this, type, listener );
 
 	}
@@ -176,20 +148,6 @@ export class TilesRenderer extends TilesRendererBase {
 
 			console.warn( 'TilesRenderer: "load-tile-set" event has been deprecated. Use "load-tileset" instead.' );
 			type = 'load-tileset';
-
-		}
-
-		if ( type === 'load-tileset' ) {
-
-			console.warn( 'TilesRenderer: "load-tileset" event has been deprecated. Use "load-tileset-end" instead.' );
-			type = 'load-tileset-end';
-
-		}
-
-		if ( type === 'load-model' ) {
-
-			console.warn( 'TilesRenderer: "load-model" event has been deprecated. Use "load-model-end" instead.' );
-			type = 'load-model-end';
 
 		}
 


### PR DESCRIPTION
Fix #1405 
Fix #1296

- Add "load-model-start", "load-tileset-start" events
- Deprecate the "load-content" event
- Deprecate the "tile-download-start" event

**TODO**
- Make the event logic more robust. Currently "load-model-start" will fire for subtrees even though they are not geometry. And "load-model" then will not fire. Decide what to do here? With plugins it's not fully possible to interpret whether the content has geometry or not.