### PR TITLE
Fix tiles fade with displayActiveTiles 

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -1189,6 +1189,7 @@ export class TilesRendererBase {
 			distanceFromCamera: Infinity,
 			error: Infinity,
 			inFrustum: false,
+			wasInFrustum: false,
 			isLeaf: false,
 			used: false,
 			usedLastFrame: false,

--- a/src/core/renderer/tiles/traverseFunctions.js
+++ b/src/core/renderer/tiles/traverseFunctions.js
@@ -442,20 +442,27 @@ function toggleTiles( tile, renderer ) {
 	const isUsed = isUsedThisFrame( tile, renderer.frameCount );
 	if ( isUsed ) {
 
-		// any internal tileset and additive tile must be marked as active and loaded
-		if ( tile.internal.hasUnrenderableContent || ( tile.internal.hasRenderableContent && tile.refine === 'ADD' ) ) {
+		// any internal tileset loaded and marked as being used so we don't unload them
+		if ( tile.internal.hasUnrenderableContent ) {
+
+			renderer.markTileUsed( tile );
+			renderer.queueTileForDownload( tile );
+
+		}
+
+		// ADD tiles are part of the display frontier alongside their children
+		if ( tile.internal.hasRenderableContent && tile.refine === 'ADD' ) {
 
 			tile.traversal.active = true;
 
 		}
 
 		// queue any tiles to load that we need to, and unmark any unloaded or non visible tiles as "active"
-		// TODO: it may be more simple to track a separate variable than "active" here
 		if ( ( tile.traversal.active || tile.traversal.kicked ) && tile.internal.hasContent ) {
 
 			renderer.markTileUsed( tile );
 
-			if ( tile.internal.hasUnrenderableContent || tile.traversal.allUsedChildrenProcessed ) {
+			if ( tile.traversal.allUsedChildrenProcessed ) {
 
 				renderer.queueTileForDownload( tile );
 

--- a/src/core/renderer/tiles/traverseFunctions.js
+++ b/src/core/renderer/tiles/traverseFunctions.js
@@ -52,6 +52,10 @@ function resetFrameState( tile, renderer ) {
 
 	if ( tile.traversal.lastFrameVisited !== renderer.frameCount ) {
 
+		tile.traversal.wasInFrustum = tile.traversal.inFrustum;
+		tile.traversal.wasSetActive = tile.traversal.active;
+		tile.traversal.wasSetVisible = tile.traversal.visible;
+		tile.traversal.usedLastFrame = tile.traversal.used;
 		tile.traversal.lastFrameVisited = renderer.frameCount;
 		tile.traversal.used = false;
 		tile.traversal.inFrustum = false;
@@ -560,11 +564,6 @@ function toggleTiles( tile, renderer ) {
 			}
 
 		}
-
-		// save the current status for the next frame
-		tile.traversal.wasSetActive = setActive;
-		tile.traversal.wasSetVisible = setVisible;
-		tile.traversal.usedLastFrame = isUsed;
 
 		// TODO: clean this up since "traversal.active" and "traversal.visible" fields are
 		// overloaded and overused above.

--- a/src/three/plugins/fade/TilesFadePlugin.js
+++ b/src/three/plugins/fade/TilesFadePlugin.js
@@ -178,7 +178,7 @@ export class TilesFadePlugin {
 
 		options = {
 
-			maximumFadeOutTiles: Infinity,
+			maximumFadeOutTiles: 50,
 			fadeRootTiles: false,
 			fadeDuration: 250,
 			...options,

--- a/src/three/plugins/fade/TilesFadePlugin.js
+++ b/src/three/plugins/fade/TilesFadePlugin.js
@@ -32,15 +32,6 @@ const _fromQuat = /* @__PURE__ */ new Quaternion();
 const _toQuat = /* @__PURE__ */ new Quaternion();
 const _scale = /* @__PURE__ */ new Vector3();
 
-function onUpdateBefore() {
-
-	const fadeManager = this._fadeManager;
-
-	// store the fade count before the update so we can check whether fading started or stopped
-	this._fadingBefore = fadeManager.fadeCount;
-
-}
-
 function onUpdateAfter() {
 
 	const fadeManager = this._fadeManager;
@@ -236,11 +227,9 @@ export class TilesFadePlugin {
 
 		};
 
-		this._onTileVisibilityChange = ( { tile, visible } ) => {
+		this._onTileVisibilityChange = ( { tile } ) => {
 
-			// this function gets fired _after_ all set visible callbacks including the batched meshes
-
-			// revert the scene and fade to the initial state when toggling
+			// reset batched mesh fade state when tile visibility changes
 			this.forEachBatchIds( tile, ( id, batchedMesh, plugin ) => {
 
 				batchedMesh.setFadeAt( id, 0, 0 );
@@ -253,7 +242,8 @@ export class TilesFadePlugin {
 
 		this._onUpdateBefore = () => {
 
-			onUpdateBefore.call( this );
+			// store the fade count before the update so we can check whether fading started or stopped
+			this._fadingBefore = this._fadeManager.fadeCount;
 
 		};
 

--- a/src/three/plugins/fade/TilesFadePlugin.js
+++ b/src/three/plugins/fade/TilesFadePlugin.js
@@ -51,31 +51,30 @@ function onUpdateAfter() {
 
 	}
 
-	// update the visibility of tiles based on visibility since we must use
-	// the active tiles for rendering fade
-	if ( ! displayActiveTiles ) {
+	// update the visibility of tiles based on whether they are in the frustum. When
+	// displayActiveTiles is enabled all active tiles are shown regardless of frustum state,
+	// otherwise only in-frustum tiles are shown. This must run every frame to correct stale
+	// scene.visible values left by the previous frame's correction.
+	tiles.visibleTiles.forEach( t => {
 
-		tiles.visibleTiles.forEach( t => {
+		// if a tile is fading out then it may not be traversed and thus will not have
+		// the frustum flag set correctly.
+		const targetVisible = displayActiveTiles || t.traversal.inFrustum;
+		const scene = t.engineData.scene;
+		if ( scene ) {
 
-			// if a tile is fading out then it may not be traversed and thus will not have
-			// the frustum flag set correctly.
-			const scene = t.engineData.scene;
-			if ( scene ) {
+			scene.visible = targetVisible;
 
-				scene.visible = t.traversal.inFrustum;
+		}
 
-			}
+		this.forEachBatchIds( t, ( id, batchedMesh, plugin ) => {
 
-			this.forEachBatchIds( t, ( id, batchedMesh, plugin ) => {
-
-				batchedMesh.setVisibleAt( id, t.traversal.inFrustum );
-				plugin.batchedMesh.setVisibleAt( id, t.traversal.inFrustum );
-
-			} );
+			batchedMesh.setVisibleAt( id, targetVisible );
+			plugin.batchedMesh.setVisibleAt( id, targetVisible );
 
 		} );
 
-	}
+	} );
 
 	if ( maximumFadeOutTiles < this._fadingOutCount ) {
 

--- a/src/three/plugins/fade/TilesFadePlugin.js
+++ b/src/three/plugins/fade/TilesFadePlugin.js
@@ -110,16 +110,10 @@ function onUpdateAfter() {
 
 		// prevent faded tiles from being unloaded
 		const scene = tile.engineData.scene;
-		const isFadingOut = fadeManager.isFadingOut( tile );
 		tiles.markTileUsed( tile );
 		if ( scene ) {
 
 			fadeMaterialManager.setFade( scene, fadeIn, fadeOut );
-			if ( isFadingOut ) {
-
-				scene.visible = true;
-
-			}
 
 		}
 
@@ -247,13 +241,6 @@ export class TilesFadePlugin {
 			// this function gets fired _after_ all set visible callbacks including the batched meshes
 
 			// revert the scene and fade to the initial state when toggling
-			const scene = tile.engineData.scene;
-			if ( scene ) {
-
-				scene.visible = true;
-
-			}
-
 			this.forEachBatchIds( tile, ( id, batchedMesh, plugin ) => {
 
 				batchedMesh.setFadeAt( id, 0, 0 );
@@ -486,11 +473,6 @@ export class TilesFadePlugin {
 		tiles.forEachLoadedModel( ( scene, tile ) => {
 
 			this._fadeManager.deleteObject( tile );
-			if ( scene ) {
-
-				scene.visible = true; // TODO
-
-			}
 
 		} );
 

--- a/src/three/plugins/fade/TilesFadePlugin.js
+++ b/src/three/plugins/fade/TilesFadePlugin.js
@@ -4,6 +4,28 @@ import { FadeMaterialManager } from './FadeMaterialManager.js';
 import { FadeBatchedMesh } from './FadeBatchedMesh.js';
 
 const HAS_POPPED_IN = Symbol( 'HAS_POPPED_IN' );
+
+function tileWasInFrustumLastFrame( tile ) {
+
+	// Check if an ancestor was outside the frustum last frame, indicating that this one
+	// would have been, too.
+	let current = tile;
+	while ( current ) {
+
+		if ( current.traversal.wasSetActive && ! current.internal.hasUnrenderableContent ) {
+
+			return current.traversal.wasInFrustum;
+
+		}
+
+		current = current.parent;
+
+	}
+
+	return false;
+
+}
+
 const _fromPos = /* @__PURE__ */ new Vector3();
 const _toPos = /* @__PURE__ */ new Vector3();
 const _fromQuat = /* @__PURE__ */ new Quaternion();
@@ -13,16 +35,9 @@ const _scale = /* @__PURE__ */ new Vector3();
 function onUpdateBefore() {
 
 	const fadeManager = this._fadeManager;
-	const tiles = this.tiles;
 
-	// store the tiles renderer state before the tiles update so we can check
-	// whether fading started or stopped completely
+	// store the fade count before the update so we can check whether fading started or stopped
 	this._fadingBefore = fadeManager.fadeCount;
-	this._displayActiveTiles = tiles.displayActiveTiles;
-
-	// we need to display all active tiles in this case so we don't fade tiles in
-	// when moving from off screen
-	tiles.displayActiveTiles = true;
 
 }
 
@@ -30,14 +45,10 @@ function onUpdateAfter() {
 
 	const fadeManager = this._fadeManager;
 	const fadeMaterialManager = this._fadeMaterialManager;
-	const displayActiveTiles = this._displayActiveTiles;
 	const fadingBefore = this._fadingBefore;
 	const prevCameraTransforms = this._prevCameraTransforms;
 	const { tiles, maximumFadeOutTiles, batchedMesh } = this;
 	const { cameras } = tiles;
-
-	// reset the active tiles flag
-	tiles.displayActiveTiles = displayActiveTiles;
 
 	// update fade step
 	fadeManager.update();
@@ -50,31 +61,6 @@ function onUpdateAfter() {
 		tiles.dispatchEvent( { type: 'needs-render' } );
 
 	}
-
-	// update the visibility of tiles based on whether they are in the frustum. When
-	// displayActiveTiles is enabled all active tiles are shown regardless of frustum state,
-	// otherwise only in-frustum tiles are shown. This must run every frame to correct stale
-	// scene.visible values left by the previous frame's correction.
-	tiles.visibleTiles.forEach( t => {
-
-		// if a tile is fading out then it may not be traversed and thus will not have
-		// the frustum flag set correctly.
-		const targetVisible = displayActiveTiles || t.traversal.inFrustum;
-		const scene = t.engineData.scene;
-		if ( scene ) {
-
-			scene.visible = targetVisible;
-
-		}
-
-		this.forEachBatchIds( t, ( id, batchedMesh, plugin ) => {
-
-			batchedMesh.setVisibleAt( id, targetVisible );
-			plugin.batchedMesh.setVisibleAt( id, targetVisible );
-
-		} );
-
-	} );
 
 	if ( maximumFadeOutTiles < this._fadingOutCount ) {
 
@@ -192,7 +178,7 @@ export class TilesFadePlugin {
 
 		options = {
 
-			maximumFadeOutTiles: 50,
+			maximumFadeOutTiles: Infinity,
 			fadeRootTiles: false,
 			fadeDuration: 250,
 			...options,
@@ -399,9 +385,22 @@ export class TilesFadePlugin {
 	setTileVisible( tile, visible ) {
 
 		const fadeManager = this._fadeManager;
+		const wasFading = fadeManager.isFading( tile );
+
+		// Tiles that were off-screen last frame pop in/out without fading
+		if ( ! tileWasInFrustumLastFrame( tile ) ) {
+
+			if ( wasFading ) {
+
+				fadeManager.completeFade( tile );
+
+			}
+
+			return false;
+
+		}
 
 		// track the fade state
-		const wasFading = fadeManager.isFading( tile );
 		if ( fadeManager.isFadingOut( tile ) ) {
 
 			this._fadingOutCount --;

--- a/src/three/plugins/fade/TilesFadePlugin.js
+++ b/src/three/plugins/fade/TilesFadePlugin.js
@@ -12,7 +12,7 @@ function tileWasInFrustumLastFrame( tile ) {
 	let current = tile;
 	while ( current ) {
 
-		if ( current.traversal.wasSetActive && ! current.internal.hasUnrenderableContent ) {
+		if ( current.traversal.wasSetActive ) {
 
 			return current.traversal.wasInFrustum;
 

--- a/src/three/plugins/mvt/GlyphAtlasTexture.js
+++ b/src/three/plugins/mvt/GlyphAtlasTexture.js
@@ -229,6 +229,10 @@ export class GlyphAtlasTexture extends CanvasTexture {
 
 		return this._draw( key, ( ctx, x, y, w, h ) => {
 
+			// TODO: this draw is resulting in alpha blending white outline
+			// We might be able to use "source-over" and "destination-in" with "globalCompositeOperation"
+			// to fix this.
+
 			const iw = w * iconScale;
 			const ih = h * iconScale;
 			const scale = Math.min( iw / vbW, ih / vbH );


### PR DESCRIPTION
Fix #1623 
Fix #1020

- Remove need for "displayActiveTiles" "hack" so only visible tiles are ever present.
- Ensure that "active" is never set to true for internal tileset json tiles.
- Add "wasInFrustum" to tile traversal object.
- Ensure "was*" fields are consistent per their last frame.