### PR TITLE
MVTAnnotationsPlugin: Add level of detail toggle

### DIFF
--- a/example/three/annotationsExample.js
+++ b/example/three/annotationsExample.js
@@ -17,7 +17,7 @@ import {
 	MVTLabelGlyphs,
 	UpdateOnChangePlugin,
 } from '3d-tiles-renderer/plugins';
-import { LoadRegionPlugin } from '3d-tiles-renderer/three/plugins';
+import { LoadRegionPlugin } from '3d-tiles-renderer/plugins';
 import { CameraCartographicRegion } from './src/plugins/CameraCartographicRegion.js';
 import {
 	Scene,
@@ -254,20 +254,9 @@ class ExampleAnnotationsDriver extends MVTAnnotationsDriver {
 init();
 animate();
 
-function reinstantiateTiles() {
+function initTiles() {
 
-	if ( tiles ) {
-
-		scene.remove( tiles.group );
-		tiles.dispose();
-		tiles = null;
-
-	}
-
-	const overlay = new PMTilesOverlay( {
-		url: 'https://data.source.coop/protomaps/openstreetmap/v4.pmtiles',
-	} );
-
+	// instantiate the tiles renderer
 	tiles = new TilesRenderer();
 	tiles.registerPlugin( new UpdateOnChangePlugin() );
 	tiles.registerPlugin( new CesiumIonAuthPlugin( { apiToken: import.meta.env.VITE_ION_KEY, assetId: '2275207', autoRefreshToken: true } ) );
@@ -276,34 +265,49 @@ function reinstantiateTiles() {
 	} ) );
 	tiles.registerPlugin( new TilesFadePlugin() );
 	tiles.registerPlugin( new MeshBVHPlugin() );
+
+	//
+
+	// Create the overlay referencing the data to load for annotations
+	// Note: The source coop link can be very slow to load so it's recommended to load the data locally
+	// or host it on a faster server.
+	const overlay = new PMTilesOverlay( {
+		// url: new URL( '../local-data/v4.pmtiles', import.meta.url ).toString(),
+		url: 'https://data.source.coop/protomaps/openstreetmap/v4.pmtiles',
+	} );
+
+	// create the driver for rendering labels, icons
 	driver = new ExampleAnnotationsDriver();
-	driver.language = params.language;
-	driver.annotationPoints.drawMode = params.drawMode;
-	driver.characterPoints.drawMode = params.drawMode;
 	tiles.registerPlugin( new MVTAnnotationsPlugin( {
 		overlay,
 		camera,
 		driver,
 	} ) );
 
+	//
+
 	// use the camera cartographic region plugin to prevent particularly low-lod
 	// tiles from loading beneath the camera, causing navigation issues.
-	const cameraRegion = new CameraCartographicRegion( {
-		camera,
-		radius: 1500,
-		errorTarget: 5000,
-	} );
-
 	tiles.registerPlugin( new LoadRegionPlugin( {
-		regions: [ cameraRegion ],
+		regions: [
+			new CameraCartographicRegion( {
+				camera,
+				radius: 1500,
+				errorTarget: 5000,
+			} ),
+		],
 	} ) );
 
+	//
+
+	// initialize
 	tiles.group.rotation.x = - Math.PI / 2;
 	scene.add( tiles.group );
 
 	tiles.setResolutionFromRenderer( camera, renderer );
 	tiles.setCamera( camera );
 
+	// controls
 	controls.setEllipsoid( tiles.ellipsoid, tiles.group );
 
 }
@@ -328,7 +332,7 @@ function init() {
 	controls.flightSpeed = 0.25;
 	controls.maxAltitude = Math.PI / 2;
 
-	reinstantiateTiles();
+	initTiles();
 
 	// Zaragoza, Spain
 	tiles.group.updateMatrixWorld();
@@ -340,6 +344,7 @@ function init() {
 	camera.matrixWorld.premultiply( tiles.group.matrixWorld );
 	camera.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
 
+	// resize
 	onWindowResize();
 	window.addEventListener( 'resize', onWindowResize );
 	renderer.domElement.addEventListener( 'pointermove', onPointerMove );
@@ -396,6 +401,7 @@ function init() {
 
 function onPointerMove( e ) {
 
+	// pointer for highlighting tooltips
 	const rect = renderer.domElement.getBoundingClientRect();
 	pointer.x = ( ( e.clientX - rect.left ) / rect.width ) * 2 - 1;
 	pointer.y = - ( ( e.clientY - rect.top ) / rect.height ) * 2 + 1;
@@ -408,16 +414,32 @@ function onPointerMove( e ) {
 
 function updateTooltip() {
 
+	// run raycast, update tooltip display
 	raycaster.setFromCamera( pointer, camera );
 
 	const hits = raycaster.intersectObject( driver.annotationPoints );
 	if ( hits.length > 0 ) {
 
+		// display the name of the hovered icon
 		const { properties } = hits[ 0 ];
 		if ( properties ) {
 
-			tooltip.textContent = properties.name || properties[ 'name:en' ] || `${ properties.kind.replace( '_', ' ' ) } (unnamed)`;
+			// get the name based on the properties and language
+			let text;
+			if ( params.language === 'default' ) {
+
+				text = properties.name;
+
+			} else {
+
+				text = properties[ `name:${ params.language }` ] || properties.name;
+
+			}
+
+			tooltip.textContent = text || `${ properties.kind.replace( '_', ' ' ) } (unnamed)`;
 			tooltip.style.display = 'block';
+
+			// position
 			const x = Math.min( Math.max( lastClientX - tooltip.offsetWidth / 2, 4 ), window.innerWidth - tooltip.offsetWidth - 4 );
 			const y = Math.max( lastClientY - tooltip.offsetHeight - 10, 4 );
 			tooltip.style.left = x + 'px';

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1183,11 +1183,13 @@ constructor(
 
 		// Supplies the annotation callbacks: feature filtering,
 		// placement priority, per-character sizing, and render
-		// updates.
+		// updates. Cannot be changed once initialized.
 		driver?: MVTAnnotationsDriver,
 
 		// Target resolution used when selecting the vector tile level
-		// to load. Lower values load coarser tiles with fewer
+		// to load. This is equivalent to "resolution" value in
+		// ImageOverlayPlugin used to drive loaded levels of detail for
+		// the overlays. Lower values load coarser tiles with fewer
 		// annotations, independently of the shared overlay's own
 		// resolution. Set to null to use the overlay resolution.
 		// Cannot be changed once initialized.

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1061,7 +1061,10 @@ Disposes all textures used by this instance.
 
 Bundles the callbacks the "MVTAnnotationsPlugin" needs into a single object. Subclass and override
 the methods to customize which features become annotations, their placement priority, per-character
-sizing, the displayed text, and how visibility changes are rendered.
+sizing, the displayed text, and how visibility changes are rendered. By default all points of interest
+are rendered as circles and labels are rendered as white text with a black outline. Custom implementations
+can be used for more sophisticated text rendering, variable font weights based on properties, and custom
+icons.
 
 
 ### .needsUpdate

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1131,13 +1131,24 @@ Whether a parsed annotation should currently be displayed. Unlike `filterAnnotat
 decides what is parsed once.
 
 
-### .onAnnotationsUpdate
+### .onPointsUpdate
 
 ```js
-onAnnotationsUpdate( added: Set, removed: Set ): void
+onPointsUpdate( added: Array<Object>, removed: Array<Object> ): void
 ```
 
-Called each frame with the annotations whose visibility changed, for the caller to render.
+Called each frame with the point ( PoI ) annotations whose visibility changed, for the caller
+to render.
+
+
+### .onLabelsUpdate
+
+```js
+onLabelsUpdate( added: Array<Object>, removed: Array<Object> ): void
+```
+
+Called each frame with the line / label annotations whose visibility changed, for the caller
+to render.
 
 
 ### .dispose
@@ -1154,7 +1165,8 @@ the plugin from its own `dispose`.
 
 Plugin that extracts point features from an MVT overlay and manages their screen-space
 occupation, preventing label crowding via a hierarchical lock system and raycasted depth
-placement. Rendering is left entirely to the caller via the driver's `onAnnotationsUpdate`.
+placement. Rendering is left entirely to the caller via the driver's `onPointsUpdate` /
+`onLabelsUpdate`.
 
 
 ### .constructor
@@ -1173,6 +1185,13 @@ constructor(
 		// placement priority, per-character sizing, and render
 		// updates.
 		driver?: MVTAnnotationsDriver,
+
+		// Target resolution used when selecting the vector tile level
+		// to load. Lower values load coarser tiles with fewer
+		// annotations, independently of the shared overlay's own
+		// resolution. Set to null to use the overlay resolution.
+		// Cannot be changed once initialized.
+		resolution = 50: number | null,
 	}
 )
 ```
@@ -1217,6 +1236,15 @@ Returns the number of icons currently used.
 ```js
 constructor( slotCount = 32: number, slotSize = 64: number )
 ```
+
+### .keys
+
+```js
+keys(): void
+```
+
+Returns the keys associated with all glyphs.
+
 
 ### .has
 
@@ -1541,6 +1569,15 @@ constructor(
 	}
 )
 ```
+
+### .reset
+
+```js
+reset(): void
+```
+
+Resets the cached glyphs content. Used when changing fonts or styles.
+
 
 ### .measureChar
 

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1106,7 +1106,7 @@ contract. Lower values sort first, are placed first, and win collisions.
 ### .measureChar
 
 ```js
-measureChar( char: string ): number
+measureChar( char: string, layer: layer, properties: Object ): number
 ```
 
 Advance width of a single character, in pixels, used to space glyphs along text labels.
@@ -1310,6 +1310,16 @@ drawChar(
 ```
 
 Renders a single character in the slot, centered on its text metrics bounding box.
+
+
+### .measureChar
+
+```js
+measureChar( char: string, font: string ): TextMetrics
+```
+
+Function that returns a text metrics object for the given character rendered with
+the provided set of styles.
 
 
 ### .drawImage

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1600,14 +1600,21 @@ export class TiledImageOverlay extends ImageOverlay {
 	}
 
 	// Texture acquisition API implementations
-	calculateLevel( range ) {
+	calculateLevel( range, resolution = null ) {
 
 		const [ minX, minY, maxX, maxY ] = range;
 		const w = maxX - minX;
 		const h = maxY - minY;
 
+		// callers can provide their own target resolution to select a different level than the
+		// one used for drawing the overlay textures
+		if ( resolution === null ) {
+
+			resolution = this.regionImageSource.resolution;
+
+		}
+
 		let level = 0;
-		const resolution = this.regionImageSource.resolution;
 		const maxLevel = this.tiling.maxLevel;
 		for ( ; level < maxLevel; level ++ ) {
 

--- a/src/three/plugins/images/MVTOverlay.js
+++ b/src/three/plugins/images/MVTOverlay.js
@@ -54,6 +54,12 @@ export class MVTOverlay extends ImageOverlay {
 
 	}
 
+	get resolution() {
+
+		return this.imageSource.resolution;
+
+	}
+
 	constructor( options = {} ) {
 
 		super( options );
@@ -72,12 +78,14 @@ export class MVTOverlay extends ImageOverlay {
 
 	}
 
-	calculateLevel( range ) {
+	// the MVTOverlay provides an optional resolution argument so that
+	// MVTAnnotationsPlugin can adjust it to prevent large amounts of
+	// annotations from loading.
+	calculateLevel( range, resolution = this.resolution ) {
 
 		const [ minX, minY, maxX, maxY ] = range;
 		const w = maxX - minX;
 		const h = maxY - minY;
-		const resolution = this.imageSource.resolution;
 		const maxLevel = this.tiling.maxLevel;
 
 		let level = 0;

--- a/src/three/plugins/images/MVTOverlay.js
+++ b/src/three/plugins/images/MVTOverlay.js
@@ -111,27 +111,27 @@ export class MVTOverlay extends ImageOverlay {
 
 	}
 
-	hasContent( range ) {
+	hasContent( range, level = this.calculateLevel( range ) ) {
 
-		return this.imageSource.hasContent( ...range, this.calculateLevel( range ) );
-
-	}
-
-	getTexture( range ) {
-
-		return this.imageSource.get( ...range, this.calculateLevel( range ) );
+		return this.imageSource.hasContent( ...range, level );
 
 	}
 
-	lockTexture( range ) {
+	getTexture( range, level = this.calculateLevel( range ) ) {
 
-		return this.imageSource.lock( ...range, this.calculateLevel( range ) );
+		return this.imageSource.get( ...range, level );
 
 	}
 
-	releaseTexture( range ) {
+	lockTexture( range, level = this.calculateLevel( range ) ) {
 
-		this.imageSource.release( ...range, this.calculateLevel( range ) );
+		return this.imageSource.lock( ...range, level );
+
+	}
+
+	releaseTexture( range, level = this.calculateLevel( range ) ) {
+
+		this.imageSource.release( ...range, level );
 
 	}
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
@@ -29,6 +29,7 @@ export interface MVTAnnotationsPluginOptions {
 	overlay: object;
 	camera?: Camera | null;
 	driver?: MVTAnnotationsDriver;
+	resolution?: number | null;
 
 }
 
@@ -40,6 +41,7 @@ export class MVTAnnotationsPlugin {
 	overlay: object;
 	camera: Camera | null;
 	driver: MVTAnnotationsDriver;
+	resolution: number | null;
 
 	readonly contentCache: object;
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
@@ -41,7 +41,7 @@ export class MVTAnnotationsPlugin {
 	overlay: object;
 	camera: Camera | null;
 	driver: MVTAnnotationsDriver;
-	resolution: number | null;
+	resolution: number;
 
 	readonly contentCache: object;
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
@@ -29,7 +29,7 @@ export interface MVTAnnotationsPluginOptions {
 	overlay: object;
 	camera?: Camera | null;
 	driver?: MVTAnnotationsDriver;
-	resolution?: number | null;
+	resolution?: number;
 
 }
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -272,11 +272,13 @@ export class DefaultMVTAnnotationsDriver extends MVTAnnotationsDriver {
  * content is parsed for point features.
  * @param {Camera} [options.camera=null] - Initial camera. Can be updated with `setCamera()`.
  * @param {MVTAnnotationsDriver} [options.driver] - Supplies the annotation callbacks: feature
- * filtering, placement priority, per-character sizing, and render updates.
+ * filtering, placement priority, per-character sizing, and render updates. Cannot be changed
+ * once initialized.
  * @param {number|null} [options.resolution=50] - Target resolution used when selecting the
- * vector tile level to load. Lower values load coarser tiles with fewer annotations, independently
- * of the shared overlay's own resolution. Set to null to use the overlay resolution. Cannot be
- * changed once initialized.
+ * vector tile level to load. This is equivalent to "resolution" value in ImageOverlayPlugin
+ * used to drive loaded levels of detail for the overlays. Lower values load coarser tiles with
+ * fewer annotations, independently of the shared overlay's own resolution. Set to null to use
+ * the overlay resolution. Cannot be changed once initialized.
  */
 export class MVTAnnotationsPlugin {
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -45,7 +45,10 @@ function collectMeshes( object ) {
 /**
  * Bundles the callbacks the "MVTAnnotationsPlugin" needs into a single object. Subclass and override
  * the methods to customize which features become annotations, their placement priority, per-character
- * sizing, the displayed text, and how visibility changes are rendered.
+ * sizing, the displayed text, and how visibility changes are rendered. By default all points of interest
+ * are rendered as circles and labels are rendered as white text with a black outline. Custom implementations
+ * can be used for more sophisticated text rendering, variable font weights based on properties, and custom
+ * icons.
  */
 export class MVTAnnotationsDriver {
 
@@ -196,8 +199,7 @@ function splitAnnotations( set ) {
  * Ready-to-use driver so `new MVTAnnotationsPlugin( { overlay } )` displays something without any
  * setup. Every point feature is drawn as a filled white circle and every named line as white,
  * black-outlined Arial text. No feature filtering is applied. Supply a custom `MVTAnnotationsDriver`
- * to the plugin to override this behavior. Custom implementations can be used for more sophisticated
- * text rendering, custom we
+ * to the plugin to override this behavior.
  * @private
  * @extends MVTAnnotationsDriver
  */

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -273,46 +273,16 @@ export class DefaultMVTAnnotationsDriver extends MVTAnnotationsDriver {
  * @param {Camera} [options.camera=null] - Initial camera. Can be updated with `setCamera()`.
  * @param {MVTAnnotationsDriver} [options.driver] - Supplies the annotation callbacks: feature
  * filtering, placement priority, per-character sizing, and render updates.
- * @param {number|null} [options.resolution=null] - Target resolution used when selecting the
+ * @param {number|null} [options.resolution=50] - Target resolution used when selecting the
  * vector tile level to load. Lower values load coarser tiles with fewer annotations, independently
- * of the shared overlay's own resolution. Defaults to the overlay resolution when null.
+ * of the shared overlay's own resolution. Set to null to use the overlay resolution. Cannot be
+ * changed once initialized.
  */
 export class MVTAnnotationsPlugin {
 
 	get contentCache() {
 
 		return this.overlay.imageSource._contentCache;
-
-	}
-
-	get resolution() {
-
-		return this._resolution;
-
-	}
-
-	set resolution( v ) {
-
-		if ( v !== this._resolution ) {
-
-			const { tiles } = this;
-			tiles.visibleTiles.forEach( tile => {
-
-				this._markVectorTile( tile, false );
-
-			} );
-
-			this._resolution = v;
-
-			tiles.visibleTiles.forEach( tile => {
-
-				this._markVectorTile( tile, true );
-
-			} );
-
-		}
-
-
 
 	}
 
@@ -326,14 +296,14 @@ export class MVTAnnotationsPlugin {
 			overlay,
 			camera = null,
 			driver = new DefaultMVTAnnotationsDriver(),
-			resolution = null,
+			resolution = 50,
 		} = options;
 
 		// user settings
 		this.overlay = overlay;
 		this.camera = camera;
 		this.driver = driver;
-		this._resolution = resolution;
+		this.resolution = resolution;
 
 		// annotations call these live each frame so driver changes take effect immediately
 		this._measureChar = char => this.driver.measureChar( char );

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -285,6 +285,37 @@ export class MVTAnnotationsPlugin {
 
 	}
 
+	get resolution() {
+
+		return this._resolution;
+
+	}
+
+	set resolution( v ) {
+
+		if ( v !== this._resolution ) {
+
+			const { tiles } = this;
+			tiles.visibleTiles.forEach( tile => {
+
+				this._markVectorTile( tile, false );
+
+			} );
+
+			this._resolution = v;
+
+			tiles.visibleTiles.forEach( tile => {
+
+				this._markVectorTile( tile, true );
+
+			} );
+
+		}
+
+
+
+	}
+
 	constructor( options = {} ) {
 
 		// plugin fields
@@ -302,7 +333,7 @@ export class MVTAnnotationsPlugin {
 		this.overlay = overlay;
 		this.camera = camera;
 		this.driver = driver;
-		this.resolution = resolution;
+		this._resolution = resolution;
 
 		// annotations call these live each frame so driver changes take effect immediately
 		this._measureChar = char => this.driver.measureChar( char );

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -273,6 +273,9 @@ export class DefaultMVTAnnotationsDriver extends MVTAnnotationsDriver {
  * @param {Camera} [options.camera=null] - Initial camera. Can be updated with `setCamera()`.
  * @param {MVTAnnotationsDriver} [options.driver] - Supplies the annotation callbacks: feature
  * filtering, placement priority, per-character sizing, and render updates.
+ * @param {number|null} [options.resolution=null] - Target resolution used when selecting the
+ * vector tile level to load. Lower values load coarser tiles with fewer annotations, independently
+ * of the shared overlay's own resolution. Defaults to the overlay resolution when null.
  */
 export class MVTAnnotationsPlugin {
 
@@ -292,12 +295,14 @@ export class MVTAnnotationsPlugin {
 			overlay,
 			camera = null,
 			driver = new DefaultMVTAnnotationsDriver(),
+			resolution = null,
 		} = options;
 
 		// user settings
 		this.overlay = overlay;
 		this.camera = camera;
 		this.driver = driver;
+		this.resolution = resolution;
 
 		// annotations call these live each frame so driver changes take effect immediately
 		this._measureChar = char => this.driver.measureChar( char );
@@ -713,9 +718,9 @@ export class MVTAnnotationsPlugin {
 	_forEachTileInBounds( range, callback ) {
 
 		// iterate over every mvt tile in the overlay
-		const { overlay } = this;
+		const { overlay, resolution } = this;
 		const { tiling } = overlay;
-		const level = overlay.calculateLevel( range );
+		const level = overlay.calculateLevel( range, resolution );
 
 		if ( ! overlay.isReady ) {
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -108,9 +108,11 @@ export class MVTAnnotationsDriver {
 	/**
 	 * Advance width of a single character, in pixels, used to space glyphs along text labels.
 	 * @param {string} char - The character to measure.
+	 * @param {layer} layer - The layer associated with the text.
+	 * @param {Object} properties - The properties associated with the text.
 	 * @returns {number} The advance width in pixels.
 	 */
-	measureChar( char ) {
+	measureChar( char, layer, properties ) {
 
 		return 1;
 
@@ -194,7 +196,8 @@ function splitAnnotations( set ) {
  * Ready-to-use driver so `new MVTAnnotationsPlugin( { overlay } )` displays something without any
  * setup. Every point feature is drawn as a filled white circle and every named line as white,
  * black-outlined Arial text. No feature filtering is applied. Supply a custom `MVTAnnotationsDriver`
- * to the plugin to override this behavior.
+ * to the plugin to override this behavior. Custom implementations can be used for more sophisticated
+ * text rendering, custom we
  * @private
  * @extends MVTAnnotationsDriver
  */
@@ -235,7 +238,7 @@ export class DefaultMVTAnnotationsDriver extends MVTAnnotationsDriver {
 
 	}
 
-	measureChar( char ) {
+	measureChar( char, layer, properties ) {
 
 		return this.labels.measureChar( char );
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -662,9 +662,10 @@ export class MVTAnnotationsPlugin {
 		tiles.removeEventListener( 'tile-visibility-change', this._onVisibilityChange );
 		tiles.removeEventListener( 'dispose-model', this._onDisposeModel );
 
-		tileLoadState.forEach( ( info, tile ) => {
+		// visible tiles are the ones currently marked in the hierarchy
+		tileLoadState.forEach( ( range, tile ) => {
 
-			if ( info.active ) {
+			if ( tiles.visibleTiles.has( tile ) ) {
 
 				this._markVectorTile( tile, false );
 
@@ -692,10 +693,7 @@ export class MVTAnnotationsPlugin {
 		const { range } = getMeshesCartographicRange( meshes, tiles.ellipsoid, _matrix, overlay.projection );
 
 		// TODO: why not process here?
-		this.tileLoadState.set( tile, {
-			range,
-			active: false,
-		} );
+		this.tileLoadState.set( tile, range );
 
 	}
 
@@ -703,13 +701,8 @@ export class MVTAnnotationsPlugin {
 
 	_markVectorTile( tile, state ) {
 
-		const { tileLoadState } = this;
-		const info = tileLoadState.get( tile );
-
-		// TODO: is this "active" state needed? It should be trackable via visibility but it seems to be
-		// causing some issues.
-		info.active = state;
-		this._forEachTileInBounds( info.range, ( x, y, l ) => {
+		const range = this.tileLoadState.get( tile );
+		this._forEachTileInBounds( range, ( x, y, l ) => {
 
 			this.hierarchy.setTargetState( x, y, l, state );
 

--- a/src/three/plugins/mvt/MVTGlyphAtlasTexture.js
+++ b/src/three/plugins/mvt/MVTGlyphAtlasTexture.js
@@ -180,6 +180,13 @@ export class MVTGlyphAtlasTexture extends CanvasTexture {
 
 	}
 
+	/**
+	 * Function that returns a text metrics object for the given character rendered with
+	 * the provided set of styles.
+	 * @param {string} char
+	 * @param {string} font
+	 * @returns {TextMetrics}
+	 */
 	measureChar( char, font ) {
 
 		const { ctx } = this;

--- a/src/three/plugins/mvt/annotations/LineAnnotation.js
+++ b/src/three/plugins/mvt/annotations/LineAnnotation.js
@@ -139,8 +139,10 @@ export class LineAnnotation extends OccupancyAnnotation {
 
 		}
 
+		// compute the radius as the full width of M to add some
+		// margin around the labels
 		this.totalTextWidth = total;
-		this.characterRadius = measureChar( 'M' ) / 2;
+		this.characterRadius = measureChar( 'M' );
 
 	}
 

--- a/src/three/plugins/mvt/annotations/LineAnnotation.js
+++ b/src/three/plugins/mvt/annotations/LineAnnotation.js
@@ -128,12 +128,12 @@ export class LineAnnotation extends OccupancyAnnotation {
 
 	updateCharacterWidthCache( measureChar ) {
 
-		const { text, characterWidths } = this;
+		const { text, characterWidths, properties, layer } = this;
 		characterWidths.length = text.length;
 		let total = 0;
 		for ( let i = 0, l = text.length; i < l; i ++ ) {
 
-			const width = measureChar( text[ i ] );
+			const width = measureChar( text[ i ], layer, properties );
 			characterWidths[ i ] = width;
 			total += width;
 
@@ -142,7 +142,7 @@ export class LineAnnotation extends OccupancyAnnotation {
 		// compute the radius as the full width of M to add some
 		// margin around the labels
 		this.totalTextWidth = total;
-		this.characterRadius = measureChar( 'M' );
+		this.characterRadius = measureChar( 'M', layer, properties );
 
 	}
 


### PR DESCRIPTION
Related to #1600
Fix #1658 

- Remove unnecessary "active" flag
- Expose a flag for adjusting the annotation level of detail
- Add missing arguments for MVTOverlay
- Update docs