### PR TITLE
ImageOverlayPlugin: Fix tile splitting stalling over tiles with low geometric error

### DIFF
--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -28,6 +28,7 @@ const _box = /* @__PURE__ */ new Box3();
 const SPLIT_TILE_DATA = Symbol( 'SPLIT_TILE_DATA' );
 const SPLIT_HASH = Symbol( 'SPLIT_HASH' );
 const ORIGINAL_REFINE = Symbol( 'ORIGINAL_REFINE' );
+const ORIGINAL_GEOMETRIC_ERROR = Symbol( 'ORIGINAL_GEOMETRIC_ERROR' );
 
 const PROCESS_QUEUE = /* @__PURE__ */ new PriorityQueue();
 PROCESS_QUEUE.maxJobs = 10;
@@ -282,6 +283,13 @@ export class ImageOverlayPlugin {
 		tile.refine = tile[ ORIGINAL_REFINE ];
 		delete tile[ ORIGINAL_REFINE ];
 		delete tile[ SPLIT_HASH ];
+
+		if ( ORIGINAL_GEOMETRIC_ERROR in tile ) {
+
+			tile.geometricError = tile[ ORIGINAL_GEOMETRIC_ERROR ];
+			delete tile[ ORIGINAL_GEOMETRIC_ERROR ];
+
+		}
 
 	}
 
@@ -655,6 +663,20 @@ export class ImageOverlayPlugin {
 			} );
 
 		} );
+
+		// The tile's overlays are composited into textures "resolution" texels across, so one
+		// texel spans roughly the content size divided by that resolution. Raise the tile's
+		// error to at least that value while split children exist so traversal keeps entering
+		// and selecting them (children are only traversed while the parent error exceeds the
+		// error target), and restore it when the splits are removed. Each split child inherits
+		// half, and "shouldSplit" stops the recursion at the overlays' max level (#1636).
+		if ( ! ( ORIGINAL_GEOMETRIC_ERROR in tile ) ) {
+
+			const texelError = _box.setFromObject( clone ).getSize( _vec ).length() / this.resolution;
+			tile[ ORIGINAL_GEOMETRIC_ERROR ] = tile.geometricError;
+			tile.geometricError = Math.max( tile.geometricError, texelError );
+
+		}
 
 		// run the clipping operations by performing every permutation of sides
 		// defined by the split directions

--- a/src/three/plugins/images/ImageOverlayPlugin.js
+++ b/src/three/plugins/images/ImageOverlayPlugin.js
@@ -670,7 +670,9 @@ export class ImageOverlayPlugin {
 		// and selecting them (children are only traversed while the parent error exceeds the
 		// error target), and restore it when the splits are removed. Each split child inherits
 		// half, and "shouldSplit" stops the recursion at the overlays' max level (#1636).
-		if ( ! ( ORIGINAL_GEOMETRIC_ERROR in tile ) ) {
+		// Additive tiles are excluded: they can have real children, and raising their error
+		// would make traversal load that child geometry far deeper than the tile set intends.
+		if ( tile.refine !== 'ADD' && ! ( ORIGINAL_GEOMETRIC_ERROR in tile ) ) {
 
 			const texelError = _box.setFromObject( clone ).getSize( _vec ).length() / this.resolution;
 			tile[ ORIGINAL_GEOMETRIC_ERROR ] = tile.geometricError;

--- a/test/three/ImageOverlayPlugin.test.js
+++ b/test/three/ImageOverlayPlugin.test.js
@@ -1,0 +1,96 @@
+import { Group, Matrix4, Mesh, MeshBasicMaterial, PlaneGeometry } from 'three';
+import { ImageOverlayPlugin } from '../../src/plugins.js';
+import { WGS84_ELLIPSOID } from '../../src/three/renderer/math/GeoConstants.js';
+
+// Builds the minimal structures needed to exercise the tile splitting logic
+// without a renderer: a plugin with one stub overlay that always wants to
+// split, and a loaded tile scene containing a single 100 x 100 m quad.
+function createSplitFixture() {
+
+	const plugin = new ImageOverlayPlugin( { resolution: 256 } );
+	plugin.tiles = {
+		ellipsoid: WGS84_ELLIPSOID,
+		processNodeQueue: { remove() {} },
+		lruCache: { remove() {} },
+	};
+
+	const tile = {
+		refine: 'REPLACE',
+		geometricError: 0.3,
+		boundingVolume: { box: [ 0, 0, 0, 50, 0, 0, 0, 50, 0, 0, 0, 1 ] },
+		children: [],
+		content: { uri: './tile.glb' },
+		internal: { virtualChildCount: 0 },
+		engineData: { transformInverse: new Matrix4() },
+	};
+
+	const overlay = { frame: null, shouldSplit: () => true };
+	plugin.overlayInfo.set( overlay, {
+		tileInfo: new Map( [[ tile, { target: {}, range: [ 0, 0, 1, 1 ] } ]] ),
+	} );
+
+	const scene = new Group();
+	const mesh = new Mesh( new PlaneGeometry( 100, 100 ), new MeshBasicMaterial() );
+	mesh.position.set( WGS84_ELLIPSOID.radius.x, 0, 0 );
+	scene.add( mesh );
+	scene.updateMatrixWorld( true );
+
+	return { plugin, tile, scene };
+
+}
+
+describe( 'ImageOverlayPlugin tile splitting', () => {
+
+	it( 'raises the tile geometric error to the overlay texel size while splits exist', async () => {
+
+		const { plugin, tile, scene } = createSplitFixture();
+		await plugin.expandVirtualChildren( scene, tile );
+
+		// one texel of the 256 px overlay texture spans contentSize / resolution,
+		// here the diagonal of a 100 x 100 quad divided by 256
+		const texelError = Math.sqrt( 2 * 100 * 100 ) / 256;
+		expect( tile.children.length ).toBeGreaterThan( 0 );
+		expect( tile.internal.virtualChildCount ).toBe( tile.children.length );
+		expect( tile.geometricError ).toBeCloseTo( texelError, 10 );
+
+		// split children inherit half the raised error, keeping the ladder halving
+		tile.children.forEach( child => {
+
+			expect( child.geometricError ).toBeCloseTo( texelError / 2, 10 );
+
+		} );
+
+	} );
+
+	it( 'does not raise the error of tiles that produce no splits', async () => {
+
+		const { plugin, tile, scene } = createSplitFixture();
+		for ( const info of plugin.overlayInfo.values() ) {
+
+			info.tileInfo.get( tile ).target = null;
+
+		}
+
+		await plugin.expandVirtualChildren( scene, tile );
+
+		expect( tile.children.length ).toBe( 0 );
+		expect( tile.geometricError ).toBe( 0.3 );
+
+	} );
+
+	it( 'restores the original geometric error when splits are removed', async () => {
+
+		const { plugin, tile, scene } = createSplitFixture();
+		await plugin.expandVirtualChildren( scene, tile );
+		expect( tile.geometricError ).not.toBe( 0.3 );
+
+		plugin._removeVirtualChildren( tile );
+
+		expect( tile.children.length ).toBe( 0 );
+		expect( tile.internal.virtualChildCount ).toBe( 0 );
+		expect( tile.refine ).toBe( 'REPLACE' );
+		expect( tile.geometricError ).toBe( 0.3 );
+
+	} );
+
+} );

--- a/test/three/ImageOverlayPlugin.test.js
+++ b/test/three/ImageOverlayPlugin.test.js
@@ -9,7 +9,7 @@ function createSplitFixture() {
 
 	const plugin = new ImageOverlayPlugin( { resolution: 256 } );
 	plugin.tiles = {
-		ellipsoid: WGS84_ELLIPSOID,
+		surface: WGS84_ELLIPSOID,
 		processNodeQueue: { remove() {} },
 		lruCache: { remove() {} },
 	};
@@ -74,6 +74,22 @@ describe( 'ImageOverlayPlugin tile splitting', () => {
 		await plugin.expandVirtualChildren( scene, tile );
 
 		expect( tile.children.length ).toBe( 0 );
+		expect( tile.geometricError ).toBe( 0.3 );
+
+	} );
+
+	it( 'splits additive tiles without raising their geometric error', async () => {
+
+		const { plugin, tile, scene } = createSplitFixture();
+		tile.refine = 'ADD';
+		await plugin.expandVirtualChildren( scene, tile );
+
+		expect( tile.children.length ).toBeGreaterThan( 0 );
+		expect( tile.geometricError ).toBe( 0.3 );
+
+		plugin._removeVirtualChildren( tile );
+
+		expect( tile.refine ).toBe( 'ADD' );
 		expect( tile.geometricError ).toBe( 0.3 );
 
 	} );


### PR DESCRIPTION
Fixes #1636.

Virtual split children were created under tiles whose own `geometricError` stays that of the source geometry. Over flat quantized-mesh terrain that error is centimeter-scale, so traversal never elected to enter or select the split children (children are only traversed while the parent's error exceeds the error target) and imagery stayed capped at the terrain leaf level.

When split children are created, the tile's `geometricError` is now raised to at least the world-space size of one texel of its composited overlay texture (content size divided by the plugin's `resolution`), and restored when the splits are removed. Each split child inherits half of that as before, so the floor halves with each split level, and `shouldSplit()` still stops the recursion at the overlays' max level, so no image tiles are loaded beyond the native resolution of the overlays. The net change is 22 lines.

Before/after on a keyless repro (four flat tiles with `geometricError` 0.3 m, like flat quantized-mesh leaves, under an OSM overlay via `ImageOverlayPlugin`, camera 600 m):

| master | this PR |
|---|---|
| ![master: imagery frozen at the level shown when splits were created](https://raw.githubusercontent.com/clement-igonet/threejs-maplibre/main/evidence/1636/before-master.png) | ![fix: splits refine to the overlay's native resolution](https://raw.githubusercontent.com/clement-igonet/threejs-maplibre/main/evidence/1636/after-fix.png) |

Unit tests cover the new behavior: the error is raised to the texel size when splits are created, untouched when no split happens, and restored when splits are removed. Lint and the `test/three` suite pass.
