### PR TITLE
TilesRenderer: Preserve group transform during tile fade out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - MVTAnnotationsPlugin: Add a `useIdleCallback` option.
 
 ### Fixed
+- TilesRenderer, TilesFadePlugin: Keep fading-out tiles parented to the tiles renderer group until they are hidden.
 - EnvironmentControls, GlobeControls: Fix orthographic camera zoom when adjusting zoomSpeed.
 - GeoJSONOverlay: Fix content bounds check treating the normalized tile range as radians, causing every tile to report content.
 - MVTAnnotationsPlugin: Adjust plugin to prefetch vector tile content.

--- a/src/three/renderer/tiles/TilesRenderer.js
+++ b/src/three/renderer/tiles/TilesRenderer.js
@@ -954,14 +954,14 @@ export class TilesRenderer extends TilesRendererBase {
 		if ( scene ) {
 
 			// an active scene is parented to the group so its world matrix is included for raycasting
-			// or other spatial queries while active. A tile is never visible while inactive, so an
-			// inactive scene is always fully detached.
+			// or other spatial queries while active. A tile can remain visible while inactive during
+			// a fade out, so only detach it once it is both inactive and hidden.
 			if ( active ) {
 
 				scene.parent = this.group;
 				scene.updateMatrixWorld( true );
 
-			} else {
+			} else if ( ! this.visibleTiles.has( tile ) ) {
 
 				scene.parent = null;
 

--- a/test/three/TilesRenderer.test.ts
+++ b/test/three/TilesRenderer.test.ts
@@ -58,3 +58,22 @@ test( 'TilesRenderer should not throw', () => {
 	} ).not.toThrow();
 
 } );
+
+test( 'TilesRenderer should keep visible inactive tiles parented to the group', () => {
+
+	const renderer = new TilesRenderer();
+	const scene = new Object3D();
+	const tile = { engineData: { scene } } as Tile;
+
+	renderer.setTileActive( tile, true );
+	renderer.setTileVisible( tile, true );
+	renderer.setTileActive( tile, false );
+
+	// A fade plugin can keep an inactive tile visible until the fade completes.
+	// Keep the logical parent so the group transform remains in matrixWorld.
+	expect( scene.parent ).toBe( renderer.group );
+
+	renderer.setTileVisible( tile, false );
+	expect( scene.parent ).toBe( null );
+
+} );


### PR DESCRIPTION
## Summary

- keep visible inactive tile scenes parented to `TilesRenderer.group` during fade out
- detach the scene only after it is both inactive and hidden
- add a regression test covering the active-to-fading visibility transition
- document the fix in the changelog

This preserves the tileset group transform while `TilesFadePlugin` delays the final visibility change.

Fixes #1715

## Tests

- `npm test` (619 tests passed)
- `npm run lint` (passes with 4 pre-existing warnings)
