### PR TITLE
PriorityQueue, DataCache: Adjust abort signal strategy

### DIFF
--- a/src/core/renderer/utilities/PriorityQueue.js
+++ b/src/core/renderer/utilities/PriorityQueue.js
@@ -6,12 +6,11 @@ import { Scheduler } from './Scheduler.js';
  *
  * @extends Error
  */
-export class PriorityQueueItemRemovedError extends Error {
+export class PriorityQueueItemRemovedError extends DOMException {
 
 	constructor() {
 
-		super( 'PriorityQueue: Item removed' );
-		this.name = 'PriorityQueueItemRemovedError';
+		super( 'PriorityQueue: Item removed', 'AbortError' );
 
 	}
 

--- a/src/core/renderer/utilities/PriorityQueue.js
+++ b/src/core/renderer/utilities/PriorityQueue.js
@@ -1,12 +1,8 @@
 import { Scheduler } from './Scheduler.js';
 
-/**
- * Error thrown when a queued item's promise is rejected because the item was removed
- * before its callback could run.
- *
- * @extends Error
- */
-export class PriorityQueueItemRemovedError extends DOMException {
+// Error thrown when a queued item's promise is rejected because the item was removed
+// before its callback could run.
+class PriorityQueueItemRemovedError extends DOMException {
 
 	constructor() {
 
@@ -167,7 +163,7 @@ export class PriorityQueue {
 	}
 
 	/**
-	 * Removes an item from the queue, rejecting its promise with `PriorityQueueItemRemovedError`.
+	 * Removes an item from the queue, rejecting its promise with an `AbortError` DOMException.
 	 * @param {any} item
 	 */
 	remove( item ) {
@@ -184,7 +180,7 @@ export class PriorityQueue {
 			const info = callbacks.get( item );
 			info.promise.catch( err => {
 
-				if ( ! ( err instanceof PriorityQueueItemRemovedError ) ) {
+				if ( err.name !== 'AbortError' ) {
 
 					throw err;
 

--- a/src/three/plugins/images/GeneratedSurfacePlugin.js
+++ b/src/three/plugins/images/GeneratedSurfacePlugin.js
@@ -122,7 +122,21 @@ export class GeneratedSurfacePlugin {
 
 			if ( overlay.hasContent( range, level ) ) {
 
-				await overlay.lockTexture( range, level );
+				try {
+
+					await overlay.lockTexture( range, level );
+
+				} catch ( err ) {
+
+					if ( err.name !== 'AbortError' ) {
+
+						throw err;
+
+					}
+
+					return null;
+
+				}
 
 				const texture = overlay.getTexture( range, level );
 				tile[ OVERLAY_RANGE ] = range;

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -2,7 +2,7 @@
 /** @import { WMTSTileMatrix } from './WMTSImageSource.js' */
 /** @import { VectorTileStyle } from './utils/VectorShapeCanvasRenderer.js' */
 import { Color, BufferAttribute, Matrix4, Vector3, Box3, Triangle, CanvasTexture } from 'three';
-import { PriorityQueue, PriorityQueueItemRemovedError, unifiedPriorityCallback, DEFAULT_DOWNLOAD_QUEUE } from '3d-tiles-renderer/core';
+import { PriorityQueue, unifiedPriorityCallback, DEFAULT_DOWNLOAD_QUEUE } from '3d-tiles-renderer/core';
 import { CesiumIonAuth, GoogleCloudAuth } from '3d-tiles-renderer/core/plugins';
 import { XYZImageSource } from './sources/XYZImageSource.js';
 import { QuadKeyImageSource } from './sources/QuadKeyImageSource.js';
@@ -1025,7 +1025,15 @@ export class ImageOverlayPlugin {
 				range = overlay.projection.toNormalizedRange( range );
 
 				info.range = range;
-				overlay.lockTexture( range );
+				overlay.lockTexture( range ).catch( err => {
+
+					if ( err.name !== 'AbortError' ) {
+
+						throw err;
+
+					}
+
+				} );
 
 			}
 
@@ -1117,7 +1125,15 @@ export class ImageOverlayPlugin {
 		if ( info.range === null ) {
 
 			info.range = range;
-			overlay.lockTexture( range );
+			overlay.lockTexture( range ).catch( err => {
+
+				if ( err.name !== 'AbortError' ) {
+
+					throw err;
+
+				}
+
+			} );
 
 		}
 
@@ -1179,7 +1195,7 @@ export class ImageOverlayPlugin {
 			} )
 			.catch( err => {
 
-				if ( err instanceof PriorityQueueItemRemovedError ) {
+				if ( err.name === 'AbortError' ) {
 
 					return null;
 
@@ -1231,11 +1247,28 @@ export class ImageOverlayPlugin {
 
 			failed.forEach( ( { tile, overlay, info } ) => {
 
-				overlay.lockTexture( info.range );
+				overlay.lockTexture( info.range ).catch( err => {
+
+					if ( err.name !== 'AbortError' ) {
+
+						throw err;
+
+					}
+
+				} );
 				this._fetchTileOverlayTexture( tile, overlay, info )
 					.then( () => {
 
 						this._updateLayers( tile );
+
+					} )
+					.catch( err => {
+
+						if ( err.name !== 'AbortError' ) {
+
+							throw err;
+
+						}
 
 					} );
 

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1025,20 +1025,7 @@ export class ImageOverlayPlugin {
 				range = overlay.projection.toNormalizedRange( range );
 
 				info.range = range;
-				const lockResult = overlay.lockTexture( range );
-				if ( lockResult instanceof Promise ) {
-
-					lockResult.catch( err => {
-
-						if ( err.name !== 'AbortError' ) {
-
-							throw err;
-
-						}
-
-					} );
-
-				}
+				overlay.lockTextureSafe( range );
 
 			}
 
@@ -1130,20 +1117,7 @@ export class ImageOverlayPlugin {
 		if ( info.range === null ) {
 
 			info.range = range;
-			const lockResult = overlay.lockTexture( range );
-			if ( lockResult instanceof Promise ) {
-
-				lockResult.catch( err => {
-
-					if ( err.name !== 'AbortError' ) {
-
-						throw err;
-
-					}
-
-				} );
-
-			}
+			overlay.lockTextureSafe( range );
 
 		}
 
@@ -1257,20 +1231,7 @@ export class ImageOverlayPlugin {
 
 			failed.forEach( ( { tile, overlay, info } ) => {
 
-				const lockResult = overlay.lockTexture( info.range );
-				if ( lockResult instanceof Promise ) {
-
-					lockResult.catch( err => {
-
-						if ( err.name !== 'AbortError' ) {
-
-							throw err;
-
-						}
-
-					} );
-
-				}
+				overlay.lockTextureSafe( info.range );
 
 				this._fetchTileOverlayTexture( tile, overlay, info )
 					.then( () => {
@@ -1877,6 +1838,23 @@ export class GeoJSONOverlay extends ImageOverlay {
 	lockTexture( range ) {
 
 		return this.imageSource.lock( ...range );
+
+	}
+
+	lockTextureSafe( range ) {
+
+		const result = this.lockTexture( range );
+		if ( result instanceof Promise ) {
+
+			result.catch( err => {
+
+				if ( err.name !== 'AbortError' ) throw err;
+
+			} );
+
+		}
+
+		return result;
 
 	}
 

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1025,15 +1025,20 @@ export class ImageOverlayPlugin {
 				range = overlay.projection.toNormalizedRange( range );
 
 				info.range = range;
-				overlay.lockTexture( range ).catch( err => {
+				const lockResult = overlay.lockTexture( range );
+				if ( lockResult instanceof Promise ) {
 
-					if ( err.name !== 'AbortError' ) {
+					lockResult.catch( err => {
 
-						throw err;
+						if ( err.name !== 'AbortError' ) {
 
-					}
+							throw err;
 
-				} );
+						}
+
+					} );
+
+				}
 
 			}
 
@@ -1125,15 +1130,20 @@ export class ImageOverlayPlugin {
 		if ( info.range === null ) {
 
 			info.range = range;
-			overlay.lockTexture( range ).catch( err => {
+			const lockResult = overlay.lockTexture( range );
+			if ( lockResult instanceof Promise ) {
 
-				if ( err.name !== 'AbortError' ) {
+				lockResult.catch( err => {
 
-					throw err;
+					if ( err.name !== 'AbortError' ) {
 
-				}
+						throw err;
 
-			} );
+					}
+
+				} );
+
+			}
 
 		}
 
@@ -1247,15 +1257,21 @@ export class ImageOverlayPlugin {
 
 			failed.forEach( ( { tile, overlay, info } ) => {
 
-				overlay.lockTexture( info.range ).catch( err => {
+				const lockResult = overlay.lockTexture( info.range );
+				if ( lockResult instanceof Promise ) {
 
-					if ( err.name !== 'AbortError' ) {
+					lockResult.catch( err => {
 
-						throw err;
+						if ( err.name !== 'AbortError' ) {
 
-					}
+							throw err;
 
-				} );
+						}
+
+					} );
+
+				}
+
 				this._fetchTileOverlayTexture( tile, overlay, info )
 					.then( () => {
 

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1843,6 +1843,7 @@ export class GeoJSONOverlay extends ImageOverlay {
 
 	lockTextureSafe( range ) {
 
+		// locks a texture without risk of throwing due to abort
 		const result = this.lockTexture( range );
 		if ( result instanceof Promise ) {
 

--- a/src/three/plugins/images/sources/MVTImageSource.js
+++ b/src/three/plugins/images/sources/MVTImageSource.js
@@ -200,11 +200,7 @@ export class MVTImageSource extends RegionImageSource {
 
 		await Promise.all( promises );
 
-		if ( signal && signal.aborted ) {
-
-			return null;
-
-		}
+		signal?.throwIfAborted();
 
 		this._drawToCanvas( canvas, regionBounds, level );
 

--- a/src/three/plugins/images/sources/RegionImageSource.js
+++ b/src/three/plugins/images/sources/RegionImageSource.js
@@ -73,11 +73,7 @@ export class TiledRegionImageSource extends RegionImageSource {
 		// lock tiles for the requested level
 		await this._markImages( range, level, false );
 
-		if ( signal && signal.aborted ) {
-
-			return null;
-
-		}
+		signal?.throwIfAborted();
 
 		// Fast path: if the range maps to exactly one tile with matching bounds, use its
 		// texture directly without compositing into an intermediate canvas to save memory.

--- a/src/three/plugins/images/utils/DataCache.js
+++ b/src/three/plugins/images/utils/DataCache.js
@@ -1,3 +1,13 @@
+export class DataCacheItemRemovedError extends DOMException {
+
+	constructor() {
+
+		super( 'DataCache: Item removed', 'AbortError' );
+
+	}
+
+}
+
 function hash( ...args ) {
 
 	return args.join( '_' );
@@ -78,8 +88,9 @@ export class DataCache {
 			info.result = this.fetchItem( args, abortController.signal );
 			if ( info.result instanceof Promise ) {
 
-				info.result.then( res => {
+				info.result = info.result.then( res => {
 
+					abortController.signal.throwIfAborted();
 					info.result = res;
 					info.bytes = this.getMemoryUsage( res );
 					this.cachedBytes += info.bytes;
@@ -88,10 +99,6 @@ export class DataCache {
 				} ).finally( () => {
 
 					this.active --;
-
-				} ).catch( e => {
-
-					// error logging and handling can be handled elsewhere
 
 				} );
 
@@ -168,7 +175,7 @@ export class DataCache {
 		for ( const key in cache ) {
 
 			const { abortController } = cache[ key ];
-			abortController.abort();
+			abortController.abort( new DataCacheItemRemovedError() );
 
 			this.releaseViaFullKey( key, true );
 
@@ -202,7 +209,7 @@ export class DataCache {
 
 					// abort any loads
 					const { result, abortController } = info;
-					abortController.abort();
+					abortController.abort( new DataCacheItemRemovedError() );
 
 					// dispose of the object even if it still is in progress
 					if ( result instanceof Promise ) {

--- a/src/three/plugins/images/utils/DataCache.js
+++ b/src/three/plugins/images/utils/DataCache.js
@@ -1,4 +1,6 @@
-export class DataCacheItemRemovedError extends DOMException {
+// Error thrown when a cache item's promise is rejected because the item was released
+// before its callback could run.
+class DataCacheItemRemovedError extends DOMException {
 
 	constructor() {
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -422,14 +422,6 @@ export class MVTAnnotationsPlugin {
 		this._onDisposeTile = ( { tile } ) => {
 
 			const { tileLoadState } = this;
-			const info = tileLoadState.get( tile );
-			if ( ! info ) {
-
-				return;
-
-			}
-
-			info.disposed = true;
 			tileLoadState.delete( tile );
 
 		};
@@ -481,7 +473,6 @@ export class MVTAnnotationsPlugin {
 
 		this.tileLoadState.set( tile, {
 			range: null,
-			disposed: false,
 		} );
 
 	}

--- a/src/three/plugins/mvt/MVTHierarchy.js
+++ b/src/three/plugins/mvt/MVTHierarchy.js
@@ -155,12 +155,10 @@ export class MVTHierarchy extends EventDispatcher {
 					tile.showTimer = 0;
 					tile.hideTimer = 0;
 
-					// Release the content lock for any state that called lock(), and reset synchronously
-					// before any async abort callbacks can fire
+					// Release the content lock; reset synchronously so the tile is in a clean
+					// state before any async callbacks can observe it
 					if ( tile.loadingState !== UNLOADED ) {
 
-						// TODO: this is being done here because it's currently difficult to determine
-						// whether an item was cancelled via the abort signal, download queue, or failed.
 						scope.contentCache.release( tile.x, tile.y, tile.level );
 						tile.loadingState = UNLOADED;
 
@@ -187,25 +185,16 @@ export class MVTHierarchy extends EventDispatcher {
 
 							if ( tile.loadingState === LOADING ) {
 
-								if ( res === null ) {
-
-									// TODO: we need to adjust data cache to be more clear about what is returned here
-									tile.loadingState = UNLOADED;
-
-								} else {
-
-									tile.loadingState = LOADED;
-
-								}
+								tile.loadingState = LOADED;
 
 							}
 
 						} )
-						.catch( () => {
+						.catch( err => {
 
 							if ( tile.loadingState === LOADING ) {
 
-								tile.loadingState = FAILED;
+								tile.loadingState = err.name === 'AbortError' ? UNLOADED : FAILED;
 
 							}
 


### PR DESCRIPTION
Related to #1600
Fix #1630

**To Do**
- Investigate "stuck" icons / MVT tiles when zooming out. Somehow children are getting an extra "target" ref? (see #1634)
- X Consider a "safe" or "silent" version of lock that won't throw and instead the throw is handled when the data is retrieved through "get"
- X Adjust DataCache to throw an abort error on process cancellation
- X Remove export for PriorityQueue error
- X Adjust all catching from the queues / caches to check for an AbortError
- X Considering removing ".aborted" checks and prefer throwing