### PR TITLE
Export ImageOverlay and TiledImageOverlay

### DIFF
--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1276,7 +1276,7 @@ export class ImageOverlayPlugin {
  * @param {boolean} [options.alphaInvert=false] If true, inverts the alpha channel before
  * applying the mask or blend.
  */
-class ImageOverlay {
+export class ImageOverlay {
 
 	get isPlanarProjection() {
 
@@ -1389,7 +1389,7 @@ class ImageOverlay {
  * multiple source tiles into a single texture per 3D tile region.
  * @extends ImageOverlay
  */
-class TiledImageOverlay extends ImageOverlay {
+export class TiledImageOverlay extends ImageOverlay {
 
 	get tiling() {
 


### PR DESCRIPTION
This is a proposal to export `ImageOverlay` and `TiledImageOverlay` classes so that library users can override them.