### PR TITLE
DebugTilesPlugin: Add support for displaying empty tiles bounds

### DIFF
--- a/src/core/renderer/tiles/optimizedTraverseFunctions.js
+++ b/src/core/renderer/tiles/optimizedTraverseFunctions.js
@@ -548,6 +548,17 @@ function toggleTiles( tile, renderer ) {
 
 			}
 
+		} else {
+
+			// For non-renderable tiles, notify plugins when the tile becomes or stops being a traversal leaf so we
+			// can display "empty" tiles in plugins like the DebugTilesPlugin.
+			setVisible = tile.traversal.isLeaf;
+			if ( tile.traversal.wasSetVisible !== setVisible ) {
+
+				renderer.invokeOnePlugin( plugin => plugin.setEmptyTileVisible && plugin.setEmptyTileVisible( tile, setVisible ) );
+
+			}
+
 		}
 
 		tile.traversal.wasSetActive = setActive;

--- a/src/core/renderer/tiles/optimizedTraverseFunctions.js
+++ b/src/core/renderer/tiles/optimizedTraverseFunctions.js
@@ -463,10 +463,6 @@ function toggleTiles( tile, renderer ) {
 
 			}
 
-		} else {
-
-			tile.traversal.active = false;
-
 		}
 
 		// when loading parent tiles as fallbacks, keep all used tiles downloaded

--- a/src/three/plugins/DebugTilesPlugin.js
+++ b/src/three/plugins/DebugTilesPlugin.js
@@ -393,6 +393,12 @@ export class DebugTilesPlugin {
 
 	}
 
+	setEmptyTileVisible( tile, visible ) {
+
+		this._onTileVisibilityChange( tile, visible );
+
+	}
+
 	_initExtremes() {
 
 		if ( ! ( this.tiles && this.tiles.root ) ) {


### PR DESCRIPTION
Supersedes #1524
Fix https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/1451

- Adds a "setEmptyTileVisible" plugin function specifically so DebugTilesPlugin can display the empty leaf tiles during traversal.
- Legacy traversal is untouched since it will be removed.