### PR TITLE
Add double-tap zoom for Environment Controls

### DIFF
--- a/src/three/renderer/controls/EnvironmentControls.d.ts
+++ b/src/three/renderer/controls/EnvironmentControls.d.ts
@@ -30,6 +30,9 @@ export class EnvironmentControls extends EventDispatcher<EnvironmentControlsEven
 	adjustHeight: boolean;
 	enableDamping: boolean;
 	dampingFactor: number;
+	enableDoubleTapZoom: boolean;
+	doubleTapZoomScale: number;
+	doubleTapAnimationDuration: number;
 	useFallbackPlane: boolean;
 
 	fallbackPlane: Plane;


### PR DESCRIPTION
#973

Implements double-tap to zoom functionality for EnvironmentControls, inspired by Google Maps and other modern mapping platforms. This adds an intuitive touch gesture for zooming in on mobile and tablet devices.

@gkjohnson the animation is in `_updateDoubleTapAnimation`


**Complete Implementation**
1. Configuration Options ([EnvironmentControls.js:107-109](src/three/renderer/controls/EnvironmentControls.js))

```
this.enableDoubleTapZoom = true;           // Enable/disable feature
this.doubleTapZoomScale = 2.0;             // 2x zoom multiplier
this.doubleTapAnimationDuration = 0.3;     // 300ms animation
```
2. State Management ([EnvironmentControls.js:133-136](src/three/renderer/controls/EnvironmentControls.js))

```
this._lastTapTime = 0;
this._lastTapPoint = new Vector2();
this._doubleTapAnim = null;  // Single object for animation state
```
3. Tap Detection ([EnvironmentControls.js:442-450](src/three/renderer/controls/EnvironmentControls.js))
```
Added in pointerupCallback
Detects single-finger touch taps
Calls _detectDoubleTap() before pointer cleanup

```
4. Three Private Methods ([EnvironmentControls.js:1141-1244](src/three/renderer/controls/EnvironmentControls.js))
```
_detectDoubleTap() - 300ms window, 10px tolerance
_startDoubleTapZoom() - Raycasts to find target, sets up animation
_updateDoubleTapAnimation() - Ease-out cubic interpolation
```
5. Update Loop Integration ([EnvironmentControls.js:713-747](src/three/renderer/controls/EnvironmentControls.js))
```
Calls _updateDoubleTapAnimation() every frame
Blocks normal zoom/drag/rotate during animation
Dispatches change events
```
