### PR TITLE
Docs: fix documented default value of loadAncestors

### DIFF
--- a/src/core/renderer/API.md
+++ b/src/core/renderer/API.md
@@ -908,7 +908,7 @@ potentially causing brief gaps during rapid movement. Implicitly treated as `tru
 ### .loadAncestors
 
 ```js
-loadAncestors: boolean = false
+loadAncestors: boolean = true
 ```
 
 **Experimental.** When `true`, ancestor tiles are queued for download and displayed as a

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -557,7 +557,7 @@ export class TilesRendererBase {
 		 * strategy. Increases memory usage but provides smoother transitions on first load.
 		 * Implicitly enables sibling loading to prevent flickering during camera movement.
 		 * @type {boolean}
-		 * @default false
+		 * @default true
 		 */
 		this.loadAncestors = true;
 


### PR DESCRIPTION
The `loadAncestors` property (introduced by #1533)  was documented as defaulting to `false` in both the API doc and the JSDoc comment, but the actual implementation initializes it to `true`.

This PR fixes corrects the documented default value to match the code.