### PR TITLE
TilesRenderer: Deprecate events, fix some naming

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.d.ts
+++ b/src/core/renderer/tiles/TilesRendererBase.d.ts
@@ -6,6 +6,7 @@ import { Tileset } from './Tileset.js';
 // Events dispatched by TilesRendererBase, available across all renderer implementations.
 export interface TilesRendererBaseEventMap<TScene = unknown> {
 	'needs-update': {};
+	/** @deprecated */
 	'load-content': {};
 	'load-tileset': { tileset : Tileset, /* @deprecated Use tileset instead */ tileSet? : Tileset, url : string };
 	/* @deprecated Use 'load-tileset' instead */

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -252,11 +252,6 @@ const unifiedPriorityCallback = ( a, b ) => {
  */
 
 /**
- * Fired when any tile content (model or external tileset) finishes loading.
- * @event TilesRendererBase#load-content
- */
-
-/**
  * Fired when any tileset JSON finishes loading.
  * @event TilesRendererBase#load-tileset
  * @property {Tileset} tileset - The loaded tileset object.
@@ -835,7 +830,6 @@ export class TilesRendererBase {
 					this.rootLoadingState = LOADED;
 					this.rootTileset = root;
 					this.dispatchEvent( { type: 'needs-update' } );
-					this.dispatchEvent( { type: 'load-content' } );
 					this.dispatchEvent( {
 						type: 'load-tileset',
 						tileset: root,
@@ -1800,7 +1794,6 @@ export class TilesRendererBase {
 				// dispatch an event indicating that this model has completed and that a new
 				// call to "update" is needed.
 				this.dispatchEvent( { type: 'needs-update' } );
-				this.dispatchEvent( { type: 'load-content' } );
 				if ( isExternalTileset ) {
 
 					this.dispatchEvent( {

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -252,6 +252,12 @@ const unifiedPriorityCallback = ( a, b ) => {
  */
 
 /**
+ * Fired when any tile content (model or external tileset) finishes loading.
+ * @deprecated
+ * @event TilesRendererBase#load-content
+ */
+
+/**
  * Fired when any tileset JSON finishes loading.
  * @event TilesRendererBase#load-tileset
  * @property {Tileset} tileset - The loaded tileset object.
@@ -830,6 +836,7 @@ export class TilesRendererBase {
 					this.rootLoadingState = LOADED;
 					this.rootTileset = root;
 					this.dispatchEvent( { type: 'needs-update' } );
+					this.dispatchEvent( { type: 'load-content' } ); // @deprecated
 					this.dispatchEvent( {
 						type: 'load-tileset',
 						tileset: root,
@@ -1794,6 +1801,7 @@ export class TilesRendererBase {
 				// dispatch an event indicating that this model has completed and that a new
 				// call to "update" is needed.
 				this.dispatchEvent( { type: 'needs-update' } );
+				this.dispatchEvent( { type: 'load-content' } ); // @deprecated
 				if ( isExternalTileset ) {
 
 					this.dispatchEvent( {

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -204,7 +204,7 @@ export class ImageOverlayPlugin {
 				this.resetVirtualChildren( ! this.enableTileSplitting );
 				tiles.recalculateBytesUsed();
 
-				tiles.dispatchEvent( { type: 'needs-rerender' } );
+				tiles.dispatchEvent( { type: 'needs-render' } );
 
 			}
 

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1191,7 +1191,7 @@ export class ImageOverlayPlugin {
 				}
 
 				info.failed = true;
-				tiles.dispatchEvent( { type: 'load-error', tile, overlay, error: err } );
+				tiles.dispatchEvent( { type: 'load-error', tile, overlay, error: err, url: null } );
 				return null;
 
 			} );

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -146,6 +146,10 @@ export class TilesRenderer extends TilesRendererBase {
 			console.warn( 'TilesRenderer: "load-tile-set" event has been deprecated. Use "load-tileset" instead.' );
 			type = 'load-tileset';
 
+		} else if ( type === 'load-content' ) {
+
+			console.warn( 'TilesRenderer: "load-content" event has been deprecated. Use "load-model" or "load-tileset" instead.' );
+
 		}
 
 		EventDispatcher.prototype.addEventListener.call( this, type, listener );
@@ -158,6 +162,10 @@ export class TilesRenderer extends TilesRendererBase {
 
 			console.warn( 'TilesRenderer: "load-tile-set" event has been deprecated. Use "load-tileset" instead.' );
 			type = 'load-tileset';
+
+		} else if ( type === 'load-content' ) {
+
+			console.warn( 'TilesRenderer: "load-content" event has been deprecated. Use "load-model" or "load-tileset" instead.' );
 
 		}
 

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -180,6 +180,10 @@ export class TilesRenderer extends TilesRendererBase {
 			console.warn( 'TilesRenderer: "load-tile-set" event has been deprecated. Use "load-tileset" instead.' );
 			type = 'load-tileset';
 
+		} else if ( type === 'load-content' ) {
+
+			console.warn( 'TilesRenderer: "load-content" event has been deprecated. Use "load-model" or "load-tileset" instead.' );
+
 		}
 
 		EventDispatcher.prototype.removeEventListener.call( this, type, listener );

--- a/test/three/TilesRenderer.test.ts
+++ b/test/three/TilesRenderer.test.ts
@@ -33,7 +33,6 @@ function typecheck( renderer: TilesRenderer ) {
 	renderer.addEventListener( 'load-tileset', loadTileset );
 	renderer.addEventListener( 'tiles-load-start', emptyEvent );
 	renderer.addEventListener( 'tiles-load-end', emptyEvent );
-	renderer.addEventListener( 'load-content', emptyEvent );
 	renderer.addEventListener( 'load-model', loadModel );
 	renderer.addEventListener( 'dispose-model', disposeModel );
 	renderer.addEventListener( 'tile-visibility-change', tileVisibilityChange );


### PR DESCRIPTION
Related to #1405 

- Deprecate "load-content" event
- Rename "needs-rerender" event to "needs-render"