### PR TITLE
TilesRenderer: deprecate "optimizedLoadStrategy"

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -385,6 +385,29 @@ export class TilesRendererBase {
 	}
 
 	/**
+	 * Enables an optimized tile loading strategy that loads only the tiles
+	 * needed for the current view, reducing memory usage and improving initial load times.
+	 * Tiles are loaded independently based on screen-space error without requiring all parent
+	 * tiles to load first. Prevents visual gaps and flashing during camera movement.
+	 *
+	 * Based in part on {@link https://cesium.com/learn/cesium-native/ref-doc/selection-algorithm-details.html Cesium Native tile selection}.
+	 * @type {boolean}
+	 * @default true
+	 */
+	get optimizedLoadStrategy() {
+
+		return this._optimizedLoadStrategy;
+
+	}
+
+	set optimizedLoadStrategy( v ) {
+
+		console.warn( 'TilesRenderer: "optimizedLoadStrategy" has been deprecated. Please toggle "loadAncestors" to adjust the tile load behavior.' );
+		this._optimizedLoadStrategy = v;
+
+	}
+
+	/**
 	 * @param {string} [url] - URL of the root tileset JSON to load.
 	 */
 	constructor( url = null ) {
@@ -568,21 +591,7 @@ export class TilesRendererBase {
 		 */
 		this.maxDepth = Infinity;
 
-		/**
-		 * **Experimental.** Enables an optimized tile loading strategy that loads only the tiles
-		 * needed for the current view, reducing memory usage and improving initial load times.
-		 * Tiles are loaded independently based on screen-space error without requiring all parent
-		 * tiles to load first. Prevents visual gaps and flashing during camera movement.
-		 *
-		 * Based in part on {@link https://cesium.com/learn/cesium-native/ref-doc/selection-algorithm-details.html Cesium Native tile selection}.
-		 * @warn Setting is currently incompatible with plugins that split tiles and on-the-fly generate and
-		 * dispose of child tiles including the `ImageOverlayPlugin` `enableTileSplitting` setting,
-		 * `QuantizedMeshPlugin`, & `ImageFormatPlugin` subclasses (XYZ, TMS, etc). Any tile sets
-		 * that share caches or queues must also use the same setting.
-		 * @type {boolean}
-		 * @default false
-		 */
-		this.optimizedLoadStrategy = false;
+		this._optimizedLoadStrategy = true;
 
 		/**
 		 * **Experimental.** When `true`, sibling tiles are loaded together to prevent gaps during
@@ -606,7 +615,7 @@ export class TilesRendererBase {
 		 * @type {boolean}
 		 * @default false
 		 */
-		this.loadAncestors = false;
+		this.loadAncestors = true;
 
 		/**
 		 * The number of tiles to process immediately when traversing the tile set to determine

--- a/src/three/plugins/images/GeneratedSurfacePlugin.js
+++ b/src/three/plugins/images/GeneratedSurfacePlugin.js
@@ -93,7 +93,6 @@ export class GeneratedSurfacePlugin {
 
 		}
 
-		const { overlay } = this;
 		let res;
 		if ( this._useEllipsoid() ) {
 
@@ -102,37 +101,6 @@ export class GeneratedSurfacePlugin {
 		} else {
 
 			res = this._createPlanarMesh( tile );
-
-		}
-
-		if ( overlay ) {
-
-			const x = tile[ TILE_X ];
-			const y = tile[ TILE_Y ];
-			const level = tile[ TILE_LEVEL ];
-			const range = this._tiling.getTileBounds( x, y, level, true, false );
-
-			if ( overlay.hasContent( range, level ) ) {
-
-				await overlay.lockTexture( range, level );
-
-				const texture = overlay.getTexture( range, level );
-				tile.overlayRange = range;
-				tile.overlayLevel = level;
-
-				if ( abortSignal.aborted ) {
-
-					overlay.releaseTexture( range, level );
-					tile.overlayRange = null;
-					tile.overlayLevel = null;
-					return null;
-
-				}
-
-				res.material.map = texture;
-				res.material.needsUpdate = true;
-
-			}
 
 		}
 
@@ -148,19 +116,6 @@ export class GeneratedSurfacePlugin {
 		if ( level < maxLevel && tile.parent !== null ) {
 
 			this.expandChildren( tile );
-
-		}
-
-	}
-
-	disposeTile( tile ) {
-
-		const { overlayRange, overlayLevel } = tile;
-		if ( this.overlay && overlayRange ) {
-
-			this.overlay.releaseTexture( overlayRange, overlayLevel );
-			tile.overlayRange = null;
-			tile.overlayLevel = null;
 
 		}
 


### PR DESCRIPTION
Fix #1426 

**TODO**
- ~Consider removing "GeneratedSurfacePlugin" texture overlays~
- Fix MVT case with tile splitting (limit surface gen depth to 3)