### PR TITLE
Ellipsoid: fix normal not calculated at surface point in getPositionToCartographic

### DIFF
--- a/src/three/renderer/math/Ellipsoid.js
+++ b/src/three/renderer/math/Ellipsoid.js
@@ -353,7 +353,7 @@ export class Ellipsoid {
 		// From Cesium function Ellipsoid.cartesianToCartographic
 		// https://github.com/CesiumGS/cesium/blob/665ec32e813d5d6fe906ec3e87187f6c38ed5e49/packages/engine/Source/core/renderer/Ellipsoid.js#L463
 		this.getPositionToSurfacePoint( pos, _vec );
-		this.getPositionToNormal( pos, _norm );
+		this.getPositionToNormal( _vec, _norm );
 
 		const heightDelta = _vec2.subVectors( pos, _vec );
 

--- a/test/three/Ellipsoid.test.js
+++ b/test/three/Ellipsoid.test.js
@@ -178,6 +178,30 @@ describe( 'Ellipsoid', () => {
 
 	} );
 
+	it( 'should match Cesium Cartesian to Cartographic results.', () => {
+
+		const HEIGHT_EPSILON = 1e-5;
+		const LAT_LON_EPSILON = 1e-7;
+		const LAT = 40;
+		const LON = - 75;
+		const HEIGHT = 5000;
+		const cart = new Cesium.Cartographic( LON, LAT, HEIGHT );
+
+		c_wgsEllipse.cartographicToCartesian( cart, c );
+		v.set( c.x, c.y, c.z );
+
+		const cesiumResult = new Cesium.Cartographic();
+		c_wgsEllipse.cartesianToCartographic( c, cesiumResult );
+
+		const result = {};
+		wgsEllipse.getPositionToCartographic( v, result );
+
+		compareCoord( result.lon, cesiumResult.longitude, LAT_LON_EPSILON );
+		compareCoord( result.lat, cesiumResult.latitude, LAT_LON_EPSILON );
+		compareCoord( result.height, cesiumResult.height, HEIGHT_EPSILON );
+
+	} );
+
 	it( 'should match the expected elevation.', () => {
 
 		//ellipsoid rotation


### PR DESCRIPTION
As explained in #1531, fixes the latitudinal inaccuracy of `getPositionToCartographic` by calculating the surface normal at the surface-projected position instead of the input position.

I also added a regression test that compares the results of `getPositionToCartographic` with the Cesium counterpart at a known coordinate.