### PR TITLE
fix: ensure all children are preprocessed

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -792,7 +792,7 @@ export class TilesRendererBase {
 			if ( '__depth' in child ) {
 
 				// the child has already been processed
-				break;
+				continue;
 
 			} else if ( immediate ) {
 


### PR DESCRIPTION
Related issue found here: https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/1441