### PR TITLE
GeoJSONOverlay: Improve performance for complex data sets

### DIFF
--- a/src/three/plugins/images/sources/GeoJSONImageSource.js
+++ b/src/three/plugins/images/sources/GeoJSONImageSource.js
@@ -47,7 +47,7 @@ export class GeoJSONImageSource extends RegionImageSource {
 		this.fillStyle = fillStyle;
 
 		this.features = null;
-		this.featureBounds = new WeakMap();
+		this.featureBounds = new Map();
 		this.contentBounds = null;
 
 		this.projection = new ProjectionScheme();
@@ -119,14 +119,13 @@ export class GeoJSONImageSource extends RegionImageSource {
 
 	_updateCache( force = false ) {
 
-		// TODO: do this lazily rather than all at once? This means we would skip the full content bounds
-		if ( this.features && ! force ) {
+		const { geojson, featureBounds } = this;
+		if ( ! geojson || ( this.features && ! force ) ) {
 
 			return;
 
 		}
 
-		const { geojson, featureBounds } = this;
 		featureBounds.clear();
 
 		let minLon = Infinity;


### PR DESCRIPTION
Related to #1327 

Improves the performance with complex GeoJSON data sets by caching the features and bounds ahead of time rather than regenerating them every draw. Tested with the existing complex data set url:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ccf567dc-4807-48b3-8635-3276962ca314" />

When testing with the initial camera view a full "redraw" of all tiles goes down from ~2300ms to ~500ms, or an almost 80% improvement. This smooths out navigation quite a bit, too. The remaining time on the redraw method seems to be dominated by the actual "draw" portion of the function rather than the forceful cache update (the draw method could probably be improved, as well):

<img width="500" alt="image" src="https://github.com/user-attachments/assets/8918e01f-a4be-47d0-a7ae-0df84686338b" />

cc @SoftwareMechanic 