### PR TITLE
TilesRenderer: Add delay queue for loads

### DIFF
--- a/src/core/renderer/index.d.ts
+++ b/src/core/renderer/index.d.ts
@@ -12,5 +12,6 @@ export * from './constants.js';
 
 export { LRUCache } from './utilities/LRUCache.js';
 export { PriorityQueue } from './utilities/PriorityQueue.js';
+export { DelayQueue } from './utilities/DelayQueue.js';
 export { BatchTable } from './utilities/BatchTable.js';
 export { FeatureTable } from './utilities/FeatureTable.js';

--- a/src/core/renderer/index.js
+++ b/src/core/renderer/index.js
@@ -9,5 +9,6 @@ export * from './constants.js';
 
 export { LRUCache } from './utilities/LRUCache.js';
 export * from './utilities/PriorityQueue.js';
+export * from './utilities/DelayQueue.js';
 export * as TraversalUtils from './utilities/TraversalUtils.js';
 export * as LoaderUtils from './utilities/LoaderUtils.js';

--- a/src/core/renderer/tiles/TilesRendererBase.d.ts
+++ b/src/core/renderer/tiles/TilesRendererBase.d.ts
@@ -12,6 +12,7 @@ export class TilesRendererBase {
 	errorThreshold : number;
 	displayActiveTiles : boolean;
 	maxDepth : number;
+	downloadDelay : number;
 
 	loadProgress: number;
 

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -1,6 +1,7 @@
 import { getUrlExtension } from '../utilities/urlExtension.js';
 import { LRUCache } from '../utilities/LRUCache.js';
 import { PriorityQueue } from '../utilities/PriorityQueue.js';
+import { DelayQueue } from '../utilities/DelayQueue.js';
 import { markUsedTiles, toggleTiles, markVisibleTiles, markUsedSetLeaves } from './traverseFunctions.js';
 import { UNLOADED, QUEUED, LOADING, PARSING, LOADED, FAILED } from '../constants.js';
 import { throttle } from '../utilities/throttle.js';
@@ -127,6 +128,18 @@ export class TilesRendererBase {
 
 	}
 
+	get downloadDelay() {
+
+		return this.delayQueue.delay;
+
+	}
+
+	set downloadDelay( value ) {
+
+		this.delayQueue.delay = value;
+
+	}
+
 	constructor( url = null ) {
 
 		// state
@@ -141,6 +154,8 @@ export class TilesRendererBase {
 
 		const lruCache = new LRUCache();
 		lruCache.unloadPriorityCallback = lruPriorityCallback;
+
+		const delayQueue = new DelayQueue();
 
 		const downloadQueue = new PriorityQueue();
 		downloadQueue.maxJobs = 25;
@@ -159,6 +174,7 @@ export class TilesRendererBase {
 		this.usedSet = new Set();
 		this.loadingTiles = new Set();
 		this.lruCache = lruCache;
+		this.delayQueue = delayQueue;
 		this.downloadQueue = downloadQueue;
 		this.parseQueue = parseQueue;
 		this.processNodeQueue = processNodeQueue;

--- a/src/core/renderer/utilities/DelayQueue.d.ts
+++ b/src/core/renderer/utilities/DelayQueue.d.ts
@@ -1,6 +1,7 @@
 export class DelayQueue {
 
 	delay: number;
+	readonly running: boolean;
 
 	add( item: any, callback: ( item: any ) => any ): Promise<any>;
 	remove( item: any ): void;

--- a/src/core/renderer/utilities/DelayQueue.d.ts
+++ b/src/core/renderer/utilities/DelayQueue.d.ts
@@ -1,8 +1,8 @@
 export class DelayQueue {
 
-	delay : number;
+	delay: number;
 
-	add( item : any, callback : ( item : any ) => any ) : Promise< any >;
-	remove( item : any ) : void;
+	add( item: any, callback: ( item: any ) => any ): Promise<any>;
+	remove( item: any ): void;
 
 }

--- a/src/core/renderer/utilities/DelayQueue.d.ts
+++ b/src/core/renderer/utilities/DelayQueue.d.ts
@@ -1,0 +1,8 @@
+export class DelayQueue {
+
+	delay : number;
+
+	add( item : any, callback : ( item : any ) => any ) : Promise< any >;
+	remove( item : any ) : void;
+
+}

--- a/src/core/renderer/utilities/DelayQueue.js
+++ b/src/core/renderer/utilities/DelayQueue.js
@@ -1,0 +1,162 @@
+export class DelayQueueItemRemovedError extends Error {
+
+	constructor() {
+
+		super( 'DelayQueue: Item removed' );
+		this.name = 'DelayQueueItemRemovedError';
+
+	}
+
+}
+
+export class DelayQueue {
+
+	get delay() {
+
+		return this._delay;
+
+	}
+
+	set delay( value ) {
+
+		this._delay = value;
+		this._scheduleTimeout( true );
+
+	}
+
+	constructor() {
+
+		this._delay = 0;
+		this.items = [];
+		this.timeoutId = null;
+
+	}
+
+	add( item, callback ) {
+
+		const data = {
+			item,
+			callback,
+			time: performance.now(),
+			reject: null,
+			resolve: null,
+		};
+
+		data.promise = new Promise( ( resolve, reject ) => {
+
+			data.resolve = resolve;
+			data.reject = reject;
+
+			this.items.push( data );
+			this._scheduleTimeout();
+
+		} );
+
+		return data.promise;
+
+	}
+
+	remove( item ) {
+
+		const { items } = this;
+		const index = items.findIndex( data => data.item === item );
+		if ( index !== - 1 ) {
+
+			const data = items[ index ];
+			data.promise.catch( err => {
+
+				if ( ! ( err instanceof DelayQueueItemRemovedError ) ) {
+
+					throw err;
+
+				}
+
+			} );
+			data.reject( new DelayQueueItemRemovedError() );
+			items.splice( index, 1 );
+
+		}
+
+	}
+
+	_scheduleTimeout( force = false ) {
+
+		if ( force && this.timeoutId !== null ) {
+
+			clearTimeout( this.timeoutId );
+			this.timeoutId = null;
+
+		}
+
+		if ( this.timeoutId !== null || this.items.length === 0 ) {
+
+			return;
+
+		}
+
+		const now = performance.now();
+		const firstItem = this.items[ 0 ];
+		const readyTime = firstItem.time + this.delay;
+		const remainingTime = Math.max( 0, readyTime - now );
+
+		this.timeoutId = setTimeout( () => {
+
+			this._processEntries();
+
+		}, remainingTime );
+
+	}
+
+	_processEntries() {
+
+		const now = performance.now();
+		const { items, delay } = this;
+
+		let toRemove = 0;
+		for ( let i = 0; i < items.length; i ++ ) {
+
+			const { item, callback, resolve, reject, time } = items[ i ];
+			const readyTime = time + delay;
+			if ( readyTime > now ) {
+
+				break;
+
+			}
+
+			toRemove ++;
+
+			let result;
+			try {
+
+				result = callback( item );
+
+			} catch ( err ) {
+
+				reject( err );
+				continue;
+
+			}
+
+			if ( result instanceof Promise ) {
+
+				result.then( resolve ).catch( reject );
+
+			} else {
+
+				resolve( result );
+
+			}
+
+		}
+
+		if ( toRemove > 0 ) {
+
+			items.splice( 0, toRemove );
+
+		}
+
+		this._scheduleTimeout();
+
+	}
+
+}

--- a/src/core/renderer/utilities/DelayQueue.js
+++ b/src/core/renderer/utilities/DelayQueue.js
@@ -118,6 +118,8 @@ export class DelayQueue {
 
 	_processEntries() {
 
+		this.timeoutId = null;
+
 		const now = performance.now();
 		const { items, delay, itemSet } = this;
 

--- a/src/core/renderer/utilities/DelayQueue.js
+++ b/src/core/renderer/utilities/DelayQueue.js
@@ -28,6 +28,7 @@ export class DelayQueue {
 
 		this._delay = 0;
 		this.items = [];
+		this.itemSet = new Set();
 		this.timeoutId = null;
 
 	}
@@ -48,6 +49,7 @@ export class DelayQueue {
 			data.reject = reject;
 
 			this.items.push( data );
+			this.itemSet.add( item );
 			this._scheduleTimeout();
 
 		} );
@@ -58,7 +60,13 @@ export class DelayQueue {
 
 	remove( item ) {
 
-		const { items } = this;
+		const { items, itemSet } = this;
+		if ( ! itemSet.has( item ) ) {
+
+			return;
+
+		}
+
 		const index = items.findIndex( data => data.item === item );
 		if ( index !== - 1 ) {
 
@@ -74,6 +82,7 @@ export class DelayQueue {
 			} );
 			data.reject( new DelayQueueItemRemovedError() );
 			items.splice( index, 1 );
+			this.itemSet.delete( item );
 
 		}
 
@@ -110,7 +119,7 @@ export class DelayQueue {
 	_processEntries() {
 
 		const now = performance.now();
-		const { items, delay } = this;
+		const { items, delay, itemSet } = this;
 
 		let toRemove = 0;
 		for ( let i = 0; i < items.length; i ++ ) {
@@ -124,6 +133,7 @@ export class DelayQueue {
 			}
 
 			toRemove ++;
+			itemSet.delete( item );
 
 			let result;
 			try {

--- a/src/core/renderer/utilities/DelayQueue.js
+++ b/src/core/renderer/utilities/DelayQueue.js
@@ -24,9 +24,15 @@ export class DelayQueue {
 
 	}
 
+	get running() {
+
+		return this.items.length > 0;
+
+	}
+
 	constructor() {
 
-		this._delay = 0;
+		this._delay = 500;
 		this.items = [];
 		this.itemSet = new Set();
 		this.timeoutId = null;

--- a/src/core/renderer/utilities/DelayQueue.js
+++ b/src/core/renderer/utilities/DelayQueue.js
@@ -82,7 +82,7 @@ export class DelayQueue {
 			} );
 			data.reject( new DelayQueueItemRemovedError() );
 			items.splice( index, 1 );
-			this.itemSet.delete( item );
+			itemSet.delete( item );
 
 		}
 

--- a/test/core/DelayQueue.test.js
+++ b/test/core/DelayQueue.test.js
@@ -1,0 +1,206 @@
+import { DelayQueue } from '../../src/core/renderer/utilities/DelayQueue.js';
+
+const wait = ms => new Promise( resolve => setTimeout( resolve, ms ) );
+
+describe( 'DelayQueue', () => {
+
+	it( 'should fire callback after the specified delay.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 50;
+
+		let called = false;
+		const item = { id: 1 };
+		queue.add( item, () => {
+
+			called = true;
+
+		} );
+
+		expect( called ).toBe( false );
+
+		await wait( 30 );
+		expect( called ).toBe( false );
+
+		await wait( 30 );
+		expect( called ).toBe( true );
+
+	} );
+
+	it( 'should process multiple items in order after their delays.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 50;
+
+		const results = [];
+		queue.add( { id: 1 }, item => results.push( item.id ) );
+		queue.add( { id: 2 }, item => results.push( item.id ) );
+		queue.add( { id: 3 }, item => results.push( item.id ) );
+
+		await wait( 60 );
+		expect( results ).toEqual( [ 1, 2, 3 ] );
+
+	} );
+
+	it( 'should batch process items added at different times.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 50;
+
+		const results = [];
+		queue.add( { id: 1 }, item => results.push( item.id ) );
+
+		await wait( 20 );
+		queue.add( { id: 2 }, item => results.push( item.id ) );
+
+		await wait( 40 );
+		expect( results ).toEqual( [ 1 ] );
+
+		await wait( 20 );
+		expect( results ).toEqual( [ 1, 2 ] );
+
+	} );
+
+	it( 'should return a promise that resolves with callback result.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 10;
+
+		const promise = queue.add( { id: 1 }, async () => {
+
+			await wait( 5 );
+			return 'success';
+
+		} );
+
+		const result = await promise;
+		expect( result ).toBe( 'success' );
+
+	} );
+
+	it( 'should remove items from the queue.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 50;
+
+		const results = [];
+		const item1 = { id: 1 };
+		const item2 = { id: 2 };
+		const item3 = { id: 3 };
+
+		queue.add( item1, item => results.push( item.id ) );
+		queue.add( item2, item => results.push( item.id ) );
+		queue.add( item3, item => results.push( item.id ) );
+
+		queue.remove( item2 );
+
+		await wait( 60 );
+		expect( results ).toEqual( [ 1, 3 ] );
+
+	} );
+
+	it( 'should reject promise when item is removed.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 50;
+
+		const item = { id: 1 };
+		let rejected = false;
+
+		const promise = queue.add( item, () => 'success' ).catch( () => {
+
+			rejected = true;
+
+		} );
+
+		queue.remove( item );
+
+		await promise;
+		expect( rejected ).toBe( true );
+
+	} );
+
+	it( 'should update delay retroactively.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 100;
+
+		let called = false;
+		queue.add( { id: 1 }, () => {
+
+			called = true;
+
+		} );
+
+		await wait( 30 );
+		queue.delay = 50;
+
+		await wait( 30 );
+		expect( called ).toBe( true );
+
+		// Test increasing delay
+		queue.delay = 50;
+		called = false;
+		queue.add( { id: 2 }, () => {
+
+			called = true;
+
+		} );
+
+		await wait( 30 );
+		queue.delay = 100;
+
+		await wait( 30 );
+		expect( called ).toBe( false );
+
+		await wait( 50 );
+		expect( called ).toBe( true );
+
+	} );
+
+	it( 'should handle errors in callbacks.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 10;
+
+		let rejected = false;
+		let rejectedMessage = null;
+		const promise = queue.add( { id: 1 }, () => {
+
+			throw new Error( 'test error' );
+
+		} ).catch( err => {
+
+			rejected = true;
+			rejectedMessage = err.message;
+
+		} );
+
+		await promise;
+		expect( rejected ).toBe( true );
+		expect( rejectedMessage ).toBe( 'test error' );
+
+	} );
+
+	it( 'should continue processing after an error.', async () => {
+
+		const queue = new DelayQueue();
+		queue.delay = 10;
+
+		const results = [];
+
+		queue.add( { id: 1 }, () => {
+
+			throw new Error( 'error' );
+
+		} ).catch( () => {} );
+
+		queue.add( { id: 2 }, item => results.push( item.id ) );
+		queue.add( { id: 3 }, item => results.push( item.id ) );
+
+		await wait( 20 );
+		expect( results ).toEqual( [ 2, 3 ] );
+
+	} );
+
+} );


### PR DESCRIPTION
Fix #1423

An experiment for delaying tile downloads to prevent downloads of unneeded data especially while the camera is moving. This can add some arbitrary delays during a still camera, though, such as when internal tile sets are downloaded, causing new child tiles to suddenly be available and incurring a new delay. This may not be the best way to introduce a delay into tile downloads

**TODO**
- Docs