### PR TITLE
Scale `forEachTileInBounds` epsilon with the queried range.

### DIFF
--- a/src/three/plugins/images/overlays/utils.js
+++ b/src/three/plugins/images/overlays/utils.js
@@ -3,13 +3,16 @@ import { Vector3, Matrix4, MathUtils } from 'three';
 // iterates over all present tiles in the given tileset at the given level in the given range
 export function forEachTileInBounds( range, level, tiling, callback ) {
 
-	// pull the bounds in a bit to avoid loading unnecessary tiles. 1e-8 was chosen since smaller values
-	// are not larger enough and cause extra tiles to load in cases where 1-to-1 tile-to-image should occur
+	// Pull the bounds in a bit so a range that matches a tile exactly does not load
+	// neighboring tiles. The epsilon is scaled to the queried range span so it stays
+	// sub-pixel in composed overlay textures at deep tile levels.
 	let [ minLon, minLat, maxLon, maxLat ] = range;
-	minLat += 1e-8;
-	minLon += 1e-8;
-	maxLat -= 1e-8;
-	maxLon -= 1e-8;
+	const epsX = ( maxLon - minLon ) * 1e-4;
+	const epsY = ( maxLat - minLat ) * 1e-4;
+	minLat += epsY;
+	minLon += epsX;
+	maxLat -= epsY;
+	maxLon -= epsX;
 
 	const clampedLevel = Math.max( Math.min( level, tiling.maxLevel ), tiling.minLevel );
 	const [ minX, minY, maxX, maxY ] = tiling.getTilesInRange( minLon, minLat, maxLon, maxLat, clampedLevel, true );

--- a/test/three/forEachTileInBounds.test.js
+++ b/test/three/forEachTileInBounds.test.js
@@ -1,0 +1,80 @@
+import { forEachTileInBounds } from '../../src/three/plugins/images/overlays/utils.js';
+import { TilingScheme } from '../../src/three/plugins/images/utils/TilingScheme.js';
+
+function collectTiles( range, level, tiling ) {
+
+	const tiles = [];
+	forEachTileInBounds( range, level, tiling, ( x, y, l ) => {
+
+		tiles.push( [ x, y, l ] );
+
+	} );
+
+	return tiles;
+
+}
+
+describe( 'forEachTileInBounds', () => {
+
+	// span of one tile at level 19 in normalized units
+	const LEVEL = 19;
+	const TILE_SPAN = 1 / 2 ** 19;
+
+	let scheme;
+	beforeEach( () => {
+
+		scheme = new TilingScheme();
+		scheme.generateLevels( 21, 1, 1 );
+
+	} );
+
+	it( 'should report exactly one tile when the range matches a single tile with float error.', () => {
+
+		const NOISE = 1e-12;
+		const range = [
+			1000 * TILE_SPAN - NOISE,
+			1000 * TILE_SPAN - NOISE,
+			1001 * TILE_SPAN + NOISE,
+			1001 * TILE_SPAN + NOISE,
+		];
+
+		expect( collectTiles( range, LEVEL, scheme ) ).toEqual( [[ 1000, 1000, LEVEL ]] );
+
+	} );
+
+	it( 'should include a deep-level tile that the range overhangs by less than a fixed epsilon.', () => {
+
+		// The range covers one tile fully and extends a hair past the shared boundary into the
+		// next tile. The neighboring tile must be included, otherwise a composed texture is
+		// left with uncovered, transparent pixels at the tile edge.
+		const OVERHANG = 5e-9;
+		const range = [
+			1000 * TILE_SPAN,
+			1000 * TILE_SPAN,
+			1001 * TILE_SPAN + OVERHANG,
+			1001 * TILE_SPAN,
+		];
+
+		const tiles = collectTiles( range, LEVEL, scheme );
+		expect( tiles ).toContainEqual( [ 1000, 1000, LEVEL ] );
+		expect( tiles ).toContainEqual( [ 1001, 1000, LEVEL ] );
+
+	} );
+
+	it( 'should not include neighboring tiles when the range aligns to tile boundaries.', () => {
+
+		const range = [
+			1000 * TILE_SPAN,
+			1000 * TILE_SPAN,
+			1002 * TILE_SPAN,
+			1001 * TILE_SPAN,
+		];
+
+		expect( collectTiles( range, LEVEL, scheme ) ).toEqual( [
+			[ 1000, 1000, LEVEL ],
+			[ 1001, 1000, LEVEL ],
+		] );
+
+	} );
+
+} );


### PR DESCRIPTION
Fixes https://github.com/NASA-AMMOS/3DTilesRendererJS/issues/1717

| Before | After |
| - | - |
| <img width="1792" height="985" alt="before-1" src="https://github.com/user-attachments/assets/bc438252-f2ce-4a0b-a7c7-5d9067acc9f9" /> | <img width="1564" height="976" alt="after-1" src="https://github.com/user-attachments/assets/10f76697-c567-4173-b4d9-c6eaaaba42df" /> |
| <img width="1792" height="985" alt="before-2" src="https://github.com/user-attachments/assets/8350b436-cc42-4f5c-99e2-b64fd3af1de9" /> | <img width="1564" height="976" alt="after-2" src="https://github.com/user-attachments/assets/6b328a37-1dc5-491d-8c8f-e125fb9a0366" /> |
| <img width="1792" height="985" alt="before-4" src="https://github.com/user-attachments/assets/821937d7-be05-4059-b2be-48272983e5aa" /> | <img width="1564" height="976" alt="after-4" src="https://github.com/user-attachments/assets/68f6fd72-c60f-47e7-a303-677090007b8c" /> |
