### PR TITLE
Fix Orthographic camera zoomSpeed calculation

### DIFF
--- a/src/three/renderer/controls/EnvironmentControls.js
+++ b/src/three/renderer/controls/EnvironmentControls.js
@@ -1283,8 +1283,8 @@ export class EnvironmentControls extends EventDispatcher {
 			_mouseBefore.unproject( camera );
 
 			// zoom the camera
-			const normalizedDelta = Math.pow( 0.95, Math.abs( scale * 0.05 ) * zoomSpeed );
-			let scaleFactor = scale > 0 ? 1 / Math.abs( normalizedDelta ) : normalizedDelta;
+			let scaleFactor = Math.pow( 0.95, - zoomSpeed * scale * 0.05 );
+
 			if ( scaleFactor > 1 ) {
 
 				if ( maxZoom < camera.zoom * scaleFactor ) {

--- a/src/three/renderer/controls/EnvironmentControls.js
+++ b/src/three/renderer/controls/EnvironmentControls.js
@@ -1283,10 +1283,8 @@ export class EnvironmentControls extends EventDispatcher {
 			_mouseBefore.unproject( camera );
 
 			// zoom the camera
-			const normalizedDelta = Math.pow( 0.95, Math.abs( scale * 0.05 ) );
+			const normalizedDelta = Math.pow( 0.95, Math.abs( scale * 0.05 ) * zoomSpeed );
 			let scaleFactor = scale > 0 ? 1 / Math.abs( normalizedDelta ) : normalizedDelta;
-			scaleFactor *= zoomSpeed;
-
 			if ( scaleFactor > 1 ) {
 
 				if ( maxZoom < camera.zoom * scaleFactor ) {

--- a/src/three/renderer/controls/GlobeControls.js
+++ b/src/three/renderer/controls/GlobeControls.js
@@ -678,11 +678,10 @@ export class GlobeControls extends EnvironmentControls {
 			this._alignCameraUpToNorth( MathUtils.lerp( 0, 0.2, distanceAlpha * deltaAlpha ) );
 
 			const scale = this.zoomDelta;
-			const normalizedDelta = Math.pow( 0.95, Math.abs( scale * 0.05 ) );
-			const scaleFactor = scale > 0 ? 1 / Math.abs( normalizedDelta ) : normalizedDelta;
+			const scaleFactor = Math.pow( 0.95, - zoomSpeed * scale * 0.05 );
 
 			const maxScaleFactor = minZoom / camera.zoom;
-			const clampedScaleFactor = Math.max( scaleFactor * zoomSpeed, Math.min( maxScaleFactor, 1 ) );
+			const clampedScaleFactor = Math.max( scaleFactor, Math.min( maxScaleFactor, 1 ) );
 
 			camera.zoom = Math.min( maxZoom, camera.zoom * clampedScaleFactor );
 			camera.updateProjectionMatrix();


### PR DESCRIPTION
Fixes https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/1679

Apply orthographic zoomSpeed in normalizedDelta calculation to prevent flipped/runaway zoom values