### PR TITLE
MVTAnnotationsPlugin: Add a cutoff value for all annotations

### DIFF
--- a/example/three/annotationsExample.js
+++ b/example/three/annotationsExample.js
@@ -116,6 +116,7 @@ const params = {
 	drawMode: MVTGlyphs.DrawMode.OVERLAY,
 	displayIcons: true,
 	displayPaths: true,
+	horizonCutoff: 0.1,
 	terrainRGB: false,
 
 	occupancyGrid: false,
@@ -325,6 +326,7 @@ function initTiles() {
 		overlay,
 		camera,
 		driver,
+		horizonCutoff: params.horizonCutoff,
 	} ) );
 
 	//
@@ -426,6 +428,11 @@ function init() {
 		driver.displayPaths = v;
 		driver.needsUpdate = true;
 		tiles.getPluginByName( 'UPDATE_ON_CHANGE_PLUGIN' ).needsUpdate = true;
+
+	} );
+	gui.add( params, 'horizonCutoff', 0, 0.75, 0.01 ).onChange( v => {
+
+		tiles.getPluginByName( 'MVT_ANNOTATIONS_PLUGIN' ).horizonCutoff = v;
 
 	} );
 	gui.add( params, 'terrainRGB' ).onChange( initTiles );

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1222,6 +1222,16 @@ maxOccupancyUpdateTimeMs: number = 0.5
 Time budget in milliseconds per frame for the sliced occupancy layout pass.
 
 
+### .horizonCutoff
+
+```js
+horizonCutoff: number = 0.1
+```
+
+Hides annotations once `dot( surface normal, direction to camera )` falls below this, removing
+those near the horizon. Raise it to display annotations closer, set it to 0 to disable.
+
+
 ### .constructor
 
 ```js

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.d.ts
@@ -35,6 +35,7 @@ export interface MVTAnnotationsPluginOptions {
 	camera?: Camera | null;
 	driver?: MVTAnnotationsDriver;
 	resolution?: number;
+	horizonCutoff?: number;
 
 }
 
@@ -47,6 +48,7 @@ export class MVTAnnotationsPlugin {
 	camera: Camera | null;
 	driver: MVTAnnotationsDriver;
 	resolution: number;
+	horizonCutoff: number;
 	maxSettleTimeMs: number;
 	maxOccupancyUpdateTimeMs: number;
 

--- a/src/three/plugins/mvt/MVTAnnotationsPlugin.js
+++ b/src/three/plugins/mvt/MVTAnnotationsPlugin.js
@@ -361,6 +361,38 @@ export class MVTAnnotationsPlugin {
 
 	}
 
+	/**
+	 * Hides annotations once `dot( surface normal, direction to camera )` falls below this, removing
+	 * those near the horizon. Raise it to display annotations closer, set it to 0 to disable.
+	 * @type {number}
+	 * @default 0.1
+	 */
+	get horizonCutoff() {
+
+		return this._horizonCutoff;
+
+	}
+
+	set horizonCutoff( value ) {
+
+		// gated so this can be assigned every frame without traversing the annotations
+		if ( value === this._horizonCutoff ) {
+
+			return;
+
+		}
+
+		this._horizonCutoff = value;
+
+		// TODO: A shared value for settings would be best here.
+		this.pointManager.points.forEach( point => point.horizonCutoff = value );
+		this.anchorManager.lines.forEach( line => line.horizonCutoff = value );
+
+		// the cutoff is applied during layout, so it has to be redone
+		this.occupancy.needsUpdate = true;
+
+	}
+
 	constructor( options = {} ) {
 
 		// plugin fields
@@ -372,6 +404,7 @@ export class MVTAnnotationsPlugin {
 			camera = null,
 			driver = new DefaultMVTAnnotationsDriver(),
 			resolution = 50,
+			horizonCutoff = 0.1,
 		} = options;
 
 		// user settings
@@ -379,6 +412,7 @@ export class MVTAnnotationsPlugin {
 		this.camera = camera;
 		this.driver = driver;
 		this.resolution = resolution;
+		this._horizonCutoff = horizonCutoff;
 
 		// annotations call these live each frame so driver changes take effect immediately
 		this._measureChar = char => this.driver.measureChar( char );
@@ -673,6 +707,8 @@ export class MVTAnnotationsPlugin {
 				vectorTileInfo.set( key, { annotations } );
 
 				for ( const ann of annotations ) {
+
+					ann.horizonCutoff = this._horizonCutoff;
 
 					if ( ann instanceof LineAnnotation ) {
 

--- a/src/three/plugins/mvt/ScreenOccupationManager.js
+++ b/src/three/plugins/mvt/ScreenOccupationManager.js
@@ -25,6 +25,9 @@ export class OccupancyAnnotation {
 		// whether the annotation is settled and ready to be displayed
 		this.ready = false;
 
+		// dot( surface normal, direction to camera ) below which the annotation is hidden
+		this.horizonCutoff = 0.1;
+
 		// screen pos used for sorting
 		this.screenPos = new Vector3();
 

--- a/src/three/plugins/mvt/annotations/LineAnnotation.js
+++ b/src/three/plugins/mvt/annotations/LineAnnotation.js
@@ -5,6 +5,9 @@ import { OccupancyAnnotation } from '../ScreenOccupationManager.js';
 // the body's radius so anchor density tracks real-world length on any ellipsoid.
 const ANCHOR_SPACING_METERS = 500000;
 
+const _delta = /* @__PURE__ */ new Vector3();
+const _normal = /* @__PURE__ */ new Vector3();
+
 // Share path annotation used for text anchors
 export class LineAnnotation extends OccupancyAnnotation {
 
@@ -48,6 +51,9 @@ export class LineAnnotation extends OccupancyAnnotation {
 		// screen positions, cumulative length used for calculating text layout
 		this.screenPositions = [];
 		this.cumulativeLen = [];
+
+		// per-sample dot( surface normal, direction to camera )
+		this.facingRatios = [];
 
 		// cache variables
 		this.cachedMatrix = new Matrix4();
@@ -97,6 +103,9 @@ export class LineAnnotation extends OccupancyAnnotation {
 
 		}
 
+		const { facingRatios } = this;
+		facingRatios.length = screenPositions.length;
+
 		for ( let i = 0, l = screenPositions.length; i < l; i ++ ) {
 
 			const position = positions[ i ];
@@ -109,6 +118,20 @@ export class LineAnnotation extends OccupancyAnnotation {
 			screenPos.x = ( screenPos.x * 0.5 + 0.5 ) * resolution.width;
 			screenPos.y = ( - screenPos.y * 0.5 + 0.5 ) * resolution.height;
 			screenPos.z = MathUtils.mapLinear( screenPos.z, - 1, 1, 0, 1 );
+
+			// the sample sits on the surface, so its direction from the body center stands in for
+			// the normal. Matches the approximation in PointAnnotation.
+			if ( cameraPosition !== null && position.lengthSq() > 0 ) {
+
+				_delta.subVectors( cameraPosition, position ).normalize();
+				_normal.copy( position ).normalize();
+				facingRatios[ i ] = _normal.dot( _delta );
+
+			} else {
+
+				facingRatios[ i ] = 1;
+
+			}
 
 		}
 

--- a/src/three/plugins/mvt/annotations/PointAnnotation.js
+++ b/src/three/plugins/mvt/annotations/PointAnnotation.js
@@ -2,9 +2,8 @@ import { Vector3, MathUtils } from 'three';
 import { OccupancyAnnotation } from '../ScreenOccupationManager.js';
 
 const _delta = /* @__PURE__ */ new Vector3();
+const _normal = /* @__PURE__ */ new Vector3();
 
-// suppress annotations within ~6 degrees of the globe horizon
-const PERSPECTIVE_CULL_ANGLE = Math.acos( 0.1 );
 export class PointAnnotation extends OccupancyAnnotation {
 
 	constructor() {
@@ -17,7 +16,7 @@ export class PointAnnotation extends OccupancyAnnotation {
 		this.radius = 28;
 
 		this.screenPos = new Vector3();
-		this._facingAngle = 0;
+		this._facingRatio = 1;
 
 	}
 
@@ -36,14 +35,15 @@ export class PointAnnotation extends OccupancyAnnotation {
 		// facing ratio: dot( surface normal, direction to camera )
 		// TODO: store geodetic normal on the item at creation time and use it here instead of
 		// normalize( position )
-		if ( cameraPosition !== null ) {
+		if ( cameraPosition !== null && position.lengthSq() > 0 ) {
 
-			_delta.subVectors( cameraPosition, position );
-			this._facingAngle = position.lengthSq() > 0 ? position.angleTo( _delta ) : 0;
+			_delta.subVectors( cameraPosition, position ).normalize();
+			_normal.copy( position ).normalize();
+			this._facingRatio = _normal.dot( _delta );
 
 		} else {
 
-			this._facingAngle = 0;
+			this._facingRatio = 1;
 
 		}
 
@@ -51,7 +51,7 @@ export class PointAnnotation extends OccupancyAnnotation {
 
 	evaluate( handle ) {
 
-		const { screenPos, radius, _facingAngle } = this;
+		const { screenPos, radius, horizonCutoff, _facingRatio } = this;
 		if ( ! this.ready ) {
 
 			return false;
@@ -64,7 +64,7 @@ export class PointAnnotation extends OccupancyAnnotation {
 
 		}
 
-		if ( _facingAngle > PERSPECTIVE_CULL_ANGLE ) {
+		if ( _facingRatio < horizonCutoff ) {
 
 			return false;
 

--- a/src/three/plugins/mvt/annotations/TextAnchorAnnotation.js
+++ b/src/three/plugins/mvt/annotations/TextAnchorAnnotation.js
@@ -22,6 +22,7 @@ export const RejectionReason = {
 	OCCUPANCY: 4,
 	SPACING: 5,
 	ANGLE: 6,
+	FACING: 7,
 };
 
 const _segIndices = [];
@@ -227,7 +228,7 @@ export class TextAnchorAnnotation extends OccupancyAnnotation {
 	_layoutCharacters( handle, outputIndices, outputAlphas, force = false ) {
 
 		const { line, i0, i1, alpha } = this.getActiveReference();
-		const { cumulativeLen, screenPositions, totalTextWidth, characterWidths, characterRadius, text } = line;
+		const { cumulativeLen, screenPositions, facingRatios, totalTextWidth, characterWidths, characterRadius, text } = line;
 		const anchorOffset = MathUtils.lerp( cumulativeLen[ i0 ], cumulativeLen[ i1 ], alpha );
 		const flip = this._flippedTextDir;
 		this.valid = true;
@@ -323,10 +324,15 @@ export class TextAnchorAnnotation extends OccupancyAnnotation {
 			const p1 = screenPositions[ segNext ];
 			_vec.lerpVectors( p0, p1, segAlpha );
 
-			// off-screen in depth, or colliding with an already-placed annotation
+			// off-screen in depth, near the horizon, or colliding with an already-placed annotation
 			if ( _vec.z < 0 || _vec.z > 1 ) {
 
 				this._reject( RejectionReason.DEPTH );
+				if ( ! force ) break;
+
+			} else if ( MathUtils.lerp( facingRatios[ seg ], facingRatios[ segNext ], segAlpha ) < line.horizonCutoff ) {
+
+				this._reject( RejectionReason.FACING );
 				if ( ! force ) break;
 
 			} else if ( handle.test( _vec.x, _vec.y, characterRadius ) ) {

--- a/src/three/plugins/mvt/debug/LineAnnotationOverlay.js
+++ b/src/three/plugins/mvt/debug/LineAnnotationOverlay.js
@@ -21,6 +21,7 @@ const REJECTION_COLORS = {
 	[ RejectionReason.OCCUPANCY ]: 0x00ffff,
 	[ RejectionReason.SPACING ]: 0xffff00,
 	[ RejectionReason.ANGLE ]: 0xff0000,
+	[ RejectionReason.FACING ]: 0xff00ff,
 };
 
 const _origin = /* @__PURE__ */ new Vector3();


### PR DESCRIPTION
Fix #1686

Add a user-adjustable "horizionCutoff" value that can be used to filter annotations at glancing angles.