### PR TITLE
TilingScheme: Add support for variable tiles splitting

### DIFF
--- a/src/three/plugins/DebugTilesPlugin.js
+++ b/src/three/plugins/DebugTilesPlugin.js
@@ -223,6 +223,12 @@ export class DebugTilesPlugin {
 
 		this.tiles = tiles;
 
+		if ( ! this.enabled ) {
+
+			return;
+
+		}
+
 		// initialize groups
 		const tilesGroup = tiles.group;
 		this.boxGroup = new Group();

--- a/src/three/plugins/images/ImageFormatPlugin.js
+++ b/src/three/plugins/images/ImageFormatPlugin.js
@@ -316,11 +316,12 @@ export class ImageFormatPlugin {
 		const x = tile[ TILE_X ];
 		const y = tile[ TILE_Y ];
 
-		for ( let cx = 0; cx < 2; cx ++ ) {
+		const { tileSplitX, tileSplitY } = this.tiling.getLevel( level );
+		for ( let cx = 0; cx < tileSplitX; cx ++ ) {
 
-			for ( let cy = 0; cy < 2; cy ++ ) {
+			for ( let cy = 0; cy < tileSplitY; cy ++ ) {
 
-				const child = this.createChild( 2 * x + cx, 2 * y + cy, level + 1 );
+				const child = this.createChild( tileSplitX * x + cx, tileSplitY * y + cy, level + 1 );
 				if ( child ) {
 
 					tile.children.push( child );

--- a/src/three/plugins/images/utils/TilingScheme.js
+++ b/src/three/plugins/images/utils/TilingScheme.js
@@ -86,10 +86,15 @@ export class TilingScheme {
 		}
 
 		const {
+			tileSplitX = 2,
+			tileSplitY = 2,
+		} = options;
+
+		const {
 			tilePixelWidth = 256,
 			tilePixelHeight = 256,
-			tileCountX = 2 ** level,
-			tileCountY = 2 ** level,
+			tileCountX = tileSplitX ** level,
+			tileCountY = tileSplitY ** level,
 			tileBounds = null,
 		} = options;
 
@@ -111,6 +116,10 @@ export class TilingScheme {
 			// Or the total number of tiles that can be loaded at this level.
 			tileCountX,
 			tileCountY,
+
+			// The number of tiles that the tiles at this layer split in to
+			tileSplitX,
+			tileSplitY,
 
 			// The bounds covered by the extent of the tiles at this loaded. The actual content covered by the overall tileset
 			// may be a subset of this range (eg there may be unused space).


### PR DESCRIPTION
- Add support for variable tile splitting (variable number of children per child layer)
- Fix DebugTilesPlugin not respecting an initial "enabled" flag

**TODO**
- Consider how this kind of variable tiling can be specified at the user level
  - Possibly a custom-tiled image source? Or allow more flexible parameters to XYZImageSource?

Required for loading [this data set](https://x.com/garrettkjohnson/status/2012056975115501623) which contains a variable number of splits per tile, stored in child kml tiles:

```js
// modifications made to XYZImageSource
tiling.setProjection( new ProjectionScheme( 'EPSG:4326' ) );
tiling.setContentBounds( ...tiling.projection.getBounds() );
tiling.setLevel( 1, {
	tileCountX: 4,
	tileCountY: 2,
	tileSplitX: 3,
	tileSplitY: 3,
} );

tiling.setLevel( 2, {
	tileCountX: 4 * 3,
	tileCountY: 2 * 3,
	tileSplitX: 3,
	tileSplitY: 3,
} );

tiling.setLevel( 3, {
	tileCountX: 4 * 3 * 3,
	tileCountY: 2 * 3 * 3,
	tileSplitX: 5,
	tileSplitY: 5,
} );

tiling.setLevel( 4, {
	tileCountX: 4 * 3 * 3 * 5,
	tileCountY: 2 * 3 * 3 * 5,
	tileSplitX: 2,
	tileSplitY: 2,
} );

tiling.setLevel( 5, {
	tileCountX: 4 * 3 * 3 * 5 * 2,
	tileCountY: 2 * 3 * 3 * 5 * 2,
	tileSplitX: 2,
	tileSplitY: 2,
} );

tiling.setLevel( 6, {
	tileCountX: 4 * 3 * 3 * 5 * 2 * 2,
	tileCountY: 2 * 3 * 3 * 5 * 2 * 2,
	tileSplitX: 2,
	tileSplitY: 2,
} );
```