### PR TITLE
Docs: Add community plugins to README

### DIFF
--- a/src/three/plugins/README.md
+++ b/src/three/plugins/README.md
@@ -8,11 +8,15 @@ See the [API reference](./API.md) for full class and method documentation.
 
 #### [3D-Tiles-RendererJS-3DGS-Plugin](https://github.com/WilliamLiu-1997/3D-Tiles-RendererJS-3DGS-Plugin)
 
-Plugin for rendering gaussian-splat-embeded glTF tile sets.
+Plugin to render gaussian-splat-embeded glTF tile sets.
 
 #### [3dtilesrenderer-styling-plugin](https://github.com/bertt/3dtilesrenderer-styling-plugin)
 
-Plugin for adding Cesium 3D Tiles Styling specification support.
+Plugin to add Cesium 3D Tiles Styling specification support.
+
+#### [3dtilesrenderer-outline-plugin](https://github.com/bertt/3dtilesrenderer-outline-plugin)
+
+Plugin to add support for `CESIUM_primitive_outline` glTF extension.
 
 # Use
 

--- a/src/three/plugins/README.md
+++ b/src/three/plugins/README.md
@@ -4,6 +4,16 @@ Plugins and extensions for the 3D Tiles renderer.
 
 See the [API reference](./API.md) for full class and method documentation.
 
+# Community Plugins
+
+#### [3D-Tiles-RendererJS-3DGS-Plugin](https://github.com/WilliamLiu-1997/3D-Tiles-RendererJS-3DGS-Plugin)
+
+Plugin for rendering gaussian-splat-embeded glTF tile sets.
+
+#### [3dtilesrenderer-styling-plugin](https://github.com/bertt/3dtilesrenderer-styling-plugin)
+
+Plugin for adding Cesium 3D Tiles Styling specification support.
+
 # Use
 
 ## GLTF Plugins


### PR DESCRIPTION
Added community plugins section with links and descriptions to three/plugins/README.md.

cc @WilliamLiu-1997 @bertt - I've added a new list of "Community Plugins" and included both of your projects for gaussian splats and the styling spec.

cc @jo-chemla @dbuck @AnthonyGlt @sguimmara @shotamatsuda in case you guys are aware of any other plugins that might be good to include in this list.