### PR TITLE
Add download queue with per-host limits

### DIFF
--- a/example/three/terrainrgb.js
+++ b/example/three/terrainrgb.js
@@ -14,7 +14,7 @@ import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 const PLANAR_HEIGHT_SCALE = 1 / 40075017;
 
 const options = {
-	errorTarget: 2,
+	errorTarget: 1,
 	provider: 'Terrarium (AWS)',
 	heightScale: 1,
 	unlit: false,

--- a/src/core/renderer/API.md
+++ b/src/core/renderer/API.md
@@ -339,6 +339,72 @@ Returns the array of values for the given property key across all features. Retu
 `null` if the key is not in the table.
 
 
+## DownloadPriorityQueue
+
+Manages a lazily created PriorityQueue per server origin so the requests to every server are
+prioritized and limited independently, and a slow or saturated server can never delay the
+requests made to others. The items added without a url are managed as their own group.
+
+
+### .running
+
+```js
+readonly running: boolean
+```
+
+returns whether tasks are queued or actively running in any origin queue
+
+
+### .maxJobsPerOrigin
+
+```js
+maxJobsPerOrigin: number = 6
+```
+
+Maximum number of requests that can run concurrently per server.
+
+
+### .priorityCallback
+
+```js
+priorityCallback: ( a: any, b: any ) => number | null = null
+```
+
+Comparator used to sort the queued items of every origin queue.
+
+
+### .add
+
+```js
+add(
+	url: string | null,
+	item: any,
+	callback: ( item: any ) => Promise<any> | any
+): Promise<any>
+```
+
+Adds an item to the queue of the url's server and returns a Promise that resolves when the
+item's callback completes, or rejects if the item is removed before running.
+
+
+### .remove
+
+```js
+remove( item: any ): void
+```
+
+Removes an item from its origin queue, rejecting its promise with an `AbortError` DOMException.
+
+
+### .has
+
+```js
+has( item: any ): boolean
+```
+
+Returns whether the given item is currently queued.
+
+
 ## LRUCache
 
 Least-recently-used cache for managing tile content lifecycle. Tracks which items

--- a/src/core/renderer/index.js
+++ b/src/core/renderer/index.js
@@ -9,6 +9,8 @@ export * from './constants.js';
 
 export * from './utilities/LRUCache.js';
 export * from './utilities/PriorityQueue.js';
+export * from './utilities/DownloadPriorityQueue.js';
+export * from './utilities/urlExtension.js';
 export * as TraversalUtils from './utilities/TraversalUtils.js';
 export * as LoaderUtils from './utilities/LoaderUtils.js';
 export * from './utilities/BatchTable.js';

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -1,6 +1,7 @@
 import { getUrlExtension } from '../utilities/urlExtension.js';
 import { LRUCache } from '../utilities/LRUCache.js';
 import { PriorityQueue } from '../utilities/PriorityQueue.js';
+import { DownloadPriorityQueue } from '../utilities/DownloadPriorityQueue.js';
 import { runTraversal } from './traverseFunctions.js';
 import { UNLOADED, QUEUED, LOADING, PARSING, LOADED, FAILED } from '../constants.js';
 import { throttle } from '../utilities/throttle.js';
@@ -329,7 +330,7 @@ export const unifiedPriorityCallback = ( a, b ) => {
 export const DEFAULT_LRU_CACHE = new LRUCache();
 DEFAULT_LRU_CACHE.unloadPriorityCallback = lruPriorityCallback;
 
-export const DEFAULT_DOWNLOAD_QUEUE = new PriorityQueue();
+export const DEFAULT_DOWNLOAD_QUEUE = new DownloadPriorityQueue();
 DEFAULT_DOWNLOAD_QUEUE.maxJobs = 25;
 DEFAULT_DOWNLOAD_QUEUE.priorityCallback = unifiedPriorityCallback;
 
@@ -1579,7 +1580,7 @@ export class TilesRendererBase {
 		tile.internal.loadingState = QUEUED;
 		loadingTiles.add( tile );
 
-		// queue the download and parse
+		// queue the download and parse, limiting the concurrent requests per server
 		return downloadQueue.add( tile, downloadTile => {
 
 			if ( signal.aborted ) {
@@ -1606,7 +1607,7 @@ export class TilesRendererBase {
 			} );
 			return res;
 
-		} )
+		}, url )
 			.then( res => {
 
 				if ( signal.aborted ) {

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -331,7 +331,7 @@ export const DEFAULT_LRU_CACHE = new LRUCache();
 DEFAULT_LRU_CACHE.unloadPriorityCallback = lruPriorityCallback;
 
 export const DEFAULT_DOWNLOAD_QUEUE = new DownloadPriorityQueue();
-DEFAULT_DOWNLOAD_QUEUE.maxJobs = 25;
+DEFAULT_DOWNLOAD_QUEUE.maxJobsPerOrigin = 25;
 DEFAULT_DOWNLOAD_QUEUE.priorityCallback = unifiedPriorityCallback;
 
 export const DEFAULT_PARSE_QUEUE = new PriorityQueue();
@@ -1581,7 +1581,7 @@ export class TilesRendererBase {
 		loadingTiles.add( tile );
 
 		// queue the download and parse, limiting the concurrent requests per server
-		return downloadQueue.add( tile, downloadTile => {
+		return downloadQueue.add( url, tile, downloadTile => {
 
 			if ( signal.aborted ) {
 
@@ -1607,7 +1607,7 @@ export class TilesRendererBase {
 			} );
 			return res;
 
-		}, url )
+		} )
 			.then( res => {
 
 				if ( signal.aborted ) {

--- a/src/core/renderer/utilities/DownloadPriorityQueue.d.ts
+++ b/src/core/renderer/utilities/DownloadPriorityQueue.d.ts
@@ -1,0 +1,9 @@
+import { PriorityQueue } from './PriorityQueue.js';
+
+export class DownloadPriorityQueue extends PriorityQueue {
+
+	maxJobsPerOrigin : number;
+
+	add( item : any, callback : ( item : any ) => any, url? : string | null ) : Promise< any >;
+
+}

--- a/src/core/renderer/utilities/DownloadPriorityQueue.d.ts
+++ b/src/core/renderer/utilities/DownloadPriorityQueue.d.ts
@@ -4,6 +4,6 @@ export class DownloadPriorityQueue extends PriorityQueue {
 
 	maxJobsPerOrigin : number;
 
-	add( item : any, callback : ( item : any ) => any, url? : string | null ) : Promise< any >;
+	add( url : string | null, item : any, callback : ( item : any ) => any ) : Promise< any >;
 
 }

--- a/src/core/renderer/utilities/DownloadPriorityQueue.d.ts
+++ b/src/core/renderer/utilities/DownloadPriorityQueue.d.ts
@@ -1,9 +1,15 @@
 import { PriorityQueue } from './PriorityQueue.js';
 
-export class DownloadPriorityQueue extends PriorityQueue {
+export class DownloadPriorityQueue {
 
 	maxJobsPerOrigin : number;
+	priorityCallback : ( itemA : any, itemB : any ) => number;
+	originQueues : Map< string | null, PriorityQueue >;
+
+	get running(): boolean;
 
 	add( url : string | null, item : any, callback : ( item : any ) => any ) : Promise< any >;
+	remove( item : any ) : void;
+	has( item : any ) : boolean;
 
 }

--- a/src/core/renderer/utilities/DownloadPriorityQueue.js
+++ b/src/core/renderer/utilities/DownloadPriorityQueue.js
@@ -3,8 +3,9 @@ import { PriorityQueue } from './PriorityQueue.js';
 import { getUrlOrigin } from './urlExtension.js';
 
 /**
- * PriorityQueue for scheduling downloads that additionally limits the concurrent requests made to
- * any single server, so a slow server cannot occupy every slot and block the requests to others.
+ * PriorityQueue for scheduling downloads that limits the concurrent requests per server rather
+ * than in total, so a slow or saturated server can never delay the requests made to others. The
+ * items added without a url are limited as their own group.
  */
 export class DownloadPriorityQueue extends PriorityQueue {
 
@@ -12,9 +13,10 @@ export class DownloadPriorityQueue extends PriorityQueue {
 
 		super();
 
+		this.maxJobs = Infinity;
+
 		/**
-		 * Maximum number of requests that can run concurrently per server for the items added with
-		 * a url, matching the concurrent connection limit browsers apply per origin.
+		 * Maximum number of requests that can run concurrently per server.
 		 * @type {number}
 		 * @default 6
 		 */
@@ -26,12 +28,12 @@ export class DownloadPriorityQueue extends PriorityQueue {
 
 	/**
 	 * Adds an item to the queue, limiting the concurrent requests to the url's server.
+	 * @param {string|null} url - Url the item requests data from
 	 * @param {any} item
 	 * @param {ItemCallback} callback - Invoked with `item` when it is dequeued; may return a Promise
-	 * @param {string|null} [url=null] - Url the item requests data from
 	 * @returns {Promise<any>}
 	 */
-	add( item, callback, url = null ) {
+	add( url, item, callback ) {
 
 		const origin = url === null ? null : getUrlOrigin( url );
 		const existing = this.callbacks.get( item );
@@ -49,43 +51,28 @@ export class DownloadPriorityQueue extends PriorityQueue {
 
 	_canRunJob( data ) {
 
-		const { origin } = data;
-		if ( origin === null || origin === undefined ) {
-
-			return true;
-
-		}
-
-		return ( this.originJobs.get( origin ) || 0 ) < this.maxJobsPerOrigin;
+		return ( this.originJobs.get( data.origin ) || 0 ) < this.maxJobsPerOrigin;
 
 	}
 
 	_jobStarted( data ) {
 
 		const { origin } = data;
-		if ( origin !== null && origin !== undefined ) {
-
-			this.originJobs.set( origin, ( this.originJobs.get( origin ) || 0 ) + 1 );
-
-		}
+		this.originJobs.set( origin, ( this.originJobs.get( origin ) || 0 ) + 1 );
 
 	}
 
 	_jobCompleted( data ) {
 
 		const { origin } = data;
-		if ( origin !== null && origin !== undefined ) {
+		const count = this.originJobs.get( origin ) - 1;
+		if ( count === 0 ) {
 
-			const count = this.originJobs.get( origin ) - 1;
-			if ( count === 0 ) {
+			this.originJobs.delete( origin );
 
-				this.originJobs.delete( origin );
+		} else {
 
-			} else {
-
-				this.originJobs.set( origin, count );
-
-			}
+			this.originJobs.set( origin, count );
 
 		}
 

--- a/src/core/renderer/utilities/DownloadPriorityQueue.js
+++ b/src/core/renderer/utilities/DownloadPriorityQueue.js
@@ -1,0 +1,94 @@
+/** @import { ItemCallback } from './PriorityQueue.js' */
+import { PriorityQueue } from './PriorityQueue.js';
+import { getUrlOrigin } from './urlExtension.js';
+
+/**
+ * PriorityQueue for scheduling downloads that additionally limits the concurrent requests made to
+ * any single server, so a slow server cannot occupy every slot and block the requests to others.
+ */
+export class DownloadPriorityQueue extends PriorityQueue {
+
+	constructor() {
+
+		super();
+
+		/**
+		 * Maximum number of requests that can run concurrently per server for the items added with
+		 * a url, matching the concurrent connection limit browsers apply per origin.
+		 * @type {number}
+		 * @default 6
+		 */
+		this.maxJobsPerOrigin = 6;
+
+		this.originJobs = new Map();
+
+	}
+
+	/**
+	 * Adds an item to the queue, limiting the concurrent requests to the url's server.
+	 * @param {any} item
+	 * @param {ItemCallback} callback - Invoked with `item` when it is dequeued; may return a Promise
+	 * @param {string|null} [url=null] - Url the item requests data from
+	 * @returns {Promise<any>}
+	 */
+	add( item, callback, url = null ) {
+
+		const origin = url === null ? null : getUrlOrigin( url );
+		const existing = this.callbacks.get( item );
+		if ( existing && existing.origin !== origin ) {
+
+			throw new Error( 'DownloadPriorityQueue: Item is already queued with a different url origin.' );
+
+		}
+
+		const promise = super.add( item, callback );
+		this.callbacks.get( item ).origin = origin;
+		return promise;
+
+	}
+
+	_canRunJob( data ) {
+
+		const { origin } = data;
+		if ( origin === null || origin === undefined ) {
+
+			return true;
+
+		}
+
+		return ( this.originJobs.get( origin ) || 0 ) < this.maxJobsPerOrigin;
+
+	}
+
+	_jobStarted( data ) {
+
+		const { origin } = data;
+		if ( origin !== null && origin !== undefined ) {
+
+			this.originJobs.set( origin, ( this.originJobs.get( origin ) || 0 ) + 1 );
+
+		}
+
+	}
+
+	_jobCompleted( data ) {
+
+		const { origin } = data;
+		if ( origin !== null && origin !== undefined ) {
+
+			const count = this.originJobs.get( origin ) - 1;
+			if ( count === 0 ) {
+
+				this.originJobs.delete( origin );
+
+			} else {
+
+				this.originJobs.set( origin, count );
+
+			}
+
+		}
+
+	}
+
+}

--- a/src/core/renderer/utilities/DownloadPriorityQueue.js
+++ b/src/core/renderer/utilities/DownloadPriorityQueue.js
@@ -1,33 +1,83 @@
-/** @import { ItemCallback } from './PriorityQueue.js' */
+/** @import { ItemCallback, PriorityCallback } from './PriorityQueue.js' */
 import { PriorityQueue } from './PriorityQueue.js';
 import { getUrlOrigin } from './urlExtension.js';
 
 /**
- * PriorityQueue for scheduling downloads that limits the concurrent requests per server rather
- * than in total, so a slow or saturated server can never delay the requests made to others. The
- * items added without a url are limited as their own group.
+ * Manages a lazily created PriorityQueue per server origin so the requests to every server are
+ * prioritized and limited independently, and a slow or saturated server can never delay the
+ * requests made to others. The items added without a url are managed as their own group.
  */
-export class DownloadPriorityQueue extends PriorityQueue {
+export class DownloadPriorityQueue {
 
-	constructor() {
+	/**
+	 * returns whether tasks are queued or actively running in any origin queue
+	 * @readonly
+	 * @type {boolean}
+	 */
+	get running() {
 
-		super();
+		for ( const queue of this.originQueues.values() ) {
 
-		this.maxJobs = Infinity;
+			if ( queue.running ) {
 
-		/**
-		 * Maximum number of requests that can run concurrently per server.
-		 * @type {number}
-		 * @default 6
-		 */
-		this.maxJobsPerOrigin = 6;
+				return true;
 
-		this.originJobs = new Map();
+			}
+
+		}
+
+		return false;
 
 	}
 
 	/**
-	 * Adds an item to the queue, limiting the concurrent requests to the url's server.
+	 * Maximum number of requests that can run concurrently per server.
+	 * @type {number}
+	 * @default 6
+	 */
+	get maxJobsPerOrigin() {
+
+		return this._maxJobsPerOrigin;
+
+	}
+
+	set maxJobsPerOrigin( v ) {
+
+		this._maxJobsPerOrigin = v;
+		this.originQueues.forEach( queue => queue.maxJobs = v );
+
+	}
+
+	/**
+	 * Comparator used to sort the queued items of every origin queue.
+	 * @type {PriorityCallback|null}
+	 * @default null
+	 */
+	get priorityCallback() {
+
+		return this._priorityCallback;
+
+	}
+
+	set priorityCallback( v ) {
+
+		this._priorityCallback = v;
+		this.originQueues.forEach( queue => queue.priorityCallback = v );
+
+	}
+
+	constructor() {
+
+		this.originQueues = new Map();
+		this._itemQueues = new WeakMap();
+		this._maxJobsPerOrigin = 6;
+		this._priorityCallback = null;
+
+	}
+
+	/**
+	 * Adds an item to the queue of the url's server and returns a Promise that resolves when the
+	 * item's callback completes, or rejects if the item is removed before running.
 	 * @param {string|null} url - Url the item requests data from
 	 * @param {any} item
 	 * @param {ItemCallback} callback - Invoked with `item` when it is dequeued; may return a Promise
@@ -35,46 +85,65 @@ export class DownloadPriorityQueue extends PriorityQueue {
 	 */
 	add( url, item, callback ) {
 
+		// drop the queues for origins with no work left
+		this.originQueues.forEach( ( queue, key ) => {
+
+			if ( ! queue.running ) {
+
+				this.originQueues.delete( key );
+
+			}
+
+		} );
+
 		const origin = url === null ? null : getUrlOrigin( url );
-		const existing = this.callbacks.get( item );
-		if ( existing && existing.origin !== origin ) {
+		let queue = this.originQueues.get( origin );
+		if ( ! queue ) {
+
+			queue = new PriorityQueue();
+			queue.maxJobs = this._maxJobsPerOrigin;
+			queue.priorityCallback = this._priorityCallback;
+			this.originQueues.set( origin, queue );
+
+		}
+
+		const existing = this._itemQueues.get( item );
+		if ( existing && existing !== queue && existing.has( item ) ) {
 
 			throw new Error( 'DownloadPriorityQueue: Item is already queued with a different url origin.' );
 
 		}
 
-		const promise = super.add( item, callback );
-		this.callbacks.get( item ).origin = origin;
-		return promise;
+		this._itemQueues.set( item, queue );
+		return queue.add( item, callback );
 
 	}
 
-	_canRunJob( data ) {
+	/**
+	 * Removes an item from its origin queue, rejecting its promise with an `AbortError` DOMException.
+	 * @param {any} item
+	 */
+	remove( item ) {
 
-		return ( this.originJobs.get( data.origin ) || 0 ) < this.maxJobsPerOrigin;
+		const queue = this._itemQueues.get( item );
+		if ( queue ) {
 
-	}
-
-	_jobStarted( data ) {
-
-		const { origin } = data;
-		this.originJobs.set( origin, ( this.originJobs.get( origin ) || 0 ) + 1 );
-
-	}
-
-	_jobCompleted( data ) {
-
-		const { origin } = data;
-		const count = this.originJobs.get( origin ) - 1;
-		if ( count === 0 ) {
-
-			this.originJobs.delete( origin );
-
-		} else {
-
-			this.originJobs.set( origin, count );
+			queue.remove( item );
+			this._itemQueues.delete( item );
 
 		}
+
+	}
+
+	/**
+	 * Returns whether the given item is currently queued.
+	 * @param {any} item
+	 * @returns {boolean}
+	 */
+	has( item ) {
+
+		const queue = this._itemQueues.get( item );
+		return Boolean( queue && queue.has( item ) );
 
 	}
 

--- a/src/core/renderer/utilities/PriorityQueue.js
+++ b/src/core/renderer/utilities/PriorityQueue.js
@@ -218,8 +218,7 @@ export class PriorityQueue {
 	}
 
 	/**
-	 * Immediately attempts to dequeue and run pending jobs up to `maxJobs` concurrency, skipping
-	 * the items that `_canRunJob` rejects.
+	 * Immediately attempts to dequeue and run pending jobs up to `maxJobs` concurrency.
 	 */
 	tryRunJobs() {
 
@@ -230,10 +229,9 @@ export class PriorityQueue {
 		const maxJobs = this.maxJobs;
 		let iterated = 0;
 
-		const completedCallback = data => {
+		const completedCallback = () => {
 
 			this.currJobs --;
-			this._jobCompleted( data );
 
 			if ( this.autoUpdate ) {
 
@@ -243,25 +241,14 @@ export class PriorityQueue {
 
 		};
 
-		// iterate from the highest priority end of the queue
-		for ( let i = items.length - 1; i >= 0 && maxJobs > this.currJobs && iterated < maxJobs; i -- ) {
-
-			const item = items[ i ];
-			const data = callbacks.get( item );
-			if ( ! this._canRunJob( data ) ) {
-
-				continue;
-
-			}
+		while ( maxJobs > this.currJobs && items.length > 0 && iterated < maxJobs ) {
 
 			this.currJobs ++;
 			iterated ++;
-			this._jobStarted( data );
-
-			items.splice( i, 1 );
+			const item = items.pop();
+			const { callback, resolve, reject } = callbacks.get( item );
 			callbacks.delete( item );
 
-			const { callback, resolve, reject } = data;
 			let result;
 			try {
 
@@ -270,7 +257,7 @@ export class PriorityQueue {
 			} catch ( err ) {
 
 				reject( err );
-				completedCallback( data );
+				completedCallback();
 				continue;
 
 			}
@@ -280,12 +267,12 @@ export class PriorityQueue {
 				result
 					.then( resolve )
 					.catch( reject )
-					.finally( () => completedCallback( data ) );
+					.finally( completedCallback );
 
 			} else {
 
 				resolve( result );
-				completedCallback( data );
+				completedCallback();
 
 			}
 
@@ -355,17 +342,5 @@ export class PriorityQueue {
 		}
 
 	}
-
-	// Overridable hooks for constraining and tracking the running jobs, called with the queued
-	// item's internal data
-	_canRunJob( data ) {
-
-		return true;
-
-	}
-
-	_jobStarted( data ) {}
-
-	_jobCompleted( data ) {}
 
 }

--- a/src/core/renderer/utilities/PriorityQueue.js
+++ b/src/core/renderer/utilities/PriorityQueue.js
@@ -218,7 +218,8 @@ export class PriorityQueue {
 	}
 
 	/**
-	 * Immediately attempts to dequeue and run pending jobs up to `maxJobs` concurrency.
+	 * Immediately attempts to dequeue and run pending jobs up to `maxJobs` concurrency, skipping
+	 * the items that `_canRunJob` rejects.
 	 */
 	tryRunJobs() {
 
@@ -229,9 +230,10 @@ export class PriorityQueue {
 		const maxJobs = this.maxJobs;
 		let iterated = 0;
 
-		const completedCallback = () => {
+		const completedCallback = data => {
 
 			this.currJobs --;
+			this._jobCompleted( data );
 
 			if ( this.autoUpdate ) {
 
@@ -241,14 +243,25 @@ export class PriorityQueue {
 
 		};
 
-		while ( maxJobs > this.currJobs && items.length > 0 && iterated < maxJobs ) {
+		// iterate from the highest priority end of the queue
+		for ( let i = items.length - 1; i >= 0 && maxJobs > this.currJobs && iterated < maxJobs; i -- ) {
+
+			const item = items[ i ];
+			const data = callbacks.get( item );
+			if ( ! this._canRunJob( data ) ) {
+
+				continue;
+
+			}
 
 			this.currJobs ++;
 			iterated ++;
-			const item = items.pop();
-			const { callback, resolve, reject } = callbacks.get( item );
+			this._jobStarted( data );
+
+			items.splice( i, 1 );
 			callbacks.delete( item );
 
+			const { callback, resolve, reject } = data;
 			let result;
 			try {
 
@@ -257,7 +270,8 @@ export class PriorityQueue {
 			} catch ( err ) {
 
 				reject( err );
-				completedCallback();
+				completedCallback( data );
+				continue;
 
 			}
 
@@ -266,12 +280,12 @@ export class PriorityQueue {
 				result
 					.then( resolve )
 					.catch( reject )
-					.finally( completedCallback );
+					.finally( () => completedCallback( data ) );
 
 			} else {
 
 				resolve( result );
-				completedCallback();
+				completedCallback( data );
 
 			}
 
@@ -341,5 +355,17 @@ export class PriorityQueue {
 		}
 
 	}
+
+	// Overridable hooks for constraining and tracking the running jobs, called with the queued
+	// item's internal data
+	_canRunJob( data ) {
+
+		return true;
+
+	}
+
+	_jobStarted( data ) {}
+
+	_jobCompleted( data ) {}
 
 }

--- a/src/core/renderer/utilities/urlExtension.js
+++ b/src/core/renderer/utilities/urlExtension.js
@@ -1,5 +1,6 @@
 /**
  * Returns the origin of the URL, used for grouping requests made to the same server.
+ * @private
  * @param {string} url
  * @returns {string} null if the origin cannot be derived
  */

--- a/src/core/renderer/utilities/urlExtension.js
+++ b/src/core/renderer/utilities/urlExtension.js
@@ -1,4 +1,24 @@
 /**
+ * Returns the origin of the URL, used for grouping requests made to the same server.
+ * @param {string} url
+ * @returns {string} null if the origin cannot be derived
+ */
+export function getUrlOrigin( url ) {
+
+	try {
+
+		const base = typeof location !== 'undefined' ? location.href : undefined;
+		return new URL( url, base ).origin;
+
+	} catch {
+
+		return null;
+
+	}
+
+}
+
+/**
  * Returns the file extension of the path component of a URL
  * @param {string} url
  * @returns {string} null if no extension found

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1439,7 +1439,7 @@ export class ImageOverlay {
 		}
 
 		const item = { priority: - performance.now() };
-		const promise = this.downloadQueue.add( item, () => fetch( url, options ), url );
+		const promise = this.downloadQueue.add( url, item, () => fetch( url, options ) );
 
 		if ( options.signal ) {
 
@@ -2148,7 +2148,7 @@ export class CesiumIonOverlay extends TiledImageOverlay {
 
 		// TODO: we should provide a better way to sort these
 		const item = { priority: - performance.now() };
-		const promise = this.downloadQueue.add( item, () => this.auth.fetch( url, options ), url );
+		const promise = this.downloadQueue.add( url, item, () => this.auth.fetch( url, options ) );
 		if ( options.signal ) {
 
 			options.signal.addEventListener( 'abort', () => this.downloadQueue.remove( item ), { once: true } );
@@ -2230,7 +2230,7 @@ export class GoogleMapsOverlay extends TiledImageOverlay {
 		}
 
 		const item = { priority: - performance.now() };
-		const promise = this.downloadQueue.add( item, () => this.auth.fetch( url, options ), url );
+		const promise = this.downloadQueue.add( url, item, () => this.auth.fetch( url, options ) );
 		if ( options.signal ) {
 
 			options.signal.addEventListener( 'abort', () => this.downloadQueue.remove( item ), { once: true } );

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -1439,7 +1439,7 @@ export class ImageOverlay {
 		}
 
 		const item = { priority: - performance.now() };
-		const promise = this.downloadQueue.add( item, () => fetch( url, options ) );
+		const promise = this.downloadQueue.add( item, () => fetch( url, options ), url );
 
 		if ( options.signal ) {
 
@@ -2148,7 +2148,7 @@ export class CesiumIonOverlay extends TiledImageOverlay {
 
 		// TODO: we should provide a better way to sort these
 		const item = { priority: - performance.now() };
-		const promise = this.downloadQueue.add( item, () => this.auth.fetch( url, options ) );
+		const promise = this.downloadQueue.add( item, () => this.auth.fetch( url, options ), url );
 		if ( options.signal ) {
 
 			options.signal.addEventListener( 'abort', () => this.downloadQueue.remove( item ), { once: true } );
@@ -2230,7 +2230,7 @@ export class GoogleMapsOverlay extends TiledImageOverlay {
 		}
 
 		const item = { priority: - performance.now() };
-		const promise = this.downloadQueue.add( item, () => this.auth.fetch( url, options ) );
+		const promise = this.downloadQueue.add( item, () => this.auth.fetch( url, options ), url );
 		if ( options.signal ) {
 
 			options.signal.addEventListener( 'abort', () => this.downloadQueue.remove( item ), { once: true } );

--- a/src/three/plugins/images/terrain-rgb/TerrainRGBMeshPlugin.js
+++ b/src/three/plugins/images/terrain-rgb/TerrainRGBMeshPlugin.js
@@ -192,6 +192,22 @@ export class TerrainRGBMeshPlugin {
 		const maxLevel = EXTRA_LEVELS * Math.floor( maxZoom / EXTRA_LEVELS ) + EXTRA_LEVELS - 1;
 		this._source = new XYZImageSource( { url, tileDimension, levels: maxLevel + 1 } );
 
+		// route the elevation texture requests through the download queue so they are prioritized
+		// and limited per server alongside the other content
+		this._source.fetchData = ( fetchUrl, options ) => {
+
+			const item = { priority: - performance.now() };
+			const promise = tiles.downloadQueue.add( fetchUrl, item, () => fetch( fetchUrl, options ) );
+			if ( options.signal ) {
+
+				options.signal.addEventListener( 'abort', () => tiles.downloadQueue.remove( item ), { once: true } );
+
+			}
+
+			return promise;
+
+		};
+
 		this.tiles = tiles;
 
 	}

--- a/test/core/DownloadPriorityQueue.test.js
+++ b/test/core/DownloadPriorityQueue.test.js
@@ -5,7 +5,6 @@ describe( 'DownloadPriorityQueue', () => {
 	it( 'should run the requests to separate servers independently.', () => {
 
 		const queue = new DownloadPriorityQueue();
-		queue.autoUpdate = false;
 		queue.maxJobsPerOrigin = 2;
 
 		const running = [];
@@ -16,18 +15,15 @@ describe( 'DownloadPriorityQueue', () => {
 		queue.add( 'https://b.com/1.png', {}, job( 'b1' ) );
 		queue.add( 'https://b.com/2.png', {}, job( 'b2' ) );
 		queue.add( 'https://b.com/3.png', {}, job( 'b3' ) );
-		queue.tryRunJobs();
+		queue.originQueues.forEach( q => q.tryRunJobs() );
 
 		expect( running ).toEqual( [ 'a1', 'a2', 'b1', 'b2' ] );
-		expect( queue.currJobs ).toEqual( 4 );
-		expect( queue.items ).toHaveLength( 2 );
 
 	} );
 
 	it( 'should immediately run requests to a new server while another is saturated.', () => {
 
 		const queue = new DownloadPriorityQueue();
-		queue.autoUpdate = false;
 		queue.maxJobsPerOrigin = 2;
 
 		const running = [];
@@ -36,42 +32,22 @@ describe( 'DownloadPriorityQueue', () => {
 		queue.add( 'https://a.com/2.png', {}, job( 'a2' ) );
 		queue.add( 'https://a.com/3.png', {}, job( 'a3' ) );
 		queue.add( 'https://a.com/4.png', {}, job( 'a4' ) );
-		queue.tryRunJobs();
+		queue.originQueues.forEach( q => q.tryRunJobs() );
 
 		expect( running ).toEqual( [ 'a1', 'a2' ] );
 
 		// requests to a new server start without waiting for the saturated one to finish anything
 		queue.add( 'https://b.com/1.png', {}, job( 'b1' ) );
 		queue.add( 'https://b.com/2.png', {}, job( 'b2' ) );
-		queue.tryRunJobs();
+		queue.originQueues.forEach( q => q.tryRunJobs() );
 
 		expect( running ).toEqual( [ 'a1', 'a2', 'b1', 'b2' ] );
-
-	} );
-
-	it( 'should still apply the total job limit when set.', () => {
-
-		const queue = new DownloadPriorityQueue();
-		queue.autoUpdate = false;
-		queue.maxJobs = 3;
-		queue.maxJobsPerOrigin = 2;
-
-		const running = [];
-		const job = name => () => new Promise( () => running.push( name ) );
-		queue.add( 'https://a.com/1.png', {}, job( 'a1' ) );
-		queue.add( 'https://a.com/2.png', {}, job( 'a2' ) );
-		queue.add( 'https://b.com/1.png', {}, job( 'b1' ) );
-		queue.add( 'https://b.com/2.png', {}, job( 'b2' ) );
-		queue.tryRunJobs();
-
-		expect( running ).toEqual( [ 'a1', 'a2', 'b1' ] );
 
 	} );
 
 	it( 'should run further jobs for an origin once one completes.', async () => {
 
 		const queue = new DownloadPriorityQueue();
-		queue.autoUpdate = false;
 		queue.maxJobsPerOrigin = 1;
 
 		const running = [];
@@ -83,7 +59,10 @@ describe( 'DownloadPriorityQueue', () => {
 
 		} ) );
 		queue.add( 'https://a.com/2.png', {}, () => new Promise( () => running.push( 'a2' ) ) );
-		queue.tryRunJobs();
+
+		const originQueue = queue.originQueues.get( 'https://a.com' );
+		originQueue.autoUpdate = false;
+		originQueue.tryRunJobs();
 
 		expect( running ).toEqual( [ 'a1' ] );
 
@@ -93,17 +72,16 @@ describe( 'DownloadPriorityQueue', () => {
 		// the queue marks the job completed a couple of microtasks after its promise resolves
 		await Promise.resolve();
 		await Promise.resolve();
-		queue.tryRunJobs();
+		originQueue.tryRunJobs();
 
 		expect( running ).toEqual( [ 'a1', 'a2' ] );
-		expect( queue.originJobs.get( 'https://a.com' ) ).toEqual( 1 );
+		expect( originQueue.currJobs ).toEqual( 1 );
 
 	} );
 
-	it( 'should limit the items added without a url as their own group.', () => {
+	it( 'should manage the items added without a url as their own group.', () => {
 
 		const queue = new DownloadPriorityQueue();
-		queue.autoUpdate = false;
 		queue.maxJobsPerOrigin = 1;
 
 		const running = [];
@@ -111,23 +89,37 @@ describe( 'DownloadPriorityQueue', () => {
 		queue.add( null, {}, job( 'a' ) );
 		queue.add( null, {}, job( 'b' ) );
 		queue.add( 'https://a.com/1.png', {}, job( 'c' ) );
-		queue.tryRunJobs();
+		queue.originQueues.forEach( q => q.tryRunJobs() );
 
 		expect( running ).toEqual( [ 'a', 'c' ] );
+
+	} );
+
+	it( 'should remove queues for origins with no remaining work.', async () => {
+
+		const queue = new DownloadPriorityQueue();
+
+		const promise = queue.add( 'https://a.com/1.png', {}, () => 100 );
+		expect( queue.originQueues.size ).toEqual( 1 );
+
+		await promise;
+
+		// drained queues are pruned when new items are added
+		queue.add( 'https://b.com/1.png', {}, () => new Promise( () => {} ) );
+		expect( queue.originQueues.has( 'https://a.com' ) ).toEqual( false );
+		expect( queue.originQueues.size ).toEqual( 1 );
 
 	} );
 
 	it( 'should throw when an item is re-added with a different origin.', () => {
 
 		const queue = new DownloadPriorityQueue();
-		queue.autoUpdate = false;
 
 		const item = {};
 		const callback = () => new Promise( () => {} );
 		queue.add( 'https://a.com/1.png', item, callback ).catch( () => {} );
 
 		expect( () => queue.add( 'https://b.com/1.png', item, callback ) ).toThrow();
-		expect( () => queue.add( 'https://a.com/2.png', item, callback ) ).not.toThrow();
 
 	} );
 

--- a/test/core/DownloadPriorityQueue.test.js
+++ b/test/core/DownloadPriorityQueue.test.js
@@ -1,0 +1,134 @@
+import { DownloadPriorityQueue } from '../../src/core/renderer/utilities/DownloadPriorityQueue.js';
+
+describe( 'DownloadPriorityQueue', () => {
+
+	it( 'should run the requests to separate servers independently.', () => {
+
+		const queue = new DownloadPriorityQueue();
+		queue.autoUpdate = false;
+		queue.maxJobsPerOrigin = 2;
+
+		const running = [];
+		const job = name => () => new Promise( () => running.push( name ) );
+		queue.add( 'https://a.com/1.png', {}, job( 'a1' ) );
+		queue.add( 'https://a.com/2.png', {}, job( 'a2' ) );
+		queue.add( 'https://a.com/3.png', {}, job( 'a3' ) );
+		queue.add( 'https://b.com/1.png', {}, job( 'b1' ) );
+		queue.add( 'https://b.com/2.png', {}, job( 'b2' ) );
+		queue.add( 'https://b.com/3.png', {}, job( 'b3' ) );
+		queue.tryRunJobs();
+
+		expect( running ).toEqual( [ 'a1', 'a2', 'b1', 'b2' ] );
+		expect( queue.currJobs ).toEqual( 4 );
+		expect( queue.items ).toHaveLength( 2 );
+
+	} );
+
+	it( 'should immediately run requests to a new server while another is saturated.', () => {
+
+		const queue = new DownloadPriorityQueue();
+		queue.autoUpdate = false;
+		queue.maxJobsPerOrigin = 2;
+
+		const running = [];
+		const job = name => () => new Promise( () => running.push( name ) );
+		queue.add( 'https://a.com/1.png', {}, job( 'a1' ) );
+		queue.add( 'https://a.com/2.png', {}, job( 'a2' ) );
+		queue.add( 'https://a.com/3.png', {}, job( 'a3' ) );
+		queue.add( 'https://a.com/4.png', {}, job( 'a4' ) );
+		queue.tryRunJobs();
+
+		expect( running ).toEqual( [ 'a1', 'a2' ] );
+
+		// requests to a new server start without waiting for the saturated one to finish anything
+		queue.add( 'https://b.com/1.png', {}, job( 'b1' ) );
+		queue.add( 'https://b.com/2.png', {}, job( 'b2' ) );
+		queue.tryRunJobs();
+
+		expect( running ).toEqual( [ 'a1', 'a2', 'b1', 'b2' ] );
+
+	} );
+
+	it( 'should still apply the total job limit when set.', () => {
+
+		const queue = new DownloadPriorityQueue();
+		queue.autoUpdate = false;
+		queue.maxJobs = 3;
+		queue.maxJobsPerOrigin = 2;
+
+		const running = [];
+		const job = name => () => new Promise( () => running.push( name ) );
+		queue.add( 'https://a.com/1.png', {}, job( 'a1' ) );
+		queue.add( 'https://a.com/2.png', {}, job( 'a2' ) );
+		queue.add( 'https://b.com/1.png', {}, job( 'b1' ) );
+		queue.add( 'https://b.com/2.png', {}, job( 'b2' ) );
+		queue.tryRunJobs();
+
+		expect( running ).toEqual( [ 'a1', 'a2', 'b1' ] );
+
+	} );
+
+	it( 'should run further jobs for an origin once one completes.', async () => {
+
+		const queue = new DownloadPriorityQueue();
+		queue.autoUpdate = false;
+		queue.maxJobsPerOrigin = 1;
+
+		const running = [];
+		let resolveFirst = null;
+		const first = queue.add( 'https://a.com/1.png', {}, () => new Promise( resolve => {
+
+			running.push( 'a1' );
+			resolveFirst = resolve;
+
+		} ) );
+		queue.add( 'https://a.com/2.png', {}, () => new Promise( () => running.push( 'a2' ) ) );
+		queue.tryRunJobs();
+
+		expect( running ).toEqual( [ 'a1' ] );
+
+		resolveFirst();
+		await first;
+
+		// the queue marks the job completed a couple of microtasks after its promise resolves
+		await Promise.resolve();
+		await Promise.resolve();
+		queue.tryRunJobs();
+
+		expect( running ).toEqual( [ 'a1', 'a2' ] );
+		expect( queue.originJobs.get( 'https://a.com' ) ).toEqual( 1 );
+
+	} );
+
+	it( 'should limit the items added without a url as their own group.', () => {
+
+		const queue = new DownloadPriorityQueue();
+		queue.autoUpdate = false;
+		queue.maxJobsPerOrigin = 1;
+
+		const running = [];
+		const job = name => () => new Promise( () => running.push( name ) );
+		queue.add( null, {}, job( 'a' ) );
+		queue.add( null, {}, job( 'b' ) );
+		queue.add( 'https://a.com/1.png', {}, job( 'c' ) );
+		queue.tryRunJobs();
+
+		expect( running ).toEqual( [ 'a', 'c' ] );
+
+	} );
+
+	it( 'should throw when an item is re-added with a different origin.', () => {
+
+		const queue = new DownloadPriorityQueue();
+		queue.autoUpdate = false;
+
+		const item = {};
+		const callback = () => new Promise( () => {} );
+		queue.add( 'https://a.com/1.png', item, callback ).catch( () => {} );
+
+		expect( () => queue.add( 'https://b.com/1.png', item, callback ) ).toThrow();
+		expect( () => queue.add( 'https://a.com/2.png', item, callback ) ).not.toThrow();
+
+	} );
+
+} );

--- a/test/core/PriorityQueue.test.js
+++ b/test/core/PriorityQueue.test.js
@@ -334,4 +334,37 @@ describe( 'PriorityQueue', () => {
 
 	} );
 
+	it( 'should only complete a job once when its callback throws synchronously.', async () => {
+
+		const queue = new PriorityQueue();
+		queue.autoUpdate = false;
+		queue.maxJobs = 2;
+
+		// dispatch a synchronously throwing job alongside jobs that never resolve so the job
+		// count can be compared against the number of jobs actually running
+		let started = 0;
+		const pending = () => {
+
+			started ++;
+			return new Promise( () => {} );
+
+		};
+
+		const error = new Error( 'sync error' );
+		const promise = queue.add( {}, () => {
+
+			throw error;
+
+		} );
+		queue.add( {}, pending );
+		queue.add( {}, pending );
+		queue.tryRunJobs();
+
+		await expect( promise ).rejects.toBe( error );
+
+		// a double completion decrements the count below the number of running jobs
+		expect( queue.currJobs ).toEqual( started );
+
+	} );
+
 } );


### PR DESCRIPTION
Fix #1463

- Add a "DownloadPriorityQueue" class that caps different hosts separately to avoid a single slow server from blocking other downloads.
- Add tests
- Update plugins to use and respect the new queue
