### PR TITLE
Examples: Remove need for setting decoder and transcoder paths

### DIFF
--- a/example/r3f/flattening.jsx
+++ b/example/r3f/flattening.jsx
@@ -10,7 +10,7 @@ import {
 	MathUtils,
 } from 'three';
 
-const dracoLoader = new DRACOLoader().setDecoderPath( 'https://www.gstatic.com/draco/v1/decoders/' );
+const dracoLoader = new DRACOLoader();
 
 const LAT = 35.3606 * MathUtils.DEG2RAD;
 const LON = 138.7274 * MathUtils.DEG2RAD;

--- a/example/r3f/globe.jsx
+++ b/example/r3f/globe.jsx
@@ -29,7 +29,7 @@ import { MathUtils, Vector3 } from 'three';
 import { TilesLoadingBar } from './components/TilesLoadingBar.jsx';
 import { CameraViewTransition } from './components/CameraViewTransition.jsx';
 
-const dracoLoader = new DRACOLoader().setDecoderPath( 'https://www.gstatic.com/draco/v1/decoders/' );
+const dracoLoader = new DRACOLoader();
 const vec1 = new Vector3();
 const vec2 = new Vector3();
 

--- a/example/r3f/ion.jsx
+++ b/example/r3f/ion.jsx
@@ -13,7 +13,7 @@ import { Canvas } from '@react-three/fiber';
 import { Environment, GizmoHelper, GizmoViewport } from '@react-three/drei';
 import { useControls } from 'leva';
 
-const dracoLoader = new DRACOLoader().setDecoderPath( 'https://www.gstatic.com/draco/v1/decoders/' );
+const dracoLoader = new DRACOLoader();
 
 function App() {
 

--- a/example/r3f/settling.jsx
+++ b/example/r3f/settling.jsx
@@ -30,7 +30,7 @@ import { MathUtils, Vector3 } from 'three';
 import { TilesLoadingBar } from './components/TilesLoadingBar.jsx';
 import { CameraViewTransition } from './components/CameraViewTransition.jsx';
 
-const dracoLoader = new DRACOLoader().setDecoderPath( 'https://www.gstatic.com/draco/v1/decoders/' );
+const dracoLoader = new DRACOLoader();
 const vec1 = new Vector3();
 const vec2 = new Vector3();
 

--- a/example/three/annotationsExample.js
+++ b/example/three/annotationsExample.js
@@ -297,7 +297,7 @@ function initTiles() {
 	tiles.registerPlugin( new UpdateOnChangePlugin() );
 	tiles.registerPlugin( new CesiumIonAuthPlugin( { apiToken: import.meta.env.VITE_ION_KEY, assetId: '2275207', autoRefreshToken: true } ) );
 	tiles.registerPlugin( new GLTFExtensionsPlugin( {
-		dracoLoader: new DRACOLoader().setDecoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/' )
+		dracoLoader: new DRACOLoader(),
 	} ) );
 	tiles.registerPlugin( new TilesFadePlugin() );
 	tiles.registerPlugin( new MeshBVHPlugin() );

--- a/example/three/cesiumCompare.js
+++ b/example/three/cesiumCompare.js
@@ -266,19 +266,12 @@ async function initThree() {
 		0.2262281938283491,
 	);
 
-	const dracoLoader = new DRACOLoader();
-	dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/' );
-
-	const ktx2loader = new KTX2Loader();
-	ktx2loader.setTranscoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/basis/' );
-	ktx2loader.detectSupport( renderer );
-
 	// initialize tiles
 	const tiles = new TilesRenderer( url );
 	tiles.registerPlugin( new GLTFExtensionsPlugin( {
 		rtc: true,
-		dracoLoader: dracoLoader,
-		ktxLoader: ktx2loader,
+		dracoLoader: new DRACOLoader(),
+		ktxLoader: new KTX2Loader().detectSupport( renderer ),
 	} ) );
 
 	tiles.preprocessURL = url => unescape( url );

--- a/example/three/googleMapsAerial.js
+++ b/example/three/googleMapsAerial.js
@@ -33,9 +33,7 @@ function reinstantiateTiles() {
 	tiles.registerPlugin( new TileCompressionPlugin() );
 	tiles.registerPlugin( new TilesFadePlugin() );
 	tiles.registerPlugin( new GLTFExtensionsPlugin( {
-		// Note the DRACO compression files need to be supplied via an explicit source.
-		// We use unpkg here but in practice should be provided by the application.
-		dracoLoader: new DRACOLoader().setDecoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/' )
+		dracoLoader: new DRACOLoader(),
 	} ) );
 	reorientPlugin = new ReorientationPlugin( { lat: 35.6586 * MathUtils.DEG2RAD, lon: 139.7454 * MathUtils.DEG2RAD } );
 	tiles.registerPlugin( reorientPlugin );

--- a/example/three/googleMapsExample.js
+++ b/example/three/googleMapsExample.js
@@ -71,9 +71,7 @@ function reinstantiateTiles() {
 	tiles.registerPlugin( new UnloadTilesPlugin() );
 	tiles.registerPlugin( new TopoLinesPlugin( { projection: 'ellipsoid' } ) );
 	tiles.registerPlugin( new GLTFExtensionsPlugin( {
-		// Note the DRACO compression files need to be supplied via an explicit source.
-		// We use unpkg here but in practice should be provided by the application.
-		dracoLoader: new DRACOLoader().setDecoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/' )
+		dracoLoader: new DRACOLoader(),
 	} ) );
 
 	// use the camera cartographic region plugin to prevent particularly low-lod

--- a/example/three/i3dmExample.js
+++ b/example/three/i3dmExample.js
@@ -71,7 +71,6 @@ function init() {
 	const i3dmLoader = new I3DMLoader();
 
 	const dracoLoader = new DRACOLoader();
-	dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/' );
 	const gltfLoader = new GLTFLoader( i3dmLoader.manager );
 	gltfLoader.setDRACOLoader( dracoLoader );
 	i3dmLoader.manager.addHandler( /\.gltf$/, gltfLoader );

--- a/example/three/index.js
+++ b/example/three/index.js
@@ -90,21 +90,12 @@ function reinstantiateTiles() {
 
 	}
 
-	// Note the DRACO compression files need to be supplied via an explicit source.
-	// We use unpkg here but in practice should be provided by the application.
-	const dracoLoader = new DRACOLoader();
-	dracoLoader.setDecoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/' );
-
-	const ktx2loader = new KTX2Loader();
-	ktx2loader.setTranscoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/basis/' );
-	ktx2loader.detectSupport( renderer );
-
 	tiles = new TilesRenderer( url );
 	tiles.registerPlugin( new ImplicitTilingPlugin() );
 	tiles.registerPlugin( new GLTFExtensionsPlugin( {
 		rtc: true,
-		dracoLoader: dracoLoader,
-		ktxLoader: ktx2loader,
+		dracoLoader: new DRACOLoader(),
+		ktxLoader: new KTX2Loader(),
 	} ) );
 
 	tiles.fetchOptions.mode = 'cors';

--- a/example/three/ionExample.js
+++ b/example/three/ionExample.js
@@ -46,9 +46,7 @@ function setupTiles() {
 
 	tiles.fetchOptions.mode = 'cors';
 	tiles.registerPlugin( new GLTFExtensionsPlugin( {
-		// Note the DRACO compression files need to be supplied via an explicit source.
-		// We use unpkg here but in practice should be provided by the application.
-		dracoLoader: new DRACOLoader().setDecoderPath( 'https://unpkg.com/three@0.153.0/examples/jsm/libs/draco/gltf/' )
+		dracoLoader: new DRACOLoader(),
 	} ) );
 
 	scene.add( tiles.group );

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "jsdoc": "^4.0.5",
         "leva": "^0.10.0",
         "lil-gui": "^0.21.0",
-        "postprocessing": "^6.36.4",
         "three": "^0.185.0",
         "three-mesh-bvh": "^0.9.11",
         "typescript": "^5.6.0",
@@ -6767,16 +6766,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postprocessing": {
-      "version": "6.38.2",
-      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.38.2.tgz",
-      "integrity": "sha512-7DwuT7Tkst41ZjSj287g7C9c5/D3Xx5rMgBosg0dadbUPoZD2HNzkadKPol1d2PJAoI9f+Jeh1/v9YfLzpFGVw==",
-      "dev": true,
-      "license": "Zlib",
-      "peerDependencies": {
-        "three": ">= 0.157.0 < 0.183.0"
       }
     },
     "node_modules/potpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "leva": "^0.10.0",
         "lil-gui": "^0.21.0",
         "postprocessing": "^6.36.4",
-        "three": "^0.170.0",
+        "three": "^0.185.0",
         "three-mesh-bvh": "^0.9.11",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.48.1",
@@ -7531,6 +7531,13 @@
         "three": "*"
       }
     },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stats.js": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
@@ -7738,9 +7745,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.170.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
-      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "leva": "^0.10.0",
     "lil-gui": "^0.21.0",
     "postprocessing": "^6.36.4",
-    "three": "^0.170.0",
+    "three": "^0.185.0",
     "three-mesh-bvh": "^0.9.11",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.48.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "jsdoc": "^4.0.5",
     "leva": "^0.10.0",
     "lil-gui": "^0.21.0",
-    "postprocessing": "^6.36.4",
     "three": "^0.185.0",
     "three-mesh-bvh": "^0.9.11",
     "typescript": "^5.6.0",


### PR DESCRIPTION
By updating three.js