### PR TITLE
Fix TilesRenderer options types

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.d.ts
+++ b/src/core/renderer/tiles/TilesRendererBase.d.ts
@@ -12,8 +12,8 @@ export class TilesRendererBase {
 	errorThreshold : number;
 	displayActiveTiles : boolean;
 	maxDepth : number;
-	loadSiblings : number;
-	optimizedLoadStrategy : number;
+	loadSiblings : boolean;
+	optimizedLoadStrategy : boolean;
 
 	loadProgress: number;
 


### PR DESCRIPTION
Change type of `optimizedLoadStrategy` and `loadSiblings` from number to boolean