### PR TITLE
Fix Issue 1687: EnvironmentControls orthographic camera jump on touch zoom

### DIFF
--- a/src/three/renderer/controls/EnvironmentControls.js
+++ b/src/three/renderer/controls/EnvironmentControls.js
@@ -1280,6 +1280,7 @@ export class EnvironmentControls extends EventDispatcher {
 			const zoomIntoPoint = this.zoomPointSet || this._updateZoomPoint();
 
 			// get the mouse position before zoom
+			adjustedPointerToCoords( _pointer, domElement, _mouseBefore );
 			_mouseBefore.unproject( camera );
 
 			// zoom the camera


### PR DESCRIPTION
This addresses the following issue where _mouseBefore becomes stale for touch pointer events:

https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/1687

Before:

https://github.com/user-attachments/assets/dc0bc8da-6a2e-49c3-bc0f-00e785b782f8

https://github.com/user-attachments/assets/0bcd4a2b-368e-4d13-b3c2-62b69d4a5c23



After:

https://github.com/user-attachments/assets/bc5012e9-ed6a-4448-a825-2a38fc220f6c


https://github.com/user-attachments/assets/002c2d60-2bec-4ec8-836f-a437f6d6dc8f

