### PR TITLE
Babylon Support: Store parsed JSON in metadata field so we can access asset.copyright

### DIFF
--- a/src/babylonjs/renderer/loaders/B3DMLoader.js
+++ b/src/babylonjs/renderer/loaders/B3DMLoader.js
@@ -35,6 +35,7 @@ export class B3DMLoader extends B3DMLoaderBase {
 			...b3dm,
 			scene: gltfScene,
 			container: result.container,
+			metadata: result.metadata,
 		};
 
 	}

--- a/src/babylonjs/renderer/loaders/GLTFLoader.js
+++ b/src/babylonjs/renderer/loaders/GLTFLoader.js
@@ -29,10 +29,24 @@ export class GLTFLoader extends LoaderBase {
 
 		// load the file
 		const pluginExtension = extension === 'gltf' ? '.gltf' : '.glb';
+		let metadata = null;
 		const container = await ImportMeshAsync(
 			new File( [ buffer ], uri ),
 			scene,
-			{ pluginExtension, rootUrl }
+			{
+				pluginExtension,
+				rootUrl,
+				pluginOptions: {
+					'gltf': {
+						onParsed: ( loaderData ) => {
+
+							// loaderData.json contains the full glTF JSON
+							metadata = loaderData.json;
+
+						}
+					}
+				}
+			}
 		);
 
 		// retrieve the primary scene
@@ -49,6 +63,7 @@ export class GLTFLoader extends LoaderBase {
 		return {
 			scene: root,
 			container,
+			metadata,
 		};
 
 	}

--- a/src/babylonjs/renderer/tiles/TilesRenderer.js
+++ b/src/babylonjs/renderer/tiles/TilesRenderer.js
@@ -197,6 +197,7 @@ export class TilesRenderer extends TilesRendererBase {
 
 		engineData.group = group;
 		engineData.container = result.container;
+		engineData.metadata = result.metadata || null;
 
 	}
 
@@ -210,6 +211,7 @@ export class TilesRenderer extends TilesRendererBase {
 			engineData.container.dispose();
 			engineData.container = null;
 			engineData.group = null;
+			engineData.metadata = null;
 
 		}
 


### PR DESCRIPTION
Store the parsed JSON so that tile renderer has access to.metadata.asset.copyright so that we can properly attribute tiles