### PR TITLE
Fix loadAncestors on tiles with no renderable content

### DIFF
--- a/src/core/renderer/tiles/traverseFunctions.js
+++ b/src/core/renderer/tiles/traverseFunctions.js
@@ -324,7 +324,7 @@ function markUsedSetLeaves( tile, renderer ) {
 			if ( isUsedThisFrame( c, frameCount ) ) {
 
 				const childCanDisplay = ! canUnconditionallyRefine( c );
-				const childContentReady = ! c.internal.hasContent || isDownloadFinished( c.internal.loadingState );
+				const childContentReady = c.internal.hasUnrenderableContent || isDownloadFinished( c.internal.loadingState );
 				const childIsReady = ( childCanDisplay && childContentReady ) || c.traversal.allChildrenLoaded;
 				if ( ! childIsReady ) {
 


### PR DESCRIPTION
This PR checks that child tile has no renderable content when determining if its content is ready. This prevents gaps when  `loadAncestors` is `true` on tiles referencing `.json` files.

Closes #1642 