### PR TITLE
Tilesrenderer: Improve tile traversal speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - MVTAnnotationsPlugin: The driver's render group is only mounted under the tiles group if it has not already been parented elsewhere.
+- Traversal: Skip recomputing the view error for tiles that are only visited to update their frame state, significantly reducing traversal time.
 
 ## [0.5.2] - 2026.08.24
 ### Added

--- a/src/core/renderer/tiles/traverseFunctions.js
+++ b/src/core/renderer/tiles/traverseFunctions.js
@@ -45,8 +45,9 @@ function canUnconditionallyRefine( tile ) {
 
 }
 
-// Resets the frame information for the given tile
-function resetFrameState( tile, renderer ) {
+// Resets the frame information for the given tile. Computing the view error can be skipped
+// by passes that only rotate the frame state.
+function resetFrameState( tile, renderer, computeViewError = true ) {
 
 	if ( ! isProcessed( tile ) ) {
 
@@ -76,10 +77,14 @@ function resetFrameState( tile, renderer ) {
 		tile.traversal.allUsedChildrenProcessed = false;
 
 		// update tile frustum and error state
-		renderer.calculateTileViewErrorWithPlugin( tile, viewErrorTarget );
-		tile.traversal.inFrustum = viewErrorTarget.inView;
-		tile.traversal.error = viewErrorTarget.error;
-		tile.traversal.distanceFromCamera = viewErrorTarget.distanceFromCamera;
+		if ( computeViewError ) {
+
+			renderer.calculateTileViewErrorWithPlugin( tile, viewErrorTarget );
+			tile.traversal.inFrustum = viewErrorTarget.inView;
+			tile.traversal.error = viewErrorTarget.error;
+			tile.traversal.distanceFromCamera = viewErrorTarget.distanceFromCamera;
+
+		}
 
 		// update whether this tile can be unconditionally refined
 		tile.traversal.unconditionallyRefine = tile.internal.hasUnrenderableContent;
@@ -486,7 +491,7 @@ function markVisibleTiles( tile, renderer ) {
 // Final traverse to toggle tile visibility.
 function toggleTiles( tile, renderer ) {
 
-	resetFrameState( tile, renderer );
+	resetFrameState( tile, renderer, false );
 
 	const isUsed = isUsedThisFrame( tile, renderer.frameCount );
 	if ( isUsed ) {
@@ -577,7 +582,7 @@ function toggleTiles( tile, renderer ) {
 			// if the tile was used last frame but not this one then there's potential for the tile
 			// to not have been visited during the traversal, meaning it hasn't been reset and has
 			// stale values. This ensures the values are not stale.
-			resetFrameState( tile, renderer );
+			resetFrameState( tile, renderer, false );
 
 		}
 


### PR DESCRIPTION
Related to #678

Improve toggle tile run time by roughly 50-60% in some cases by skipping error calculation for unused tiles that are just being reset for the next frame. Total update maybe improves by ~30% since toggle tiles was the dominating function. Only applies to a moving camera

*note these are some _very rough_ estimations