### PR TITLE
MVTAnnotationsPlugin: Add use of idle callback

### DIFF
--- a/src/three/plugins/mvt/DelayedScreenOccupationManager.js
+++ b/src/three/plugins/mvt/DelayedScreenOccupationManager.js
@@ -197,10 +197,8 @@ export class DelayedScreenOccupationManager extends EventDispatcher {
 			hideDelay,
 		} = this;
 
-		added.clear();
-		removed.clear();
-
-		// increment the timers for added items
+		// added / removed accumulate until reset() is called so multiple calls to "update" do not
+		// break the caller behavior
 		const currTime = performance.now();
 		for ( const [ item, elapsed ] of _showTimers ) {
 
@@ -210,6 +208,7 @@ export class DelayedScreenOccupationManager extends EventDispatcher {
 				_showTimers.delete( item );
 				visible.add( item );
 				added.add( item );
+				removed.delete( item );
 				item.visibleTime = currTime;
 
 			} else {
@@ -229,6 +228,7 @@ export class DelayedScreenOccupationManager extends EventDispatcher {
 				_hideTimers.delete( item );
 				visible.delete( item );
 				removed.add( item );
+				added.delete( item );
 				item.onHidden();
 
 			} else {
@@ -268,6 +268,7 @@ export class DelayedScreenOccupationManager extends EventDispatcher {
 
 			visible.add( item );
 			added.add( item );
+			removed.delete( item );
 			item.visibleTime = currTime;
 
 		}
@@ -278,11 +279,21 @@ export class DelayedScreenOccupationManager extends EventDispatcher {
 
 			visible.delete( item );
 			removed.add( item );
+			added.delete( item );
 			item.onHidden();
 
 		}
 
 		_hideTimers.clear();
+
+	}
+
+	// clear the accumulated added / removed deltas. Call once per consume cycle after the caller
+	// has read them, so ticks between frames can keep accumulating into the same sets.
+	reset() {
+
+		this.added.clear();
+		this.removed.clear();
 
 	}
 

--- a/src/three/plugins/mvt/DelayedScreenOccupationManager.js
+++ b/src/three/plugins/mvt/DelayedScreenOccupationManager.js
@@ -178,14 +178,14 @@ export class DelayedScreenOccupationManager extends EventDispatcher {
 
 	}
 
-	update() {
+	update( ...args ) {
 
 		const now = performance.now() / 1000;
 		const dt = this._lastUpdateTime < 0 ? 0 : Math.min( now - this._lastUpdateTime, 0.1 );
 		this._lastUpdateTime = now;
 
 		// fires 'changed' synchronously, populating the timers
-		this.manager.update();
+		this.manager.update( ...args );
 
 		const {
 			_showTimers,

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -537,16 +537,19 @@ export class MVTAnnotationsPlugin {
 
 			}
 
+			// clear the set of "added" and "removed" annotations once consumed since the following
+			// "idle callback" run may fill it further so we have to clear explicitly.
+			occupancy.reset();
+
+			// if there's more work required the fire that we need to run during a subsequent frame and
+			// try to run during an idle callback.
 			if ( occupancy.hasPendingWork || settlingManager.hasPendingWork ) {
 
 				tiles.dispatchEvent( { type: 'needs-update' } );
 				requestIdleCallback( deadline => {
 
 					settlingManager.update( deadline.timeRemaining() * 0.9 );
-
-					// TODO: we need a way to make "occupancy.update" resilient to the calls between frames
-					// rather than calling the internal manager explicitly
-					occupancy.manager.update( deadline.timeRemaining() * 0.9 );
+					occupancy.update( deadline.timeRemaining() * 0.9 );
 
 				} );
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -540,6 +540,15 @@ export class MVTAnnotationsPlugin {
 			if ( occupancy.hasPendingWork || settlingManager.hasPendingWork ) {
 
 				tiles.dispatchEvent( { type: 'needs-update' } );
+				requestIdleCallback( deadline => {
+
+					settlingManager.update( deadline.timeRemaining() * 0.9 );
+
+					// TODO: we need a way to make "occupancy.update" resilient to the calls between frames
+					// rather than calling the internal manager explicitly
+					occupancy.manager.update( deadline.timeRemaining() * 0.9 );
+
+				} );
 
 			}
 

--- a/src/three/plugins/mvt/ScreenOccupationManager.js
+++ b/src/three/plugins/mvt/ScreenOccupationManager.js
@@ -75,7 +75,7 @@ export class ScreenOccupationManager extends EventDispatcher {
 		// time budget per frame for the sliced update pass
 		this.maxUpdateTimeMs = 0.5;
 
-		// forever-running update pass, sliced by the per-frame deadline
+		// forever-running update pass, sliced by the per-tick deadline
 		this._task = null;
 		this._deadline = 0;
 
@@ -218,15 +218,18 @@ export class ScreenOccupationManager extends EventDispatcher {
 
 	}
 
-	_resetDeadline() {
+	// set the deadline the update task runs until, this many ms from now
+	setDeadline( ms = this.maxUpdateTimeMs ) {
 
-		this._deadline = performance.now() + this.maxUpdateTimeMs;
+		this._deadline = performance.now() + ms;
 
 	}
 
-	update() {
+	update( ms = this.maxUpdateTimeMs ) {
 
-		// tick the forever-running update task, giving it a fresh time budget
+		this.setDeadline( ms );
+
+		// tick the forever-running update task
 		if ( this._task === null ) {
 
 			this._task = this._updateGenerator();
@@ -240,6 +243,9 @@ export class ScreenOccupationManager extends EventDispatcher {
 	// run the in-flight pass (or a fresh one if changes are pending) to completion so the visible
 	// sets and "change" event reflect the current state immediately
 	flush() {
+
+		// no budget so the pass runs to completion in a single tick
+		this.setDeadline( Infinity );
 
 		if ( this._task === null ) {
 
@@ -276,8 +282,6 @@ export class ScreenOccupationManager extends EventDispatcher {
 
 		// runs forever: each pass transforms, sorts, and evaluates the full item list, yielding
 		// whenever the per-frame budget is spent and resuming on the next update
-		this._resetDeadline();
-
 		while ( true ) {
 
 			const {
@@ -301,7 +305,6 @@ export class ScreenOccupationManager extends EventDispatcher {
 			if ( _lastMatrix.equals( _ndcMatrix ) && ! this.needsUpdate ) {
 
 				yield;
-				this._resetDeadline();
 				continue;
 
 			}
@@ -349,7 +352,6 @@ export class ScreenOccupationManager extends EventDispatcher {
 				if ( this._deadlineExpired() ) {
 
 					yield;
-					this._resetDeadline();
 					this.updateCameraTransform();
 
 				}
@@ -362,7 +364,6 @@ export class ScreenOccupationManager extends EventDispatcher {
 			if ( this._deadlineExpired() ) {
 
 				yield;
-				this._resetDeadline();
 				this.updateCameraTransform();
 
 			}
@@ -397,7 +398,6 @@ export class ScreenOccupationManager extends EventDispatcher {
 				if ( this._deadlineExpired() ) {
 
 					yield;
-					this._resetDeadline();
 					this.updateCameraTransform();
 
 				}
@@ -414,7 +414,6 @@ export class ScreenOccupationManager extends EventDispatcher {
 
 			// always yield at the end of a pass so an unchanged view can't busy-spin
 			yield;
-			this._resetDeadline();
 
 		}
 

--- a/src/three/plugins/mvt/SettlingManager.js
+++ b/src/three/plugins/mvt/SettlingManager.js
@@ -124,7 +124,9 @@ export class SettlingManager {
 
 	}
 
-	update() {
+	update( ms = this.maxSettleTimeMs ) {
+
+		this.setDeadline( ms );
 
 		// rebuild requeues everything that is still registered
 		if ( this.needsUpdate ) {
@@ -138,7 +140,7 @@ export class SettlingManager {
 
 		}
 
-		// tick the forever-running settling task, giving it a fresh time budget
+		// tick the forever-running settling task
 		if ( this._task === null ) {
 
 			this._task = this._settleGenerator();
@@ -149,16 +151,16 @@ export class SettlingManager {
 
 	}
 
-	// deadline
-	_deadlineExpired() {
+	// set the deadline the settling task runs until, this many ms from now
+	setDeadline( ms = this.maxSettleTimeMs ) {
 
-		return performance.now() >= this._deadline;
+		this._deadline = performance.now() + ms;
 
 	}
 
-	_resetDeadline() {
+	_deadlineExpired() {
 
-		this._deadline = performance.now() + this.maxSettleTimeMs;
+		return performance.now() >= this._deadline;
 
 	}
 
@@ -222,8 +224,6 @@ export class SettlingManager {
 		const intersectingFrustum = new Set();
 		const settlingBins = [[], [], [], []];
 
-		this._resetDeadline();
-
 		while ( true ) {
 
 			const { _queue, _items, tiles, camera, occupancy } = this;
@@ -280,7 +280,6 @@ export class SettlingManager {
 					if ( this._deadlineExpired() ) {
 
 						yield;
-						this._resetDeadline();
 
 					}
 
@@ -312,7 +311,6 @@ export class SettlingManager {
 				if ( this._deadlineExpired() ) {
 
 					yield;
-					this._resetDeadline();
 
 				}
 
@@ -348,7 +346,6 @@ export class SettlingManager {
 					if ( this._deadlineExpired() ) {
 
 						yield;
-						this._resetDeadline();
 
 					}
 
@@ -362,7 +359,6 @@ export class SettlingManager {
 
 			// always yield at the end of a pass so an empty queue can't busy-spin
 			yield;
-			this._resetDeadline();
 
 		}
 
@@ -389,7 +385,6 @@ export class SettlingManager {
 				if ( this._deadlineExpired() ) {
 
 					yield;
-					this._resetDeadline();
 
 					// bail if the item was unregistered while paused
 					if ( ! _items.has( item ) ) {


### PR DESCRIPTION
Related to #1600 

- Add use of idle callback in MVTAnnotationsPlugin to complete remaining work.

**TODO**
- Consider option to enable / disable this / make it a user defined callback
- Fix occupancy manager case