### PR TITLE
TilesRenderer: Add an "errorFalloff" option

### DIFF
--- a/example/three/annotationsExample.js
+++ b/example/three/annotationsExample.js
@@ -117,6 +117,7 @@ const params = {
 	displayIcons: true,
 	displayPaths: true,
 	horizonCutoff: 0.1,
+	errorFalloff: 0,
 	terrainRGB: false,
 
 	occupancyGrid: false,
@@ -433,6 +434,12 @@ function init() {
 	gui.add( params, 'horizonCutoff', 0, 0.75, 0.01 ).onChange( v => {
 
 		tiles.getPluginByName( 'MVT_ANNOTATIONS_PLUGIN' ).horizonCutoff = v;
+
+	} );
+	gui.add( params, 'errorFalloff', 0, 50 ).onChange( v => {
+
+		tiles.errorFalloff = v;
+		tiles.getPluginByName( 'UPDATE_ON_CHANGE_PLUGIN' ).needsUpdate = true;
 
 	} );
 	gui.add( params, 'terrainRGB' ).onChange( initTiles );

--- a/example/three/googleMapsExample.js
+++ b/example/three/googleMapsExample.js
@@ -46,6 +46,7 @@ const params = {
 	useFadePlugin: true,
 	displayTopoLines: false,
 	errorTarget: 20,
+	errorFalloff: 0,
 
 	reload: reinstantiateTiles,
 
@@ -184,6 +185,11 @@ function init() {
 	mapsOptions.add( params, 'loadAncestors' ).listen();
 	mapsOptions.add( params, 'loadSiblings' ).listen();
 	mapsOptions.add( params, 'errorTarget', 5, 100, 1 ).onChange( () => {
+
+		tiles.getPluginByName( 'UPDATE_ON_CHANGE_PLUGIN' ).needsUpdate = true;
+
+	} );
+	mapsOptions.add( params, 'errorFalloff', 0, 50 ).onChange( () => {
 
 		tiles.getPluginByName( 'UPDATE_ON_CHANGE_PLUGIN' ).needsUpdate = true;
 
@@ -368,6 +374,7 @@ function animate() {
 	// update tiles
 	camera.updateMatrixWorld();
 	tiles.errorTarget = params.errorTarget;
+	tiles.errorFalloff = params.errorFalloff;
 	tiles.loadSiblings = params.loadSiblings;
 	tiles.loadAncestors = params.loadAncestors;
 	tiles.update();

--- a/src/core/renderer/API.md
+++ b/src/core/renderer/API.md
@@ -949,6 +949,35 @@ not render if they are below this level of screen-space error. See the
 of the 3D Tiles specification for more information.
 
 
+### .errorFalloff
+
+```js
+errorFalloff: number = 0
+```
+
+Maximum screen-space error in pixels subtracted from distant tiles. Set to 0 to disable.
+Comparable to Cesium's "dynamicScreenSpaceError" settings.
+
+`error -= errorFalloff * ( 1 - e ^ -( distance * errorFalloffDensity )² )`
+
+> [!WARN]
+> Experimental and may change.
+
+
+### .errorFalloffDensity
+
+```js
+errorFalloffDensity: number = 2e-4
+```
+
+Distance scale for the "errorFalloff" curve, in inverse meters. Larger values affect
+tiles closer to the camera.
+Comparable to Cesium's "dynamicScreenSpaceError" settings.
+
+> [!WARN]
+> Experimental and may change.
+
+
 ### .displayActiveTiles
 
 ```js

--- a/src/core/renderer/tiles/TilesRendererBase.d.ts
+++ b/src/core/renderer/tiles/TilesRendererBase.d.ts
@@ -33,6 +33,8 @@ export class TilesRendererBase<TEventMap extends TilesRendererBaseEventMap = Til
 	readonly activeTiles : Set<Tile>;
 
 	errorTarget : number;
+	errorFalloff : number;
+	errorFalloffDensity : number;
 	displayActiveTiles : boolean;
 	maxDepth : number;
 	loadSiblings : boolean;

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -547,6 +547,7 @@ export class TilesRendererBase {
 
 		/**
 		 * Maximum screen-space error in pixels subtracted from distant tiles. Set to 0 to disable.
+		 * Comparable to Cesium's "dynamicScreenSpaceError" settings.
 		 *
 		 * `error -= errorFalloff * ( 1 - e ^ -( distance * errorFalloffDensity )² )`
 		 *
@@ -560,6 +561,7 @@ export class TilesRendererBase {
 		/**
 		 * Distance scale for the "errorFalloff" curve, in inverse meters. Larger values affect
 		 * tiles closer to the camera.
+		 * Comparable to Cesium's "dynamicScreenSpaceError" settings.
 		 *
 		 * > [!WARN]
 		 * > Experimental and may change.

--- a/src/core/renderer/tiles/TilesRendererBase.js
+++ b/src/core/renderer/tiles/TilesRendererBase.js
@@ -546,6 +546,29 @@ export class TilesRendererBase {
 		this.errorTarget = 16.0;
 
 		/**
+		 * Maximum screen-space error in pixels subtracted from distant tiles. Set to 0 to disable.
+		 *
+		 * `error -= errorFalloff * ( 1 - e ^ -( distance * errorFalloffDensity )² )`
+		 *
+		 * > [!WARN]
+		 * > Experimental and may change.
+		 * @type {number}
+		 * @default 0
+		 */
+		this.errorFalloff = 0;
+
+		/**
+		 * Distance scale for the "errorFalloff" curve, in inverse meters. Larger values affect
+		 * tiles closer to the camera.
+		 *
+		 * > [!WARN]
+		 * > Experimental and may change.
+		 * @type {number}
+		 * @default 2e-4
+		 */
+		this.errorFalloffDensity = 2e-4;
+
+		/**
 		 * "Active tiles" are those that are loaded and available but not necessarily visible.
 		 * These tiles are useful for raycasting off-camera or for casting shadows. Active tiles
 		 * not currently in a camera frustum are removed from the scene as an optimization.
@@ -940,6 +963,17 @@ export class TilesRendererBase {
 
 		// calculate camera view error
 		this.calculateTileViewError( tile, target );
+
+		// reduce the error of distant tiles along a fog-style curve so they refine less
+		// aggressively, mirroring Cesium's "dynamicScreenSpaceError" behavior
+		// TODO: this uses the aggregated error and distance rather than per-camera / volume values
+		const { errorFalloff, errorFalloffDensity } = this;
+		if ( errorFalloff > 0 && Number.isFinite( target.distanceFromCamera ) ) {
+
+			const falloff = target.distanceFromCamera * errorFalloffDensity;
+			target.error -= errorFalloff * ( 1 - Math.exp( - falloff * falloff ) );
+
+		}
 
 		// TODO: this logic is extremely complex. It may be more simple to have the plugin
 		// return a "should mask" field that indicates its "false" values should be respected

--- a/src/three/plugins/API.md
+++ b/src/three/plugins/API.md
@@ -1159,7 +1159,7 @@ The string a line / road annotation should display for the given feature.
 ### .isAnnotationEnabled
 
 ```js
-isAnnotationEnabled( properties: Object, type: number ): boolean
+isAnnotationEnabled( layer: string, properties: Object, type: number ): boolean
 ```
 
 Whether a parsed annotation should currently be displayed. Unlike `filterAnnotation` which
@@ -1930,7 +1930,7 @@ texture covering it. The height scale is applied so the result matches the displ
 
 ## TerrariumMeshPlugin
 
-[TerrainRGBMeshPlugin](#terrainrgbmeshplugin) for the Terrarium encoding.
+[TerrainRGBMeshPlugin](TerrainRGBMeshPlugin) for the Terrarium encoding.
 
 
 ## TileCompressionPlugin


### PR DESCRIPTION
Adds an option for adjusting the error to allow for adjusting the error threshold based on distance to the camera, which can be used reduce the tiles loaded at far distances.