### PR TITLE
docs: fix three broken documentation links and a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Here is a reference to existing 3DTilesRendererJS integrations:
 - [iTowns](https://github.com/iTowns/itowns/): Framework designed for the efficient visualization, navigation, and interaction with 2D and 3D geospatial data on the web.
 - [threepipe Plugin](https://threepipe.org/package/plugin-3d-tiles-renderer.html): Plugin for the threepipe rendering framework integrating 3DTilesRendererJS.
 - [3DBAG Viewer](https://github.com/3DBAG/3dbag-viewer): Web viewer for the 3DBAG dataset, a nationwide 3D model of all buildings in the Netherlands built with roofer.
-- [Babylon.js Guide](https://doc.babylonjs.com/features/featuresDeepDive/geospatial/loading3dTiles/): Official documention on integrating 3DTilesRendererJS into your Babylon.js project.
+- [Babylon.js Guide](https://doc.babylonjs.com/features/featuresDeepDive/geospatial/loading3dTiles/): Official documentation on integrating 3DTilesRendererJS into your Babylon.js project.
 - [Community Plugins](https://github.com/NASA-AMMOS/3DTilesRendererJS/tree/master/src/three/plugins#community-plugins): Additional community-maintained threejs plugins for 3DTilesRendererJS.
 
 # Gotchas

--- a/USAGE.md
+++ b/USAGE.md
@@ -106,7 +106,7 @@ scene.add( tilesRenderer2.group );
 
 ## Adding DRACO Decompression Support
 
-Adding support for DRACO decompression within the GLTF files that are transported in B3DM and I3DM formats. The same approach can be used to add support for KTX2 and DDS textures. Alternatively the [GLTFExtensionsPlugin](./src/plugins/README.md#gltfextensionsplugin) can be used to simplify the setup.
+Adding support for DRACO decompression within the GLTF files that are transported in B3DM and I3DM formats. The same approach can be used to add support for KTX2 and DDS textures. Alternatively the [GLTFExtensionsPlugin](./src/three/plugins/API.md#gltfextensionsplugin) can be used to simplify the setup.
 
 ```js
 

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1930,7 +1930,7 @@ texture covering it. The height scale is applied so the result matches the displ
 
 ## TerrariumMeshPlugin
 
-[TerrainRGBMeshPlugin](TerrainRGBMeshPlugin) for the Terrarium encoding.
+[TerrainRGBMeshPlugin](#terrainrgbmeshplugin) for the Terrarium encoding.
 
 
 ## TileCompressionPlugin

--- a/src/three/renderer/README.md
+++ b/src/three/renderer/README.md
@@ -23,6 +23,6 @@ function renderLoop() {
 }
 ```
 
-For more setup examples including custom materials, DRACO compression, Cesium Ion, and camera controls, see the [Three.js usage guide](../../USAGE.md).
+For more setup examples including custom materials, DRACO compression, Cesium Ion, and camera controls, see the [Three.js usage guide](../../../USAGE.md).
 
 See the [API reference](./API.md) for full class and method documentation.


### PR DESCRIPTION
Four documentation fixes, all verified against the current tree on `master`.

**Broken links**

| File | Was | Now | Why |
|---|---|---|---|
| `USAGE.md:109` | `./src/plugins/README.md#gltfextensionsplugin` | `./src/three/plugins/API.md#gltfextensionsplugin` | `src/plugins/` does not exist, and the `## GLTFExtensionsPlugin` heading is in `src/three/plugins/API.md:852`, not a README |
| `src/three/renderer/README.md:26` | `../../USAGE.md` | `../../../USAGE.md` | from `src/three/renderer/`, `../../` resolves to `src/`; `USAGE.md` is at the repo root, so it needs one more level |
| `src/three/plugins/API.md:1933` | `[TerrainRGBMeshPlugin](TerrainRGBMeshPlugin)` | `[TerrainRGBMeshPlugin](#terrainrgbmeshplugin)` | missing `#` — the target is the `## TerrainRGBMeshPlugin` heading at line 1866 of the same file |

**Typo**

`README.md:83` — "Official documention on integrating…" → "documentation".

---

One related item I did **not** change, since fixing it would mean guessing: `src/three/renderer/API.md:223` has the same missing-`#` pattern — `[WGS84_ELLIPSOID](WGS84_ELLIPSOID)` — but unlike `TerrainRGBMeshPlugin` there is no `WGS84_ELLIPSOID` heading anywhere in the docs to anchor to (`src/core/renderer/API.md` documents `WGS84_RADIUS`, `WGS84_FLATTENING`, and `WGS84_HEIGHT`, but not the ellipsoid constant itself). Happy to follow up if you can point me at the intended target.
