### PR TITLE
TilesRendererBase: Export default shared cache and queues

### DIFF
--- a/src/core/renderer/tiles/TilesRendererBase.d.ts
+++ b/src/core/renderer/tiles/TilesRendererBase.d.ts
@@ -3,6 +3,11 @@ import { PriorityQueue } from '../utilities/PriorityQueue.js';
 import { Tile } from './Tile.js';
 import { Tileset } from './Tileset.js';
 
+export const DEFAULT_LRU_CACHE : LRUCache;
+export const DEFAULT_DOWNLOAD_QUEUE : PriorityQueue;
+export const DEFAULT_PARSE_QUEUE : PriorityQueue;
+export const DEFAULT_NODE_QUEUE : PriorityQueue;
+
 // Events dispatched by TilesRendererBase, available across all renderer implementations.
 export interface TilesRendererBaseEventMap<TScene = unknown> {
 	'needs-update': {};

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -326,18 +326,18 @@ export const unifiedPriorityCallback = ( a, b ) => {
  */
 
 // Default shared caches and queues
-const DEFAULT_LRU_CACHE = new LRUCache();
+export const DEFAULT_LRU_CACHE = new LRUCache();
 DEFAULT_LRU_CACHE.unloadPriorityCallback = lruPriorityCallback;
 
 export const DEFAULT_DOWNLOAD_QUEUE = new PriorityQueue();
 DEFAULT_DOWNLOAD_QUEUE.maxJobs = 25;
 DEFAULT_DOWNLOAD_QUEUE.priorityCallback = unifiedPriorityCallback;
 
-const DEFAULT_PARSE_QUEUE = new PriorityQueue();
+export const DEFAULT_PARSE_QUEUE = new PriorityQueue();
 DEFAULT_PARSE_QUEUE.maxJobs = 5;
 DEFAULT_PARSE_QUEUE.priorityCallback = unifiedPriorityCallback;
 
-const DEFAULT_NODE_QUEUE = new PriorityQueue();
+export const DEFAULT_NODE_QUEUE = new PriorityQueue();
 DEFAULT_NODE_QUEUE.maxJobs = 25;
 DEFAULT_NODE_QUEUE.priorityCallback = ( a, b ) => {
 


### PR DESCRIPTION
Related to https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/1661

## Description

`DEFAULT_DOWNLOAD_QUEUE` is already exported, but the other shared default resources are private.

This PR additionally exports:

- `DEFAULT_LRU_CACHE`
- `DEFAULT_PARSE_QUEUE`
- `DEFAULT_NODE_QUEUE`

This allows users to configure global defaults such as cache limits and queue concurrency.

No default values or runtime behavior are changed.