### PR TITLE
Fix loadSiblings oscillation

### DIFF
--- a/src/core/renderer/tiles/optimizedTraverseFunctions.js
+++ b/src/core/renderer/tiles/optimizedTraverseFunctions.js
@@ -241,6 +241,8 @@ function markUsedTiles( tile, renderer ) {
 	if ( tile.refine === 'REPLACE' && ! anyChildrenInFrustum && children.length !== 0 ) {
 
 		tile.traversal.inFrustum = false;
+
+		renderer.markTileUsed( tile );
 		for ( let i = 0, l = children.length; i < l; i ++ ) {
 
 			recursivelyMarkUsed( children[ i ], renderer, true );


### PR DESCRIPTION
Fix #1450 

Ensure the tile that is marked as "not in frustum" is also marked as used in the cache so it does not unload