### PR TITLE
MVTAnnotationsPlugin: Add draw through option for glyphs

### DIFF
--- a/example/three/annotationsExample.js
+++ b/example/three/annotationsExample.js
@@ -108,6 +108,7 @@ const LANGUAGES = [ 'default', 'en', 'ja', 'ko' ];
 const params = {
 
 	language: 'default',
+	drawMode: MVTGlyphs.DrawMode.OVERLAY,
 	displayIcons: true,
 	displayPaths: true,
 
@@ -297,6 +298,8 @@ function reinstantiateTiles() {
 	tiles.registerPlugin( new MeshBVHPlugin() );
 	driver = new ExampleAnnotationsDriver();
 	driver.language = params.language;
+	driver.annotationPoints.drawMode = params.drawMode;
+	driver.characterPoints.drawMode = params.drawMode;
 	tiles.registerPlugin( new MVTAnnotationsPlugin( {
 		overlay,
 		camera,
@@ -368,6 +371,12 @@ function init() {
 
 		driver.language = v;
 		tiles.getPluginByName( 'UPDATE_ON_CHANGE_PLUGIN' ).needsUpdate = true;
+
+	} );
+	gui.add( params, 'drawMode', MVTIconGlyphs.DrawMode ).onChange( v => {
+
+		driver.annotationPoints.drawMode = v;
+		driver.characterPoints.drawMode = v;
 
 	} );
 	gui.add( params, 'displayIcons' ).onChange( v => {

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -909,197 +909,6 @@ extension and attaches a `StructuralMetadata` instance to `scene.userData.struct
 constructor( parser: Object )
 ```
 
-## GlyphAtlasTexture
-
-_extends `CanvasTexture`_
-
-A canvas texture that manages a grid of fixed-size slots, each holding a rendered glyph or icon.
-Slots are addressed by string key and can be drawn with text, images, or paths.
-
-
-### .isFull
-
-```js
-isFull: boolean
-```
-
-Returns true when all slots are allocated.
-
-
-### .capacity
-
-```js
-capacity: number
-```
-
-Returns the total number of icons that can be added to the atlas.
-
-
-### .count
-
-```js
-count: number
-```
-
-Returns the number of icons currently used.
-
-
-### .constructor
-
-```js
-constructor( slotCount = 32: number, slotSize = 64: number )
-```
-
-### .has
-
-```js
-has( key: string ): boolean
-```
-
-Returns true if key has an allocated slot.
-
-
-### .get
-
-```js
-get( key: string ): Object | null
-```
-
-Returns the slot bounds `{ x, y, w, h }` for key, or null if not allocated.
-
-
-### .getSlotSize
-
-```js
-getSlotSize( target: Vector2 ): Vector2
-```
-
-Returns the UV bounds of a slot for key in GPU texture space (flipY applied),
-or null if not allocated.
-
-
-### .getUV
-
-```js
-getUV( key: string ): Object | null
-```
-
-Returns the UV bounds of the slot for key in GPU texture space (flipY applied),
-or null if not allocated. x/y is the top-left corner; w/h is the slot size in UV units.
-
-
-### .drawChar
-
-```js
-drawChar(
-	key: string,
-	char: string,
-	{
-		// CSS font string (e.g. `'bold 48px sans-serif'`).
-		font = '': string,
-
-		// CSS fill color.
-		color = 'white': string,
-
-		// CSS stroke color drawn under the fill, or null to skip the
-		// stroke.
-		strokeStyle = null: string | null,
-
-		// Stroke width in atlas pixels.
-		strokeWidth = 1: number,
-	}
-): Object
-```
-
-Renders a single character in the slot, centered on its text metrics bounding box.
-
-
-### .drawImage
-
-```js
-drawImage(
-	key: string,
-	image: HTMLImageElement | HTMLCanvasElement | ImageBitmap
-): Object
-```
-
-Draws a `CanvasImageSource` into the slot, scaled to fit.
-
-
-### .drawPath
-
-```js
-drawPath(
-	key: string,
-	path2D: Path2D,
-	{
-		// CSS fill color, or null to skip fill.
-		fillStyle = null: string | null,
-
-		// CSS stroke color, or null to skip stroke.
-		strokeStyle = null: string | null,
-
-		// Stroke width in pixels.
-		lineWidth = 1: number,
-	}
-): Object
-```
-
-Renders a `Path2D` into the slot. Path coordinates are slot-local (origin at top-left).
-
-
-### .drawSVG
-
-```js
-drawSVG(
-	key: string,
-	svgText: string,
-	{
-		// CSS fill color, or null to skip fill.
-		fillStyle = 'white': string | null,
-
-		// CSS stroke color, or null to skip stroke.
-		strokeStyle = null: string | null,
-
-		// Stroke width in SVG user units before scaling.
-		strokeWidth = 1: number,
-
-		// Fraction of the slot size the icon occupies (0–1).
-		iconScale = 1: number,
-	}
-): Object
-```
-
-Parses an SVG string and renders its paths into a slot, scaled to fit.
-
-
-### .release
-
-```js
-release( key: string ): void
-```
-
-Frees the slot for key, returning it to the pool for reuse.
-
-
-### .resize
-
-```js
-resize( slotCount: number, slotSize: number ): void
-```
-
-Resizes the atlas, copying existing slot content to their new positions.
-
-
-### .clear
-
-```js
-clear(): void
-```
-
-Clears all slots and resets the atlas to empty.
-
-
 ## ImageOverlayPlugin
 
 Plugin that composites one or more tiled image overlays onto 3D tile geometry by
@@ -1302,6 +1111,16 @@ getText( properties: Object ): string
 The string a line / road annotation should display for the given feature.
 
 
+### .isAnnotationEnabled
+
+```js
+isAnnotationEnabled( properties: Object, type: number ): boolean
+```
+
+Whether a parsed annotation should currently be displayed. Unlike `filterAnnotation` which
+decides what is parsed once.
+
+
 ### .onAnnotationsUpdate
 
 ```js
@@ -1347,6 +1166,383 @@ constructor(
 	}
 )
 ```
+
+## MVTGlyphAtlasTexture
+
+_extends `CanvasTexture`_
+
+A canvas texture that manages a grid of fixed-size slots, each holding a rendered glyph or icon.
+Slots are addressed by string key and can be drawn with text, images, or paths.
+
+
+### .isFull
+
+```js
+isFull: boolean
+```
+
+Returns true when all slots are allocated.
+
+
+### .capacity
+
+```js
+capacity: number
+```
+
+Returns the total number of icons that can be added to the atlas.
+
+
+### .count
+
+```js
+count: number
+```
+
+Returns the number of icons currently used.
+
+
+### .constructor
+
+```js
+constructor( slotCount = 32: number, slotSize = 64: number )
+```
+
+### .has
+
+```js
+has( key: string ): boolean
+```
+
+Returns true if key has an allocated slot.
+
+
+### .get
+
+```js
+get( key: string ): Object | null
+```
+
+Returns the slot bounds `{ x, y, w, h }` for key, or null if not allocated.
+
+
+### .getSlotSize
+
+```js
+getSlotSize( target: Vector2 ): Vector2
+```
+
+Returns the UV bounds of a slot for key in GPU texture space (flipY applied),
+or null if not allocated.
+
+
+### .getUV
+
+```js
+getUV( key: string ): Object | null
+```
+
+Returns the UV bounds of the slot for key in GPU texture space (flipY applied),
+or null if not allocated. x/y is the top-left corner; w/h is the slot size in UV units.
+
+
+### .drawChar
+
+```js
+drawChar(
+	key: string,
+	char: string,
+	{
+		// CSS font string (e.g. `'bold 48px sans-serif'`).
+		font = '': string,
+
+		// CSS fill color.
+		color = 'white': string,
+
+		// CSS stroke color drawn under the fill, or null to skip the
+		// stroke.
+		strokeStyle = null: string | null,
+
+		// Stroke width in atlas pixels.
+		strokeWidth = 1: number,
+	}
+): Object
+```
+
+Renders a single character in the slot, centered on its text metrics bounding box.
+
+
+### .drawImage
+
+```js
+drawImage(
+	key: string,
+	image: HTMLImageElement | HTMLCanvasElement | ImageBitmap
+): Object
+```
+
+Draws a `CanvasImageSource` into the slot, scaled to fit.
+
+
+### .drawPath
+
+```js
+drawPath(
+	key: string,
+	path2D: Path2D,
+	{
+		// CSS fill color, or null to skip fill.
+		fillStyle = null: string | null,
+
+		// CSS stroke color, or null to skip stroke.
+		strokeStyle = null: string | null,
+
+		// Stroke width in pixels.
+		lineWidth = 1: number,
+	}
+): Object
+```
+
+Renders a `Path2D` into the slot. Path coordinates are slot-local (origin at top-left).
+
+
+### .drawSVG
+
+```js
+drawSVG(
+	key: string,
+	svgText: string,
+	{
+		// CSS fill color, or null to skip fill.
+		fillStyle = 'white': string | null,
+
+		// CSS stroke color, or null to skip stroke.
+		strokeStyle = null: string | null,
+
+		// Stroke width in SVG user units before scaling.
+		strokeWidth = 1: number,
+
+		// Fraction of the slot size the icon occupies (0–1).
+		iconScale = 1: number,
+	}
+): Object
+```
+
+Parses an SVG string and renders its paths into a slot, scaled to fit.
+
+
+### .release
+
+```js
+release( key: string ): void
+```
+
+Frees the slot for key, returning it to the pool for reuse.
+
+
+### .resize
+
+```js
+resize( slotCount: number, slotSize: number ): void
+```
+
+Resizes the atlas, copying existing slot content to their new positions.
+
+
+### .clear
+
+```js
+clear(): void
+```
+
+Clears all slots and resets the atlas to empty.
+
+
+## MVTGlyphs
+
+_extends `Group`_
+
+Base object that renders a batch of glyphs from a shared `MVTGlyphAtlasTexture`, fading each item
+in and out. Manages the geometry and two child draws sharing it: an opaque pass and a transparent
+"obscured" pass, combined per `drawMode`.
+
+
+### .DrawMode
+
+```js
+DrawMode: Object
+```
+
+Draw modes for `drawMode`:
+- `OBSCURED` – depth-tested, so glyphs are hidden where behind terrain.
+- `DRAW_THROUGH` – visible parts drawn opaque, parts behind terrain ghosted on top.
+- `OVERLAY` – always drawn on top of everything.
+
+
+### .size
+
+```js
+size: number
+```
+
+Glyph size in pixels.
+
+
+### .glyphAtlas
+
+```js
+glyphAtlas: MVTGlyphAtlasTexture
+```
+
+The texture atlas used for rendering glyphs.
+
+
+### .drawMode
+
+```js
+drawMode: number
+```
+
+How glyphs interact with the depth buffer; one of `MVTGlyphs.DrawMode`.
+
+
+### .fadeInDuration
+
+```js
+fadeInDuration: number
+```
+
+Seconds a glyph takes to fade in.
+
+
+### .fadeOutDuration
+
+```js
+fadeOutDuration: number
+```
+
+Seconds a glyph takes to fade out.
+
+
+### .obscuredOpacity
+
+```js
+obscuredOpacity: number
+```
+
+Opacity of the ghosted, obscured glyphs in the `DRAW_THROUGH` draw mode.
+
+
+### .dispose
+
+```js
+dispose(): void
+```
+
+Disposes the glyph atlas, geometry, and materials.
+
+
+## MVTIconGlyphs
+
+_extends [`MVTGlyphs`](#mvtglyphs)_
+
+Renders one icon glyph per point annotation. Each item's atlas key comes from `getKind`, or
+`fallback` when that key isn't in the atlas.
+
+
+### .getKind
+
+```js
+getKind: ( layer: string, properties: Object ) => string | null
+```
+
+Chooses the atlas key to draw for each point.
+
+
+### .fallback
+
+```js
+fallback: string | null
+```
+
+Atlas key used when `getKind`'s result isn't present in the atlas ( null draws nothing ).
+
+
+### .constructor
+
+```js
+constructor(
+	{
+		// Chooses the atlas key to draw for each point.
+		getKind?: (
+			layer: string,
+			properties: Object
+		) => string | null,
+
+		// Atlas key drawn when `getKind`'s result is missing from the
+		// atlas; null draws nothing.
+		fallback = null: string | null,
+
+		// Glyph size in pixels.
+		size = 18: number,
+
+		// Atlas slot size in pixels (defaults to `18 *
+		// devicePixelRatio`).
+		glyphSize?: number,
+
+		// Initial atlas slot capacity.
+		slotCount = 64: number,
+	}
+)
+```
+
+## MVTLabelGlyphs
+
+_extends [`MVTGlyphs`](#mvtglyphs)_
+
+Renders text labels one glyph per character, laid out along each annotation's path. Characters are
+rasterized into the atlas on demand, so a label's text may change at any time.
+
+
+### .constructor
+
+```js
+constructor(
+	{
+		// Glyph size in pixels.
+		size = 16: number,
+
+		// Atlas slot size in pixels (defaults to `16 *
+		// devicePixelRatio`).
+		glyphSize?: number,
+
+		// Initial atlas slot capacity ( grows as needed ).
+		slotCount = 64: number,
+
+		// Explicit CSS font string; overrides `fontFamily`.
+		font = null: string | null,
+
+		// Font family used to build the CSS font when `font` isn't
+		// given.
+		fontFamily = 'sans-serif': string,
+
+		// Outline color drawn under each glyph.
+		strokeStyle = 'black': string,
+
+		// Outline width in atlas pixels ( 0 disables the outline ).
+		strokeWidth = 0: number,
+	}
+)
+```
+
+### .measureChar
+
+```js
+measureChar( char: string ): number
+```
+
+Advance width of `char` in the label's size units, cached per character.
+
 
 ## QuantizedMeshPlugin
 

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1370,13 +1370,10 @@ in and out. Manages the geometry and two child draws sharing it: an opaque pass 
 ### .DrawMode
 
 ```js
-DrawMode: Object
+DrawMode: MVTDrawModeEnum
 ```
 
-Draw modes for `drawMode`:
-- `OBSCURED` – depth-tested, so glyphs are hidden where behind terrain.
-- `DRAW_THROUGH` – visible parts drawn opaque, parts behind terrain ghosted on top.
-- `OVERLAY` – always drawn on top of everything.
+The draw modes assignable to `drawMode`.
 
 
 ### .size
@@ -2015,6 +2012,33 @@ nullFeatureId: number | null
 ```js
 texture?: Object
 ```
+
+## MVTDrawModeEnum
+
+
+### .OBSCURED
+
+```js
+OBSCURED: number
+```
+
+Depth-tested, so glyphs are hidden where behind terrain.
+
+### .DRAW_THROUGH
+
+```js
+DRAW_THROUGH: number
+```
+
+Visible parts drawn opaque, parts behind terrain ghosted on top.
+
+### .OVERLAY
+
+```js
+OVERLAY: number
+```
+
+Always drawn on top of everything.
 
 ## VectorTileStyle
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -171,9 +171,11 @@ function splitAnnotations( set ) {
 
 /**
  * Ready-to-use driver so `new MVTAnnotationsPlugin( { overlay } )` displays something without any
- * setup: every point feature is drawn as a filled white circle and every named line as white,
+ * setup. Every point feature is drawn as a filled white circle and every named line as white,
  * black-outlined Arial text. No feature filtering is applied. Supply a custom `MVTAnnotationsDriver`
  * to the plugin to override this behavior.
+ * @private
+ * @extends MVTAnnotationsDriver
  */
 export class DefaultMVTAnnotationsDriver extends MVTAnnotationsDriver {
 

--- a/src/three/plugins/mvt/MVTGlyphMaterial.js
+++ b/src/three/plugins/mvt/MVTGlyphMaterial.js
@@ -1,5 +1,7 @@
-import { PointsMaterial, Vector2 } from 'three';
+import { PointsMaterial, Vector2, Vector4 } from 'three';
 import { MVTGlyphAtlasTexture } from './MVTGlyphAtlasTexture.js';
+
+const _viewport = /* @__PURE__ */ new Vector4();
 
 /**
  * A `PointsMaterial` that draws each point sprite as a glyph from an `MVTGlyphAtlasTexture` with fading.
@@ -63,6 +65,7 @@ export class MVTGlyphMaterial extends PointsMaterial {
 		this.transparent = true;
 		this.depthTest = false;
 		this.depthWrite = false;
+		this.resolution = new Vector2();
 
 		// owns the glyph atlas ( unless one is provided ); the cell size is kept in sync with it
 		// and pushed to the uniforms after compile
@@ -103,6 +106,7 @@ export class MVTGlyphMaterial extends PointsMaterial {
 
 					uniform sampler2D glyphAtlas;
 					uniform vec2 glyphCellSize;
+					uniform float opacity;
 					varying vec2 vGlyphUV;
 					varying float vAlpha;
 					varying float vAngle;
@@ -125,7 +129,7 @@ export class MVTGlyphMaterial extends PointsMaterial {
 
 						}
 
-						diffuseColor.a *= vAlpha;
+						diffuseColor.a *= vAlpha * opacity;
 						gl_FragColor = diffuseColor;
 
 						#include <tonemapping_fragment>
@@ -142,9 +146,13 @@ export class MVTGlyphMaterial extends PointsMaterial {
 
 	}
 
-	onBeforeRender() {
+	onBeforeRender( renderer ) {
 
 		this._glyphAtlas.getSlotSize( this._glyphCellSize );
+
+		// viewport size in pixels, refreshed each frame in onBeforeRender for screen-space raycasting
+		renderer.getViewport( _viewport );
+		this.resolution.set( _viewport.z, _viewport.w );
 
 	}
 

--- a/src/three/plugins/mvt/MVTGlyphs.d.ts
+++ b/src/three/plugins/mvt/MVTGlyphs.d.ts
@@ -1,14 +1,21 @@
-import { Points, Raycaster, Vector2 } from 'three';
+import { Group, Raycaster } from 'three';
 import { MVTGlyphMaterial } from './MVTGlyphMaterial.js';
 import { MVTGlyphAtlasTexture } from './MVTGlyphAtlasTexture.js';
 
-export class MVTGlyphs extends Points {
+export class MVTGlyphs extends Group {
+
+	static readonly DrawMode: {
+		OBSCURED: string;
+		DRAW_THROUGH: string;
+		OVERLAY: string;
+	};
 
 	size: number;
 	readonly glyphAtlas: MVTGlyphAtlasTexture;
-	resolution: Vector2;
 	fadeInDuration: number;
 	fadeOutDuration: number;
+	obscuredOpacity: number;
+	drawMode: string;
 
 	constructor( material: MVTGlyphMaterial );
 

--- a/src/three/plugins/mvt/MVTGlyphs.js
+++ b/src/three/plugins/mvt/MVTGlyphs.js
@@ -32,8 +32,11 @@ const DRAW_MODE = /* @__PURE__ */ Object.freeze( {
 export class MVTGlyphs extends Group {
 
 	/**
-	 * Draw modes for `drawMode`: `OBSCURED`, `DRAW_THROUGH`, and `OVERLAY`.
-	 * @type {{ OBSCURED: string, DRAW_THROUGH: string, OVERLAY: string }}
+	 * Draw modes for `drawMode`:
+	 * - `OBSCURED` – depth-tested, so glyphs are hidden where behind terrain.
+	 * - `DRAW_THROUGH` – visible parts drawn opaque, parts behind terrain ghosted on top.
+	 * - `OVERLAY` – always drawn on top of everything.
+	 * @type {{ OBSCURED: number, DRAW_THROUGH: number, OVERLAY: number }}
 	 */
 	static get DrawMode() {
 
@@ -70,7 +73,7 @@ export class MVTGlyphs extends Group {
 
 	/**
 	 * How glyphs interact with the depth buffer; one of `MVTGlyphs.DrawMode`.
-	 * @type {string}
+	 * @type {number}
 	 */
 	get drawMode() {
 

--- a/src/three/plugins/mvt/MVTGlyphs.js
+++ b/src/three/plugins/mvt/MVTGlyphs.js
@@ -28,7 +28,7 @@ const DRAW_MODE = /* @__PURE__ */ Object.freeze( {
 /**
  * Base object that renders a batch of glyphs from a shared `MVTGlyphAtlasTexture`, fading each item
  * in and out. Manages the geometry and two child draws sharing it: an opaque pass and a transparent
- * "obscured" pass, combined per `drawMode`.
+ * "draw through" pass, combined per `drawMode`.
  * @extends Group
  */
 export class MVTGlyphs extends Group {
@@ -56,7 +56,7 @@ export class MVTGlyphs extends Group {
 	set size( v ) {
 
 		this._opaque.material.size = v;
-		this._obscured.material.size = v;
+		this._drawThrough.material.size = v;
 
 	}
 
@@ -112,10 +112,10 @@ export class MVTGlyphs extends Group {
 		this.fadeOutDuration = 0.3;
 
 		/**
-		 * Opacity of the ghosted, obscured glyphs in the `DRAW_THROUGH` draw mode.
+		 * Opacity of the ghosted, drawThrough glyphs in the `DRAW_THROUGH` draw mode.
 		 * @type {number}
 		 */
-		this.obscuredOpacity = 0.5;
+		this.drawThroughOpacity = 0.5;
 
 		// Map<itemId, { item, fade: 0..1, state: 'in' | 'visible' | 'out' }> keyed by stable id,
 		// plus an insertion-ordered list of the same entries for stable geometry layout
@@ -128,25 +128,23 @@ export class MVTGlyphs extends Group {
 		const opaque = new Points( geometry, new MVTGlyphMaterial() );
 		opaque.frustumCulled = false;
 		opaque.renderOrder = 1000;
-		opaque.onAfterRender = ( renderer, scene, camera ) => {
+
+		const drawThrough = new Points( geometry, new MVTGlyphMaterial() );
+		drawThrough.frustumCulled = false;
+		drawThrough.material.glyphAtlas = opaque.material.glyphAtlas;
+		drawThrough.renderOrder = 1001;
+		drawThrough.onAfterRender = ( renderer, scene, camera ) => {
 
 			this._recenter( camera );
 
 		};
 
-		const obscured = new Points( geometry, new MVTGlyphMaterial() );
-		obscured.frustumCulled = false;
-		obscured.material.glyphAtlas = opaque.material.glyphAtlas;
-		obscured.material.depthTest = true;
-		obscured.material.depthFunc = GreaterDepth;
-		obscured.renderOrder = 1001;
-
 		// add the children
-		this.add( obscured, opaque );
+		this.add( drawThrough, opaque );
 
 		// store references, update draw mode
 		this._opaque = opaque;
-		this._obscured = obscured;
+		this._drawThrough = drawThrough;
 		this.drawMode = DRAW_MODE.OVERLAY;
 
 	}
@@ -160,7 +158,7 @@ export class MVTGlyphs extends Group {
 		this.glyphAtlas.dispose();
 		this.geometry.dispose();
 		this._opaque.material.dispose();
-		this._obscured.material.dispose();
+		this._drawThrough.material.dispose();
 
 	}
 
@@ -320,22 +318,23 @@ export class MVTGlyphs extends Group {
 	// configure the two child draws for the current draw mode
 	_applyDrawMode() {
 
-		const { _opaque, _obscured, obscuredOpacity, _drawMode } = this;
+		const { _opaque, _drawThrough, drawThroughOpacity, _drawMode } = this;
 		switch ( _drawMode ) {
 
 			case DRAW_MODE.OVERLAY:
 				_opaque.visible = true;
 				_opaque.material.depthTest = false;
 
-				_obscured.visible = false;
+				_drawThrough.visible = false;
 				break;
 
 			case DRAW_MODE.DRAW_THROUGH:
 				_opaque.visible = true;
 				_opaque.material.depthTest = true;
 
-				_obscured.visible = true;
-				_obscured.material.opacity = obscuredOpacity;
+				_drawThrough.visible = true;
+				_drawThrough.material.opacity = drawThroughOpacity;
+				_drawThrough.material.depthFunc = GreaterDepth;
 				break;
 
 			case DRAW_MODE.OBSCURED:
@@ -343,7 +342,7 @@ export class MVTGlyphs extends Group {
 				_opaque.visible = true;
 				_opaque.material.depthTest = true;
 
-				_obscured.visible = false;
+				_drawThrough.visible = false;
 				break;
 
 		}

--- a/src/three/plugins/mvt/MVTGlyphs.js
+++ b/src/three/plugins/mvt/MVTGlyphs.js
@@ -1,24 +1,45 @@
-/** @import { MVTGlyphAtlasTexture } from './MVTGlyphAtlasTexture.js' */
-/** @import { MVTGlyphMaterial } from './MVTGlyphMaterial.js' */
-import { BufferAttribute, BufferGeometry, Matrix4, Points, Vector2, Vector3, Vector4 } from 'three';
+/** @import { MVTGlyphAtlasTexture } from './MVTGlyphAtlasTexture.js'; */
+import { BufferAttribute, BufferGeometry, GreaterDepth, Group, Matrix4, Points, Vector2, Vector3, Vector4 } from 'three';
+import { MVTGlyphMaterial } from './MVTGlyphMaterial.js';
 
 const _mvMatrix = /* @__PURE__ */ new Matrix4();
 const _uvTarget = {};
 
 // scratch reused across raycasts
-const _viewport = /* @__PURE__ */ new Vector4();
 const _point4 = /* @__PURE__ */ new Vector4();
 const _ssOrigin = /* @__PURE__ */ new Vector4();
 const _ssRay = /* @__PURE__ */ new Vector2();
 const _ssPoint = /* @__PURE__ */ new Vector2();
 const _worldPoint = /* @__PURE__ */ new Vector3();
 
+const DRAW_MODE = /* @__PURE__ */ Object.freeze( {
+	// depth tested, hidden behind terrain
+	OBSCURED: 0,
+
+	// render hidden portions as partially transparent
+	DRAW_THROUGH: 1,
+
+	// draw full opaque on top of everything
+	OVERLAY: 2,
+} );
+
 /**
- * Base `Points` object that renders a batch of glyphs from a shared `MVTGlyphAtlasTexture`, fading
- * each item in and out.
- * @extends Points
+ * Base object that renders a batch of glyphs from a shared `MVTGlyphAtlasTexture`, fading each item
+ * in and out. Manages the geometry and two child draws sharing it: an opaque pass and a transparent
+ * "obscured" pass, combined per `drawMode`.
+ * @extends Group
  */
-export class MVTGlyphs extends Points {
+export class MVTGlyphs extends Group {
+
+	/**
+	 * Draw modes for `drawMode`: `OBSCURED`, `DRAW_THROUGH`, and `OVERLAY`.
+	 * @type {{ OBSCURED: string, DRAW_THROUGH: string, OVERLAY: string }}
+	 */
+	static get DrawMode() {
+
+		return DRAW_MODE;
+
+	}
 
 	/**
 	 * Glyph size in pixels.
@@ -26,38 +47,55 @@ export class MVTGlyphs extends Points {
 	 */
 	get size() {
 
-		return this.material.size;
+		return this._opaque.material.size;
 
 	}
 
 	set size( v ) {
 
-		this.material.size = v;
+		this._opaque.material.size = v;
+		this._obscured.material.size = v;
 
 	}
 
 	/**
-	 * The glyph atlas this object samples from.
+	 * The texture atlas used for rendering glyphs.
 	 * @type {MVTGlyphAtlasTexture}
 	 */
 	get glyphAtlas() {
 
-		return this.material.glyphAtlas;
+		return this._opaque.material.glyphAtlas;
 
 	}
 
 	/**
-	 * @param {MVTGlyphMaterial} material - Material used to draw the glyphs.
+	 * How glyphs interact with the depth buffer; one of `MVTGlyphs.DrawMode`.
+	 * @type {string}
 	 */
+	get drawMode() {
+
+		return this._drawMode;
+
+	}
+
+	set drawMode( mode ) {
+
+		this._drawMode = mode;
+		this._applyDrawMode();
+
+	}
+
+	get geometry() {
+
+		return this._opaque.geometry;
+
+	}
+
 	constructor( material ) {
 
-		super( new BufferGeometry(), material );
+		super();
 
-		this.renderOrder = 1000;
 		this.frustumCulled = false;
-
-		// viewport size in pixels, refreshed each frame in onBeforeRender for screen-space raycasting
-		this.resolution = new Vector2();
 
 		/**
 		 * Seconds a glyph takes to fade in.
@@ -71,23 +109,56 @@ export class MVTGlyphs extends Points {
 		 */
 		this.fadeOutDuration = 0.3;
 
+		/**
+		 * Opacity of the ghosted, obscured glyphs in the `DRAW_THROUGH` draw mode.
+		 * @type {number}
+		 */
+		this.obscuredOpacity = 0.5;
+
 		// Map<itemId, { item, fade: 0..1, state: 'in' | 'visible' | 'out' }> keyed by stable id,
 		// plus an insertion-ordered list of the same entries for stable geometry layout
 		this._entryMap = new Map();
 		this._orderedEntries = [];
 		this._lastUpdateTime = - 1;
 
+		// create children for draw through
+		const geometry = new BufferGeometry();
+		const opaque = new Points( geometry, new MVTGlyphMaterial() );
+		opaque.frustumCulled = false;
+		opaque.renderOrder = 1000;
+		opaque.onAfterRender = ( renderer, scene, camera ) => {
+
+			this._recenter( camera );
+
+		};
+
+		const obscured = new Points( geometry, new MVTGlyphMaterial() );
+		obscured.frustumCulled = false;
+		obscured.material.glyphAtlas = opaque.material.glyphAtlas;
+		obscured.material.depthTest = true;
+		obscured.material.depthFunc = GreaterDepth;
+		obscured.renderOrder = 1001;
+
+		// add the children
+		this.add( obscured, opaque );
+
+		// store references, update draw mode
+		this._opaque = opaque;
+		this._obscured = obscured;
+		this.drawMode = DRAW_MODE.OVERLAY;
+
 	}
 
 	/**
-	 * Disposes the glyph atlas, geometry, and material.
+	 * Disposes the glyph atlas, geometry, and materials.
 	 * @returns {void}
 	 */
 	dispose() {
 
 		this.glyphAtlas.dispose();
 		this.geometry.dispose();
-		this.material.dispose();
+		this._opaque.material.dispose();
+		this._obscured.material.dispose();
 
 	}
 
@@ -173,21 +244,14 @@ export class MVTGlyphs extends Points {
 
 	}
 
-	onBeforeRender( renderer, scene, camera ) {
-
-		// use the active viewport (not getDrawingBufferSize) so raycasting matches the GPU's
-		// NDC→pixel mapping in sub-viewport scenarios
-		renderer.getViewport( _viewport );
-		this.resolution.set( _viewport.z, _viewport.w );
-
-	}
-
 	raycast( raycaster, intersects ) {
 
 		const camera = raycaster.camera;
 		if ( ! camera ) return;
 
-		const { geometry, material, matrixWorld, resolution } = this;
+		const { geometry, matrixWorld } = this;
+		const { material } = this._opaque;
+		const { resolution } = material;
 		const posAttr = geometry.getAttribute( 'position' );
 		if ( ! posAttr || posAttr.count === 0 ) return;
 
@@ -206,7 +270,7 @@ export class MVTGlyphs extends Points {
 
 		_mvMatrix.multiplyMatrices( camera.matrixWorldInverse, matrixWorld );
 
-		for ( let i = 0, l = this.geometry.drawRange.count; i < l; i ++ ) {
+		for ( let i = 0, l = geometry.drawRange.count; i < l; i ++ ) {
 
 			_point4.fromBufferAttribute( posAttr, i );
 			_point4.w = 1;
@@ -246,11 +310,47 @@ export class MVTGlyphs extends Points {
 
 		}
 
+		// end traversal
+		return false;
+
 	}
 
-	onAfterRender( renderer, scene, camera ) {
+	// configure the two child draws for the current draw mode
+	_applyDrawMode() {
 
-		// keep the root near the camera to avoid gpu jitter at globe scale
+		const { _opaque, _obscured, obscuredOpacity, _drawMode } = this;
+		switch ( _drawMode ) {
+
+			case DRAW_MODE.OVERLAY:
+				_opaque.visible = true;
+				_opaque.material.depthTest = false;
+
+				_obscured.visible = false;
+				break;
+
+			case DRAW_MODE.DRAW_THROUGH:
+				_opaque.visible = true;
+				_opaque.material.depthTest = true;
+
+				_obscured.visible = true;
+				_obscured.material.opacity = obscuredOpacity;
+				break;
+
+			case DRAW_MODE.OBSCURED:
+			default:
+				_opaque.visible = true;
+				_opaque.material.depthTest = true;
+
+				_obscured.visible = false;
+				break;
+
+		}
+
+	}
+
+	// keep the root near the camera to avoid gpu jitter at globe scale
+	_recenter( camera ) {
+
 		const { parent } = this;
 		if ( parent ) {
 

--- a/src/three/plugins/mvt/MVTGlyphs.js
+++ b/src/three/plugins/mvt/MVTGlyphs.js
@@ -12,14 +12,16 @@ const _ssRay = /* @__PURE__ */ new Vector2();
 const _ssPoint = /* @__PURE__ */ new Vector2();
 const _worldPoint = /* @__PURE__ */ new Vector3();
 
+/**
+ * @typedef {Object} MVTDrawModeEnum
+ * @property {number} OBSCURED - Depth-tested, so glyphs are hidden where behind terrain.
+ * @property {number} DRAW_THROUGH - Visible parts drawn opaque, parts behind terrain ghosted on top.
+ * @property {number} OVERLAY - Always drawn on top of everything.
+ */
+
 const DRAW_MODE = /* @__PURE__ */ Object.freeze( {
-	// depth tested, hidden behind terrain
 	OBSCURED: 0,
-
-	// render hidden portions as partially transparent
 	DRAW_THROUGH: 1,
-
-	// draw full opaque on top of everything
 	OVERLAY: 2,
 } );
 
@@ -32,11 +34,8 @@ const DRAW_MODE = /* @__PURE__ */ Object.freeze( {
 export class MVTGlyphs extends Group {
 
 	/**
-	 * Draw modes for `drawMode`:
-	 * - `OBSCURED` – depth-tested, so glyphs are hidden where behind terrain.
-	 * - `DRAW_THROUGH` – visible parts drawn opaque, parts behind terrain ghosted on top.
-	 * - `OVERLAY` – always drawn on top of everything.
-	 * @type {{ OBSCURED: number, DRAW_THROUGH: number, OVERLAY: number }}
+	 * The draw modes assignable to `drawMode`.
+	 * @type {MVTDrawModeEnum}
 	 */
 	static get DrawMode() {
 

--- a/src/three/plugins/mvt/MVTIconGlyphs.js
+++ b/src/three/plugins/mvt/MVTIconGlyphs.js
@@ -1,4 +1,3 @@
-import { MVTGlyphMaterial } from './MVTGlyphMaterial.js';
 import { MVTGlyphs } from './MVTGlyphs.js';
 
 /**
@@ -28,7 +27,7 @@ export class MVTIconGlyphs extends MVTGlyphs {
 			slotCount = 64,
 		} = options;
 
-		super( new MVTGlyphMaterial() );
+		super();
 
 		/**
 		 * Returns the atlas key for a given item, or null for none.

--- a/src/three/plugins/mvt/MVTIconGlyphs.js
+++ b/src/three/plugins/mvt/MVTIconGlyphs.js
@@ -1,6 +1,13 @@
 import { MVTGlyphs } from './MVTGlyphs.js';
 
 /**
+ * @callback MVTGetKindCallback
+ * @param {string} layer - The MVT layer the feature belongs to.
+ * @param {Object} properties - The feature's property map.
+ * @returns {string|null} The atlas key to draw, or null to use `fallback`.
+ */
+
+/**
  * Renders one icon glyph per point annotation. Each item's atlas key comes from `getKind`, or
  * `fallback` when that key isn't in the atlas.
  * @extends MVTGlyphs
@@ -9,8 +16,7 @@ export class MVTIconGlyphs extends MVTGlyphs {
 
 	/**
 	 * @param {Object} [options]
-	 * @param {( layer: string, properties: Object ) => ( string | null )} [options.getKind] - Returns
-	 * the atlas key for an item, or null.
+	 * @param {MVTGetKindCallback} [options.getKind] - Chooses the atlas key to draw for each point.
 	 * @param {string|null} [options.fallback=null] - Atlas key drawn when `getKind`'s result is
 	 * missing from the atlas; null draws nothing.
 	 * @param {number} [options.size=18] - Glyph size in pixels.
@@ -30,8 +36,8 @@ export class MVTIconGlyphs extends MVTGlyphs {
 		super();
 
 		/**
-		 * Returns the atlas key for a given item, or null for none.
-		 * @type {( layer: string, properties: Object ) => ( string | null )}
+		 * Chooses the atlas key to draw for each point.
+		 * @type {MVTGetKindCallback}
 		 */
 		this.getKind = getKind;
 

--- a/src/three/plugins/mvt/MVTLabelGlyphs.js
+++ b/src/three/plugins/mvt/MVTLabelGlyphs.js
@@ -1,4 +1,3 @@
-import { MVTGlyphMaterial } from './MVTGlyphMaterial.js';
 import { MVTGlyphs } from './MVTGlyphs.js';
 
 /**
@@ -31,7 +30,7 @@ export class MVTLabelGlyphs extends MVTGlyphs {
 			strokeWidth = 0,
 		} = options;
 
-		super( new MVTGlyphMaterial( { size } ) );
+		super();
 
 		// CSS font used to rasterize glyphs, sized to fit the atlas slot
 		const fontSize = Math.round( glyphSize * 0.7 );
@@ -51,6 +50,7 @@ export class MVTLabelGlyphs extends MVTGlyphs {
 		this._needed = new Set();
 
 		this.glyphAtlas.resize( slotCount, glyphSize );
+		this.size = size;
 
 	}
 
@@ -61,10 +61,10 @@ export class MVTLabelGlyphs extends MVTGlyphs {
 	 */
 	measureChar( char ) {
 
-		const { _advanceCache, material, glyphAtlas, _font } = this;
+		const { _advanceCache, glyphAtlas, _font } = this;
 		if ( ! _advanceCache.has( char ) ) {
 
-			const multiplier = material.size / glyphAtlas.slotSize;
+			const multiplier = this.size / glyphAtlas.slotSize;
 			const info = glyphAtlas.measureChar( char, _font );
 			const advance = info.width + 2;
 


### PR DESCRIPTION
Related to #1600 

Add an option for partially transparent glyph draw through.

**TODO**
- Fix JSDoc