### PR TITLE
TilesRendererBase: Early out of the child processing

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -810,6 +810,12 @@ export class TilesRendererBase {
 	ensureChildrenArePreprocessed( tile, immediate = false ) {
 
 		const children = tile.children;
+		if ( tile.__childrenProcessed === children.length ) {
+
+			return;
+
+		}
+
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
 			const child = children[ i ];

--- a/src/three/plugins/DebugTilesPlugin.js
+++ b/src/three/plugins/DebugTilesPlugin.js
@@ -911,21 +911,21 @@ export class DebugTilesPlugin {
 	_onDisposeModel( tile ) {
 
 		const cached = tile.cached;
-		if ( cached.boxHelperGroup ) {
+		if ( cached?.boxHelperGroup ) {
 
 			cached.boxHelperGroup.children[ 0 ].geometry.dispose();
 			delete cached.boxHelperGroup;
 
 		}
 
-		if ( cached.sphereHelper ) {
+		if ( cached?.sphereHelper ) {
 
 			cached.sphereHelper.geometry.dispose();
 			delete cached.sphereHelper;
 
 		}
 
-		if ( cached.regionHelper ) {
+		if ( cached?.regionHelper ) {
 
 			cached.regionHelper.geometry.dispose();
 			delete cached.regionHelper;
@@ -958,7 +958,7 @@ export class DebugTilesPlugin {
 
 			this._onDisposeModel( tile );
 
-		} );
+		}, null, false );
 
 		this.boxGroup?.removeFromParent();
 		this.sphereGroup?.removeFromParent();


### PR DESCRIPTION
Related to #1442
Fix #1441 

- Early out of child processing if they are already all processed
- Remove immediate processing of children in DebugTilesPlugin disposal / enable toggle
- Make DebugTilesPlugin model disposal robust to unprocessed tiles

cc @Jordan-Lane 