### PR TITLE
TilesRenderer: Adjust active tile matrix calculation

### DIFF
--- a/src/three/renderer/tiles/TilesGroup.js
+++ b/src/three/renderer/tiles/TilesGroup.js
@@ -79,30 +79,15 @@ export class TilesGroup extends Group {
 
 				}
 
-				// update the active tile scenes so they are up to date, as well. We iterate over all
-				// children above because plugins etc may add other objects.
+				// active-but-hidden tile scenes are parented to this group but not added as children,
+				// so the loop above doesn't reach them so update their world matrices explicitly
 				const { tilesRenderer } = this;
 				const { activeTiles, visibleTiles } = tilesRenderer;
 				activeTiles.forEach( tile => {
 
 					if ( ! visibleTiles.has( tile ) ) {
 
-						const { scene } = tile.engineData;
-						scene.traverse( c => {
-
-							c.updateMatrix();
-							c.matrixWorld.copy( c.matrix );
-							if ( c.parent ) {
-
-								c.matrixWorld.premultiply( c.parent.matrixWorld );
-
-							} else {
-
-								c.matrixWorld.premultiply( this.matrixWorld );
-
-							}
-
-						} );
+						tile.engineData.scene.updateMatrixWorld( true );
 
 					}
 

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -948,10 +948,9 @@ export class TilesRenderer extends TilesRendererBase {
 		const scene = tile.engineData.scene;
 		if ( scene ) {
 
-			// an active scene is parented to the group so its world matrix resolves for raycasting.
-			// When it isn't a visible child ( see setTileVisible ) the parent pointer alone carries the
-			// transform while keeping it out of the render traversal. A tile is never visible while
-			// inactive, so an inactive scene is always fully detached.
+			// an active scene is parented to the group so its world matrix is included for raycasting
+			// or other spatial queries while active. A tile is never visible while inactive, so an
+			// inactive scene is always fully detached.
 			if ( active ) {
 
 				scene.parent = this.group;

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -943,52 +943,53 @@ export class TilesRenderer extends TilesRendererBase {
 
 	setTileActive( tile, active ) {
 
-		const scene = tile.engineData.scene;
-		const group = this.group;
+		super.setTileActive( tile, active );
 
+		const scene = tile.engineData.scene;
 		if ( scene ) {
 
-			// update matrices for the tile scene
-			scene.traverse( c => {
+			// an active scene is parented to the group so its world matrix resolves for raycasting.
+			// When it isn't a visible child ( see setTileVisible ) the parent pointer alone carries the
+			// transform while keeping it out of the render traversal. A tile is never visible while
+			// inactive, so an inactive scene is always fully detached.
+			if ( active ) {
 
-				c.updateMatrix();
-				c.matrixWorld.copy( c.matrix );
-				if ( c.parent ) {
+				scene.parent = this.group;
+				scene.updateMatrixWorld( true );
 
-					c.matrixWorld.premultiply( c.parent.matrixWorld );
+			} else {
 
-				} else {
+				scene.parent = null;
 
-					c.matrixWorld.premultiply( group.matrixWorld );
-
-				}
-
-			} );
+			}
 
 		}
-
-		super.setTileActive( tile, active );
 
 	}
 
 	setTileVisible( tile, visible ) {
 
 		const scene = tile.engineData.scene;
-		const group = this.group;
+		const { activeTiles, group } = this;
 
-		if ( visible ) {
+		if ( scene ) {
 
-			if ( scene ) {
+			if ( visible ) {
 
 				group.add( scene );
 
-			}
-
-		} else {
-
-			if ( scene ) {
+			} else {
 
 				group.remove( scene );
+
+				// group.remove clears the parent, but the tile may still be active, and an active scene
+				// must keep the group as a parent (without being a child) so its world matrix still
+				// resolves for raycasting. A tile is never visible while inactive.
+				if ( activeTiles.has( tile ) ) {
+
+					scene.parent = group;
+
+				}
 
 			}
 


### PR DESCRIPTION
Fix #1669 
Related to #1600 

Adjusts active tile to assign the tile scene parent to the group to ensure the transforms reflect the parent matrices appropriately.