### PR TITLE
EnvironmentControls: Support rendering pivotMesh in custom scene

### DIFF
--- a/src/three/renderer/controls/EnvironmentControls.js
+++ b/src/three/renderer/controls/EnvironmentControls.js
@@ -390,23 +390,23 @@ export class EnvironmentControls extends EventDispatcher {
 					pointerTracker.isLeftClicked() && e.shiftKey
 				) {
 
-					this.setState( pointerTracker.isPointerTouch() ? WAITING : ROTATE );
-
 					pivotPoint.copy( hit.point );
 					pivotMesh.position.copy( hit.point );
 					pivotMesh.visible = pointerTracker.isPointerTouch() ? false : enabled;
 					pivotMesh.updateMatrixWorld();
 					scene.add( pivotMesh );
 
+					this.setState( pointerTracker.isPointerTouch() ? WAITING : ROTATE );
+
 				} else if ( pointerTracker.isLeftClicked() ) {
 
-					// if the clicked point is coming from below the plane then don't perform the drag
-					this.setState( DRAG );
 					pivotPoint.copy( hit.point );
-
 					pivotMesh.position.copy( hit.point );
 					pivotMesh.updateMatrixWorld();
 					scene.add( pivotMesh );
+
+					// if the clicked point is coming from below the plane then don't perform the drag
+					this.setState( DRAG );
 
 				}
 


### PR DESCRIPTION
This PR adds a separate scene property for the pivot mesh in `EnvironmentControls`.

In fancy render pipelines with post-processing effects, there are many cases where the pivot mesh should be excluded from the main scene pass and blended after the effects are applied. For example, tone mapping exposure changes the brightness of the pivot circle, anti-aliasing blurs it, and depth-dependent effects reveal its rectangular bounds if it is rendered in the buffer where effects are applied. Having a property to keep the pivot mesh in a separate scene provides a way to address it on the user side (there _is_ [a way to do it](https://github.com/takram-design-engineering/three-geospatial/blob/6431ef4b245bfb21861bb42a58ca495fccef6924/storybook-webgpu/src/components/GlobeControls.tsx#L28) but it ends up being quite hacky).

An alternative approach would be to change its visibility instead of adding/removing it, then let users decide where it should live, similar to `TilesRenderer.group`.

(Or perhaps `Layers` could be used instead of this PR, though I have not tried yet.)