### PR TITLE
Fix EXT_structural_metadata property tables when buffer views use EXT_meshopt_compression

### DIFF
--- a/src/three/plugins/gltf/GLTFStructuralMetadataExtension.js
+++ b/src/three/plugins/gltf/GLTFStructuralMetadataExtension.js
@@ -41,19 +41,19 @@ function getRelevantBuffers( parser, propertyTables = [] ) {
 			const { values, arrayOffsets, stringOffsets } = properties[ key ];
 			if ( result[ values ] === null ) {
 
-				result[ values ] = parser.loadBufferView( values );
+				result[ values ] = parser.getDependency( 'bufferView', values );
 
 			}
 
 			if ( result[ arrayOffsets ] === null ) {
 
-				result[ arrayOffsets ] = parser.loadBufferView( arrayOffsets );
+				result[ arrayOffsets ] = parser.getDependency( 'bufferView', arrayOffsets );
 
 			}
 
 			if ( result[ stringOffsets ] === null ) {
 
-				result[ stringOffsets ] = parser.loadBufferView( stringOffsets );
+				result[ stringOffsets ] = parser.getDependency( 'bufferView', stringOffsets );
 
 			}
 


### PR DESCRIPTION
Fixes #1675.

`getRelevantBuffers()` loaded property-table buffer views with `parser.loadBufferView( index )`, which bypasses the GLTF loader plugin hooks — so buffer views compressed with `EXT_meshopt_compression` were never decompressed and property values silently decoded as empty/no-data. Going through `parser.getDependency( 'bufferView', index )` runs the hooks, the same way three's own extensions load buffer views.

Verified against the PDOK 3D Tiles from the issue: property values (strings and numerics) now decode correctly, and behavior for uncompressed files is unchanged.
