### PR TITLE
MVTAnnotationsPlugin: Add raycasting improvements, customization 

### DIFF
--- a/example/three/annotationsExample.js
+++ b/example/three/annotationsExample.js
@@ -190,8 +190,8 @@ class ExampleAnnotationsDriver extends MVTAnnotationsDriver {
 		this.settleRaycaster = new Raycaster();
 
 		// prefer the nearest hit on a visible tile so oversized offscreen coverage tiles don't win,
-		// otherwise take the nearest hit.
-		// TODO: this LoD-aware pick likely belongs in the renderer/plugin.
+		// otherwise take the nearest hit. This is to avoid cases where high LoD tiles are "active"
+		// and overlap low LoD tiles, resulting in incorrect offsets.
 		this.performSettleRaycast = ( ray, lat, lon, target ) => {
 
 			const { settleRaycaster } = this;

--- a/example/three/annotationsExample.js
+++ b/example/three/annotationsExample.js
@@ -187,6 +187,42 @@ class ExampleAnnotationsDriver extends MVTAnnotationsDriver {
 		this.annotationPoints = annotationPoints;
 		this.characterPoints = characterPoints;
 
+		this.settleRaycaster = new Raycaster();
+
+		// prefer the nearest hit on a visible tile so oversized offscreen coverage tiles don't win,
+		// otherwise take the nearest hit.
+		// TODO: this LoD-aware pick likely belongs in the renderer/plugin.
+		this.performSettleRaycast = ( ray, lat, lon, target ) => {
+
+			const { settleRaycaster } = this;
+			settleRaycaster.ray.copy( ray );
+			settleRaycaster.far = 2 * 1e8;
+			settleRaycaster.firstHitOnly = false;
+
+			const hits = settleRaycaster.intersectObject( tiles.group, true );
+			for ( let i = 0, l = hits.length; i < l; i ++ ) {
+
+				const tile = hits[ i ].object.userData.tile;
+				if ( ! tile || tiles.visibleTiles.has( tile ) ) {
+
+					target.copy( hits[ i ].point );
+					return true;
+
+				}
+
+			}
+
+			if ( hits.length > 0 ) {
+
+				target.copy( hits[ 0 ].point );
+				return true;
+
+			}
+
+			return false;
+
+		};
+
 	}
 
 	filterAnnotation( layer, properties, type ) {

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1087,6 +1087,17 @@ Render group for the driver's own three.js objects. The plugin mounts it under
 `tiles.group` on `init` and removes it on `dispose`; add any objects the driver draws to it.
 
 
+### .performSettleRaycast
+
+```js
+performSettleRaycast: ( ray: Ray, lat: number, lon: number, target: Vector3 ) => boolean | null
+```
+
+Optional callback overriding the default surface raycast used when settling annotations
+onto the tile geometry, letting the caller analyze the hits and return a better point.
+Leave null to use the plugin's default raycasting.
+
+
 ### .filterAnnotation
 
 ```js

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
@@ -1,10 +1,13 @@
-import { Camera, Group } from 'three';
+import { Camera, Group, Ray, Vector3 } from 'three';
 import { MVTIconGlyphs } from './MVTIconGlyphs.js';
 import { MVTLabelGlyphs } from './MVTLabelGlyphs.js';
+
+export type MVTRaycastCallback = ( ray: Ray, lat: number, lon: number, target: Vector3 ) => boolean;
 
 export class MVTAnnotationsDriver {
 
 	group: Group;
+	performSettleRaycast: MVTRaycastCallback | null;
 
 	filterAnnotation( layer: string, properties: Record<string, unknown>, type: number ): boolean;
 	sortAnnotations( a: object, b: object ): number;

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -1,4 +1,4 @@
-/** @import { Camera, Scene } from 'three' */
+/** @import { Camera, Scene, Ray, Vector3 } from 'three' */
 import { Group, Matrix4 } from 'three';
 import { MVTHierarchy } from './MVTHierarchy.js';
 import { DelayedScreenOccupationManager } from './DelayedScreenOccupationManager.js';
@@ -43,6 +43,16 @@ function collectMeshes( object ) {
  */
 
 /**
+ * @callback MVTRaycastCallback
+ * @param {Ray} ray - The ray to cast, in world space.
+ * @param {number} lat - Latitude of the sample, in radians.
+ * @param {number} lon - Longitude of the sample, in radians.
+ * @param {Vector3} target - Vector to write the resolved world-space hit point into.
+ * @returns {boolean} True if a hit point was written to `target` and false to fall back to the default
+ * ellipsoid-surface placement.
+ */
+
+/**
  * Bundles the callbacks the "MVTAnnotationsPlugin" needs into a single object. Subclass and override
  * the methods to customize which features become annotations, their placement priority, per-character
  * sizing, the displayed text, and how visibility changes are rendered. By default all points of interest
@@ -75,6 +85,14 @@ export class MVTAnnotationsDriver {
 		 * @type {Group}
 		 */
 		this.group = new Group();
+
+		/**
+		 * Optional callback overriding the default surface raycast used when settling annotations
+		 * onto the tile geometry, letting the caller analyze the hits and return a better point.
+		 * Leave null to use the plugin's default raycasting.
+		 * @type {MVTRaycastCallback|null}
+		 */
+		this.performSettleRaycast = null;
 
 		this.version = 0;
 
@@ -510,6 +528,7 @@ export class MVTAnnotationsPlugin {
 
 			// raycasters
 			settlingManager.camera = camera;
+			settlingManager.performSettleRaycast = driver.performSettleRaycast;
 			settlingManager.update();
 
 			// occupancy

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -613,7 +613,7 @@ export class MVTAnnotationsPlugin {
 				// parse the icon annotations
 				const annotations = [];
 				parsePointAnnotations( vectorTile, x, y, level, tiling, _filterAnnotation, annotations );
-				parseLineAnnotations( vectorTile, x, y, level, tiling, _filterAnnotation, annotations );
+				parseLineAnnotations( vectorTile, x, y, level, tiling, tiles.ellipsoid, _filterAnnotation, annotations );
 				vectorTileInfo.set( key, { annotations } );
 
 				for ( const ann of annotations ) {

--- a/src/three/plugins/mvt/SettlingManager.js
+++ b/src/three/plugins/mvt/SettlingManager.js
@@ -82,31 +82,6 @@ function rayIntersectsFrustum( raycaster, frustum ) {
 
 }
 
-// Choose the hit belonging to the highest-LoD tile with the smallest geometric error — using the "userData.tile" back-reference
-// the renderer stamps on tile meshes. Oversized active coverage tiles otherwise win over the fine geometry beneath them when picking
-// by distance alone. Hits arrive sorted near -> far, so a strict "<" keeps the nearest hit on ties.
-function pickFinestHit( hits ) {
-
-	let best = null;
-	let bestError = Infinity;
-	for ( let i = 0, l = hits.length; i < l; i ++ ) {
-
-		const hit = hits[ i ];
-		const tile = hit.object.userData.tile;
-		const error = tile ? tile.geometricError : - Infinity;
-		if ( error < bestError ) {
-
-			bestError = error;
-			best = hit;
-
-		}
-
-	}
-
-	return best;
-
-}
-
 // Takes a set of line or point annotations and "settles" them onto the tile set.
 export class SettlingManager {
 
@@ -226,13 +201,10 @@ export class SettlingManager {
 
 		} else {
 
-			// gather every hit so we can drape onto the highest-LoD surface rather than whichever
-			// active tile the ray happens to strike first
-			_raycaster.firstHitOnly = false;
-			const best = pickFinestHit( _raycaster.intersectObject( tiles.group ) );
-			if ( best !== null ) {
+			const hits = _raycaster.intersectObject( tiles.group );
+			if ( hits.length > 0 ) {
 
-				_hit.copy( best.point );
+				_hit.copy( hits[ 0 ].point );
 				hit = true;
 
 			}

--- a/src/three/plugins/mvt/SettlingManager.js
+++ b/src/three/plugins/mvt/SettlingManager.js
@@ -82,6 +82,31 @@ function rayIntersectsFrustum( raycaster, frustum ) {
 
 }
 
+// Choose the hit belonging to the highest-LoD tile with the smallest geometric error — using the "userData.tile" back-reference
+// the renderer stamps on tile meshes. Oversized active coverage tiles otherwise win over the fine geometry beneath them when picking
+// by distance alone. Hits arrive sorted near -> far, so a strict "<" keeps the nearest hit on ties.
+function pickFinestHit( hits ) {
+
+	let best = null;
+	let bestError = Infinity;
+	for ( let i = 0, l = hits.length; i < l; i ++ ) {
+
+		const hit = hits[ i ];
+		const tile = hit.object.userData.tile;
+		const error = tile ? tile.geometricError : - Infinity;
+		if ( error < bestError ) {
+
+			bestError = error;
+			best = hit;
+
+		}
+
+	}
+
+	return best;
+
+}
+
 // Takes a set of line or point annotations and "settles" them onto the tile set.
 export class SettlingManager {
 
@@ -201,10 +226,13 @@ export class SettlingManager {
 
 		} else {
 
-			const hits = _raycaster.intersectObject( tiles.group );
-			if ( hits.length > 0 ) {
+			// gather every hit so we can drape onto the highest-LoD surface rather than whichever
+			// active tile the ray happens to strike first
+			_raycaster.firstHitOnly = false;
+			const best = pickFinestHit( _raycaster.intersectObject( tiles.group ) );
+			if ( best !== null ) {
 
-				_hit.copy( hits[ 0 ].point );
+				_hit.copy( best.point );
 				hit = true;
 
 			}

--- a/src/three/plugins/mvt/SettlingManager.js
+++ b/src/three/plugins/mvt/SettlingManager.js
@@ -98,6 +98,10 @@ export class SettlingManager {
 		this.camera = null;
 		this.maxSettleTimeMs = 1;
 
+		// custom settling callback ( ray, lat, lon, target ) => boolean overriding the default raycast.
+		// When null the default raycast against the tile group is used.
+		this.performSettleRaycast = null;
+
 		// items awaiting resettling
 		this._queue = new Set();
 		this._items = new Set();
@@ -182,7 +186,7 @@ export class SettlingManager {
 	_settleSample( lat, lon, target, threshold ) {
 
 		// cast a ray to snap a single cartographic sample onto the surface
-		const { tiles } = this;
+		const { tiles, performSettleRaycast } = this;
 		const { origin, direction } = _raycaster.ray;
 
 		// build the local ray and transform to world space for raycasting
@@ -190,12 +194,27 @@ export class SettlingManager {
 		origin.applyMatrix4( tiles.group.matrixWorld );
 		direction.transformDirection( tiles.group.matrixWorld );
 
-		const hits = _raycaster.intersectObject( tiles.group );
-		if ( hits.length > 0 ) {
+		let hit = false;
+		if ( performSettleRaycast !== null ) {
 
-			_hit
-				.copy( hits[ 0 ].point )
-				.applyMatrix4( tiles.group.matrixWorldInverse );
+			hit = performSettleRaycast( _raycaster.ray, lat, lon, _hit );
+
+		} else {
+
+			const hits = _raycaster.intersectObject( tiles.group );
+			if ( hits.length > 0 ) {
+
+				_hit.copy( hits[ 0 ].point );
+				hit = true;
+
+			}
+
+		}
+
+		if ( hit ) {
+
+
+			_hit.applyMatrix4( tiles.group.matrixWorldInverse );
 
 		} else {
 

--- a/src/three/plugins/mvt/annotations/LineAnnotation.js
+++ b/src/three/plugins/mvt/annotations/LineAnnotation.js
@@ -1,6 +1,10 @@
 import { MathUtils, Vector3, Vector2, Matrix4 } from 'three';
 import { OccupancyAnnotation } from '../ScreenOccupationManager.js';
 
+// real-world spacing between road-label anchors, in meters. Converted to an angular spacing using
+// the body's radius so anchor density tracks real-world length on any ellipsoid.
+const ANCHOR_SPACING_METERS = 500000;
+
 // Share path annotation used for text anchors
 export class LineAnnotation extends OccupancyAnnotation {
 
@@ -270,12 +274,13 @@ function subsamplePath( points, spacing ) {
 }
 
 // parse the vector tile geometry into line annotations
-export function parseLineAnnotations( vectorTile, x, y, level, tiling, filter, target = [] ) {
+export function parseLineAnnotations( vectorTile, x, y, level, tiling, ellipsoid, filter, target = [] ) {
 
-	// TODO: this needs to scale based on LoD rather than a fixed - this is hackily-scaled below
-	// anchor spacing in radians. Density  tracks real-world length, independent of the tile's
-	// zoom / size
-	const anchorSpacing = 500000 / 6378137;
+	// anchor spacing in radians, derived from the fixed real-world distance and the body's radius so
+	// density tracks real-world length independent of the ellipsoid.
+	// TODO: this needs to scale based on LoD rather than a fixed value - it is hackily scaled by the
+	// tile width below
+	const anchorSpacing = ANCHOR_SPACING_METERS / ellipsoid.radius.x;
 	const subsampleFraction = 1 / 64;
 	const tileBounds = tiling.getTileBounds( x, y, level, true, false );
 	const [ tMinX, tMinY, tMaxX, tMaxY ] = tileBounds;

--- a/src/three/renderer/API.md
+++ b/src/three/renderer/API.md
@@ -922,6 +922,10 @@ Three.js implementation of a 3D Tiles renderer. Extends `TilesRendererBase` with
 camera management, three.js scene integration, and GPU-accelerated tile loading.
 Add `tiles.group` to your scene and call `tiles.update()` each frame.
 
+Every object in a loaded tile's scene is stamped with a `userData.tile` back-reference to
+its owning tile, so a raycast hit, click target, or debug inspector can resolve the tile
+directly from any intersected object without walking the hierarchy or consulting the renderer.
+
 
 ### .autoDisableRendererCulling
 

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -45,6 +45,10 @@ function updateFrustumCulled( object, toInitialValue ) {
  * Three.js implementation of a 3D Tiles renderer. Extends `TilesRendererBase` with
  * camera management, three.js scene integration, and GPU-accelerated tile loading.
  * Add `tiles.group` to your scene and call `tiles.update()` each frame.
+ *
+ * Every object in a loaded tile's scene is stamped with a `userData.tile` back-reference to
+ * its owning tile, so a raycast hit, click target, or debug inspector can resolve the tile
+ * directly from any intersected object without walking the hierarchy or consulting the renderer.
  * @extends TilesRendererBase
  */
 export class TilesRenderer extends TilesRendererBase {
@@ -788,10 +792,12 @@ export class TilesRenderer extends TilesRendererBase {
 
 		} );
 
-		// frustum culling
+		// record the initial frustum-culled state and stamp the owning tile onto every object so
+		// raycast hits, click handling, and debug tooling can resolve back to the tile
 		scene.traverse( c => {
 
 			c[ INITIAL_FRUSTUM_CULLED ] = c.frustumCulled;
+			c.userData.tile = tile;
 
 		} );
 		updateFrustumCulled( scene, ! this.autoDisableRendererCulling );


### PR DESCRIPTION
Related to #1600 
Related to #449

- Add userdata.tile field to objects
- MVTAnnotationsDriver: add an optional "settle raycast" function
- MVTAnnotations: Remove hard coded earth constants used during line parsing
- MVTAnnotations: Prioritize high LoD tiles for settling

**TODO**
- Create issue for the following:
- The new prioritization does not work for additive tiles
- Consider centralizing a mechanism that picks the "best" hit
  - Prioritize visible over active to avoid "data cliffs"?
  - Prioritize highest LoD? How to deal with additive?